### PR TITLE
README: Fix link to SARIF specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # sarif-sdk
-.NET code and supporting files for working with the 'Static Analysis Results Interchange Format' (SARIF, see https://github.com/sarif-standard/sarif-sdk
+.NET code and supporting files for working with the 'Static Analysis Results Interchange Format' (SARIF, see https://github.com/sarif-standard/sarif-spec


### PR DESCRIPTION
You'll also want to fix the same link in the description of this GitHub repo