### PR TITLE
Make sure all tests fail even running under admin privileges.

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -53,7 +53,7 @@ sn -k GeneratedKey.snk
 
 @REM Build all code
 %~dp0.nuget\NuGet.exe restore src\Sarif.Sdk.sln 
-msbuild /verbosity:minimal /target:rebuild src\Sarif.Sdk.sln /p:Configuration=Release 
+msbuild /verbosity:minimal /target:rebuild src\Sarif.Sdk.sln /p:"Configuration=Release" /p:"Platform=Any CPU"
 
 if "%ERRORLEVEL%" NEQ "0" (
 goto ExitFailed

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -308,24 +308,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         [Fact]
         public void UnauthorizedAccessExceptionCreatingSarifLog()
         {
-            string path = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+            string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             path = Path.Combine(path, Guid.NewGuid().ToString());
 
             try
             {
-                // attempt to persist to unauthorized location will raise exception
-                var options = new TestAnalyzeOptions()
+                using (var stream = File.Create(path, 1, FileOptions.DeleteOnClose))
                 {
-                    TargetFileSpecifiers = new string[] { this.GetType().Assembly.Location },
-                    OutputFilePath = path,
-                    Verbose = true,
-                };
+                    // attempt to persist to unauthorized location will raise exception
+                    var options = new TestAnalyzeOptions()
+                    {
+                        TargetFileSpecifiers = new string[] { this.GetType().Assembly.Location },
+                        OutputFilePath = path,
+                        Verbose = true,
+                    };
 
-                ExceptionTestHelper(
-                    ExceptionCondition.None,
-                    RuntimeConditions.ExceptionCreatingLogfile,
-                    expectedExitReason: ExitReason.ExceptionCreatingLogFile,
-                    analyzeOptions: options);
+                    ExceptionTestHelper(
+                        ExceptionCondition.None,
+                        RuntimeConditions.ExceptionCreatingLogfile,
+                        expectedExitReason: ExitReason.ExceptionCreatingLogFile,
+                        analyzeOptions: options);
+                }
             }
             finally
             {

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -311,28 +311,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             path = Path.Combine(path, Guid.NewGuid().ToString());
 
-            try
+            using (var stream = File.Create(path, 1, FileOptions.DeleteOnClose))
             {
-                using (var stream = File.Create(path, 1, FileOptions.DeleteOnClose))
+                // attempt to persist to unauthorized location will raise exception
+                var options = new TestAnalyzeOptions()
                 {
-                    // attempt to persist to unauthorized location will raise exception
-                    var options = new TestAnalyzeOptions()
-                    {
-                        TargetFileSpecifiers = new string[] { this.GetType().Assembly.Location },
-                        OutputFilePath = path,
-                        Verbose = true,
-                    };
+                    TargetFileSpecifiers = new string[] { this.GetType().Assembly.Location },
+                    OutputFilePath = path,
+                    Verbose = true,
+                };
 
-                    ExceptionTestHelper(
-                        ExceptionCondition.None,
-                        RuntimeConditions.ExceptionCreatingLogfile,
-                        expectedExitReason: ExitReason.ExceptionCreatingLogFile,
-                        analyzeOptions: options);
-                }
-            }
-            finally
-            {
-                File.Delete(path);
+                ExceptionTestHelper(
+                    ExceptionCondition.None,
+                    RuntimeConditions.ExceptionCreatingLogfile,
+                    expectedExitReason: ExitReason.ExceptionCreatingLogFile,
+                    analyzeOptions: options);
             }
         }
 


### PR DESCRIPTION
Resolves #181. @lgolding 

Larry, note in the meantime that you can run tests as non-admin to verify. This change also adds explicit platform property to build step.