### PR TITLE
Analysis phases.

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -12,11 +12,11 @@ md bld\bin\nuget
 @REM Set versions for SDK and Driver
 set SDK_MAJOR=1
 set SDK_MINOR=4
-set SDK_PATCH=14
+set SDK_PATCH=15
 
 set DRV_MAJOR=1
 set DRV_MINOR=0
-set DRV_PATCH=14
+set DRV_PATCH=15
 
 set PRERELEASE=-beta
 

--- a/src/Sarif.Driver/Sdk/SarifLogger.cs
+++ b/src/Sarif.Driver/Sdk/SarifLogger.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public static ToolInfo CreateDefaultToolInfo(string prereleaseInfo = null)
         {
-            Assembly assembly = typeof(SarifLogger).Assembly;
+            Assembly assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
             string name = Path.GetFileNameWithoutExtension(assembly.Location);
             Version version = assembly.GetName().Version;
 

--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
     public static class VersionConstants                                             
     {                                                                                
         public const string Prerelease = "-beta";                             
-        public const string AssemblyVersion = "1.0.14"; 
+        public const string AssemblyVersion = "1.0.15"; 
         public const string FileVersion = AssemblyVersion + ".0";                    
         public const string Version = AssemblyVersion + Prerelease;                  
     }                                                                                

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         [TestMethod]
         public void ResultLogJsonWriter_AcceptsIssuesAndToolInfo()
         {
-            string expected = "{\"version\":\"0.4\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{},\"results\":[{\"ruleId\":null,\"fullMessage\":null,\"locations\":null}]}]}";
+            string expected = "{\"version\":\"0.4\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{},\"results\":[{\"ruleId\":null,\"locations\":null}]}]}";
             string actual = GetJson(uut =>
             {
                 uut.WriteToolAndRunInfo(s_defaultToolInfo, s_defaultRunInfo);

--- a/src/Sarif/GrammarFiles/Sarif.g4
+++ b/src/Sarif/GrammarFiles/Sarif.g4
@@ -293,7 +293,7 @@ result :
         beginning of the full message.
         }
     */
-    fullMessage
+    fullMessage?
 
     /**
         @name {ShortMessage}

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     public static class VersionConstants                                             
     {                                                                                
         public const string Prerelease = "-beta";                             
-        public const string AssemblyVersion = "1.4.14"; 
+        public const string AssemblyVersion = "1.4.15"; 
         public const string FileVersion = AssemblyVersion + ".0";                    
         public const string Version = AssemblyVersion + Prerelease;                  
     }                                                                                


### PR DESCRIPTION
Break analysis into distinct CanAnalyze v. Analyze phases. Expose logging helpers to derived AnalyzeCommandBase types. Update to v 1.0.15. @BillyONeal @nguerrera @lgolding 