### PR TITLE
Remove id from generated JSON schema

### DIFF
--- a/src/DataModelGenerator/JsonSchemaGenerator.cs
+++ b/src/DataModelGenerator/JsonSchemaGenerator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
         {
             // TODO this file shouldn't contain any references whatsoever to SARIF
             codeWriter.OpenBrace();
-            codeWriter.WriteLine(@"""id"": """ + SARIF_URL + @""",");
             codeWriter.WriteLine(@"""$schema"": ""http://json-schema.org/draft-04/schema#"",");
             codeWriter.WriteLine(@"""title"": ""Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 0.4)"",");
         }


### PR DESCRIPTION
MadsK recommends not using id. @nguerrera @lgolding @davidknise 

In case no one noticed, I checked in a large change to the SDK to produce JSON from the G4. 