### PR TITLE
Fix #101: SARIF validator console output should be in standard VS format

### DIFF
--- a/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
+++ b/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
@@ -26,6 +26,14 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
+++ b/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ExceptionCondition.cs" />
     <Compile Include="ExceptionRaisingRule.cs" />
     <Compile Include="Sdk\ExtensionMethodsTests.cs" />
+    <Compile Include="Sdk\FormatForVisualStudioTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SarifHelpers.cs" />
     <Compile Include="TestAnalysisContext.cs" />

--- a/src/Sarif.Driver.UnitTests/Sdk/ExtensionMethodsTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/ExtensionMethodsTests.cs
@@ -1,60 +1,26 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Text;
+using FluentAssertions;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
     public class ExtensionMethodsTests
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public ExtensionMethodsTests(ITestOutputHelper output)
+        [Theory]
+        [InlineData("first (foo.dll) sentence. more text", "first (foo.dll) sentence.")]
+        [InlineData("first 'foo.dll' sentence. more text", "first 'foo.dll' sentence.")]
+        [InlineData("first (') sentence. more text", "first (') sentence.")]
+        [InlineData("first '(' sentence. more text", "first '(' sentence.")]
+        [InlineData("first sentence\n more text", "first sentence")]
+        [InlineData("first sentence\r more text", "first sentence")]
+        public void GetFirstSentenceTests(string input, string expected)
         {
-            _testOutputHelper = output;
-        }
+            string actual = ExtensionMethods.GetFirstSentence(input);
 
-        [Fact]
-        public void GetFirstSentenceTests()
-        {
-            // TODO convert this to [Theory]
-            var sb = new StringBuilder();
-
-            var tests = new[]
-            {
-                new Tuple<string, string>("first (foo.dll) sentence. more text", "first (foo.dll) sentence."),
-                new Tuple<string, string>("first 'foo.dll' sentence. more text", "first 'foo.dll' sentence."),
-                new Tuple<string, string>("first (') sentence. more text", "first (') sentence."),
-                new Tuple<string, string>("first '(' sentence. more text", "first '(' sentence."),
-                new Tuple<string, string>("first sentence\n more text", "first sentence"),
-                new Tuple<string, string>("first sentence\r more text", "first sentence"),
-            };
-
-            foreach (Tuple<string, string> test in tests)
-            {
-                string input = test.Item1;
-                string expected = test.Item2;
-                string actual = ExtensionMethods.GetFirstSentence(input);
-
-                if (expected != actual)
-                {
-                    sb.AppendLine(string.Format("Input value: '{0}'", input));
-                    sb.AppendLine(string.Format("Expected: '{0}'", expected));
-                    sb.AppendLine(string.Format("Actual: '{0}'", actual));
-                    sb.AppendLine();
-                }
-            }
-
-            if (sb.Length > 0)
-            {
-                _testOutputHelper.WriteLine(sb.ToString());
-            }
-
-            Assert.Equal(0, sb.Length);
+            actual.Should().Be(expected);
         }
     }
 }

--- a/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
+{
+    // These tests test the extension method Result.FormatForVisualStudio.
+    // But by providing various Region objects and ResultKind value, they
+    // also exercise Region.FormatForVisualStudio and ResultKind.FormatForVisualStudio.
+    public class FormatForVisualStudioTests
+    {
+        private const string TestRuleId = "TST0001";
+        private const string TestFormatSpecifier = "testFormatSpecifier";
+        private const string TestAnalysisTarget = @"C:\dir\file";
+        private static readonly string DisplayedTarget = TestAnalysisTarget.Replace('\\', '/');
+
+        private static readonly RuleDescriptor TestRule = new RuleDescriptor(
+            TestRuleId,
+            "ThisIsATest",
+            "short description",
+            "full description",
+            null,           // options
+            new Dictionary<string, string>
+            {
+                [TestFormatSpecifier] = "First: {0}, Second: {1}"
+            },
+            null,           // helpUri
+            null,           // properties
+            null);          // tags
+
+        private static readonly Region MultiLineTestRegion = new Region
+        {
+            StartLine = 2,
+            StartColumn = 4,
+            EndLine = 3,
+            EndColumn = 5
+        };
+
+        private static readonly Region SingleLineTestRegion = new Region
+        {
+            StartLine = 2,
+            StartColumn = 4,
+            EndLine = 2,
+            EndColumn = 5
+        };
+
+        public static IEnumerable<object[]> ResultFormatForVisualStudioTestCases => new[]
+        {
+            new object[]
+            {
+                ResultKind.Error,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): error {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.ConfigurationError,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): error {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.InternalError,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): error {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.Warning,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): warning {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.NotApplicable,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.Note,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.Pass,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.Unknown,
+                MultiLineTestRegion,
+                $"{DisplayedTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54"
+            },
+
+            new object[]
+            {
+                ResultKind.Error,
+                SingleLineTestRegion,
+                $"{DisplayedTarget}(2,4-5): error {TestRuleId}: First: 42, Second: 54"
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(ResultFormatForVisualStudioTestCases))]
+        public void Result_FormatForVisualStudioTests(ResultKind kind, Region region, string expected)
+        {
+            Result result = MakeResultFromTestCase(kind, region);
+
+            string actual = result.FormatForVisualStudio(TestRule);
+
+            actual.Should().Be(expected);
+        }
+
+        private Result MakeResultFromTestCase(ResultKind kind, Region region)
+        {
+            return new Result
+            {
+                RuleId = TestRuleId,
+                Kind = kind,
+                Locations = new List<Location>
+                {
+                    new Location
+                    {
+                         AnalysisTarget = new List<PhysicalLocationComponent>
+                         {
+                             new PhysicalLocationComponent
+                             {
+                                 Uri = TestAnalysisTarget.CreateUriForJsonSerialization(),
+                                 Region = region
+                             },
+                         }
+                    }
+                },
+                FormattedMessage = new FormattedMessage
+                {
+                    SpecifierId = TestFormatSpecifier,
+                    Arguments = new List<string>
+                    {
+                        "42",
+                        "54"
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
     // These tests test the extension method Result.FormatForVisualStudio.
-    // But by providing various Region objects and ResultKind value, they
+    // But by providing various Region objects and ResultKind values, they
     // also exercise Region.FormatForVisualStudio and ResultKind.FormatForVisualStudio.
     public class FormatForVisualStudioTests
     {
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public static IEnumerable<object[]> ResultFormatForVisualStudioTestCases => new[]
         {
+            // Test each ResultKind value.
             new object[]
             {
                 ResultKind.Error,
@@ -105,6 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                 $"{DisplayedTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54"
             },
 
+            // Test formatting of a single-line region (previous tests used a multi-line region).
             new object[]
             {
                 ResultKind.Error,

--- a/src/Sarif.Driver.UnitTests/packages.config
+++ b/src/Sarif.Driver.UnitTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/src/Sarif.Driver/Sdk/ExtensionMethods.cs
+++ b/src/Sarif.Driver/Sdk/ExtensionMethods.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                 var lastComponent = components.Last();
                 messageLines.Add(
                     string.Format(
-                        CultureInfo.InvariantCulture, "{0}:{1} {2} {3}: {4}",
+                        CultureInfo.InvariantCulture, "{0}{1}: {2} {3}: {4}",
                         lastComponent.Uri.AbsolutePath,
                         lastComponent.Region.FormatForVisualStudio(),
                         result.Kind.FormatForVisualStudio(),

--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -343,6 +343,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
The product functionality was checked in during the previous merge a3fb424, but we didn't close the issue then because we hadn't yet provided unit tests for the `FormatForVisualStudio` extension methods that we'd added to the Driver SDK to support the implementation. Now we add the tests and close the issue.

Also:
* Reimplement `GetFirstSentenceTests` as a `Theory`, which is much more compact.

@michaelcfanning 