### PR TITLE
Move ruleInfo under runLog, which conforms to current SARIF spec. rul…

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -11,7 +11,7 @@ md bld\bin\nuget
 
 set MAJOR=1
 set MINOR=4
-set PATCH=18
+set PATCH=19
 set PRERELEASE=-beta
 
 @REM Write VersionConstants files 

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             runLog.Results = new List<Result>();
 
             log.RunLogs.Add(runLog);
-            runLog.ToolInfo.RuleInfo = new List<RuleDescriptor>();
+            runLog.RuleInfo = new List<RuleDescriptor>();
 
             SortedDictionary<int, RuleDescriptor> sortedRuleDescriptors = new SortedDictionary<int, RuleDescriptor>();
 
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
             foreach (RuleDescriptor ruleDescriptor in sortedRuleDescriptors.Values)
             {
-                runLog.ToolInfo.RuleInfo.Add(ruleDescriptor);
+                runLog.RuleInfo.Add(ruleDescriptor);
             }
 
             var settings = new JsonSerializerSettings()

--- a/src/Sarif/GrammarFiles/Sarif.g4
+++ b/src/Sarif/GrammarFiles/Sarif.g4
@@ -48,6 +48,17 @@ runLog:
         }
     */
 	runInfo?
+	
+    /**
+        @name {RuleInfo}
+        @summary 
+		{
+		An array of rule descriptor objects that describe all rules associated with an 
+		analysis tool or a specific run of an analysis tool.
+		}
+		@minItems{1}
+    */
+    ruleDescriptors?
 
     /**
         @name {Results}
@@ -111,17 +122,7 @@ toolInfo :
 		@pattern {[0-9]+(\\.[0-9]+){3}}
     */
     fileVersion?
-	
-    /**
-        @name {RuleInfo}
-        @summary 
-		{
-		An array of rule descriptor objects that describe all rules associated with an 
-		analysis tool or a specific run of an analysis tool.
-		}
-		@minItems{1}
-    */
-    ruleDescriptors?;
+;
 
 /**
     @className {RunInfo}


### PR DESCRIPTION
…eInfo was previously placed under toolInfo property. @lgolding @nguerrera @BillyONeal 