### PR TITLE
Remove 'id' member. Remove unnecessary trailing commas in the event o…

### DIFF
--- a/src/DataModelGenerator/JsonSchemaGenerator.cs
+++ b/src/DataModelGenerator/JsonSchemaGenerator.cs
@@ -84,7 +84,25 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
             codeWriter.IncrementIndentLevel();
 
             WriteMembers(codeWriter, model, type);
-            codeWriter.CloseBrace(",");
+
+            bool hasOneOrMoreRequiredMembers = false;
+            foreach (DataModelMember member in type.Members)
+            {
+                if (member.Required)
+                {
+                    hasOneOrMoreRequiredMembers = true;
+                    break;
+                }
+            }
+
+            if (hasOneOrMoreRequiredMembers)
+            {
+                codeWriter.CloseBrace(",");
+            }
+            else
+            {
+                codeWriter.CloseBrace();
+            }
 
             WriteRequiredMember(codeWriter, model, type, lastMember);
         }


### PR DESCRIPTION
…f no required members.