### PR TITLE
Add support for date-time JSON format (with corresponding C# DateTime object type)

### DIFF
--- a/src/DataModelGenerator/CodeGenerator.cs
+++ b/src/DataModelGenerator/CodeGenerator.cs
@@ -195,6 +195,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                     case DataModelTypeKind.BuiltInBoolean:
                     case DataModelTypeKind.BuiltInVersion:
                     case DataModelTypeKind.BuiltInUri:
+                    case DataModelTypeKind.BuiltInDateTime:
                         // Don't write builtin types
                         break;
                     case DataModelTypeKind.Default:
@@ -541,6 +542,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case DataModelTypeKind.BuiltInNumber:
                 case DataModelTypeKind.BuiltInString:
                 case DataModelTypeKind.BuiltInBoolean:
+                case DataModelTypeKind.BuiltInDateTime:
                     return sourceVariable;
                 case DataModelTypeKind.BuiltInVersion:
                     return "(global::System.Version)" + sourceVariable + ".Clone()";
@@ -548,6 +550,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                     return sourceVariable;
                 case DataModelTypeKind.BuiltInUri:
                     return "new global::System.Uri(" + sourceVariable + ".OriginalString, " + sourceVariable + ".IsAbsoluteUri ? global::System.UriKind.Absolute : global::System.UriKind.Relative)";
+
                 default:
                     Debug.Fail("Unexpected DataModelTypeKind");
                     throw new InvalidOperationException();

--- a/src/DataModelGenerator/DataModelBuilder.cs
+++ b/src/DataModelGenerator/DataModelBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright            CreateBuiltin("URI", "global::System.Uri", DataModelTypeKind.BuiltInUri), (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
             CreateBuiltin("INTEGER", "int", DataModelTypeKind.BuiltInNumber),
             CreateBuiltin("DICTIONARY", "global::System.Collections.Generic.Dictionary<string, string>", DataModelTypeKind.BuiltInDictionary),
             CreateBuiltin("URI", "global::System.Uri", DataModelTypeKind.BuiltInUri),
+            CreateBuiltin("DATETIME", "global::System.DateTime", DataModelTypeKind.BuiltInDateTime),
             CreateBuiltin("VERSION", "global::System.Version", DataModelTypeKind.BuiltInVersion)
             );
 

--- a/src/DataModelGenerator/DataModelTypeKind.cs
+++ b/src/DataModelGenerator/DataModelTypeKind.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
 
         BuiltInUri,
 
+        BuiltInDateTime,
+
         BuiltInVersion,
 
         /// <summary>

--- a/src/DataModelGenerator/EqualsGenerator.cs
+++ b/src/DataModelGenerator/EqualsGenerator.cs
@@ -160,6 +160,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case DataModelTypeKind.Leaf:
                 case DataModelTypeKind.BuiltInString:
                 case DataModelTypeKind.BuiltInUri:
+                case DataModelTypeKind.BuiltInDateTime:
                 case DataModelTypeKind.BuiltInVersion:
                     _codeWriter.WriteLine("result = (result * {1}) + {0}.GetHashCode();", sourceVariable, MultiplicativeConstant);
                     break;
@@ -255,6 +256,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case DataModelTypeKind.BuiltInNumber:
                 case DataModelTypeKind.BuiltInBoolean:
                 case DataModelTypeKind.BuiltInUri:
+                case DataModelTypeKind.BuiltInDateTime:
                 case DataModelTypeKind.Enum:
                 case DataModelTypeKind.BuiltInVersion:
                 _codeWriter.OpenBrace("if ({0} != {1})", sourceVariable, otherVariable);

--- a/src/DataModelGenerator/JsonSchemaGenerator.cs
+++ b/src/DataModelGenerator/JsonSchemaGenerator.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                     case DataModelTypeKind.BuiltInBoolean:
                     case DataModelTypeKind.BuiltInVersion:
                     case DataModelTypeKind.BuiltInUri:
+                    case DataModelTypeKind.BuiltInDateTime:
                     case DataModelTypeKind.Enum:
                     // Don't write builtin types
                     break;
@@ -278,7 +279,8 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case ("DICTIONARY"): { canonicalizedName = "object"; return true; }
                 case ("INTEGER"): { canonicalizedName = "integer"; return true; }
                 case ("BOOLEAN"): { canonicalizedName = "boolean"; return true; }
-                case ("URI"): { canonicalizedName = "string"; format = "uri";  return true; }
+                case ("URI"): { canonicalizedName = "string"; format = "uri"; return true; }
+                case ("DATETIME"): { canonicalizedName = "string"; format = "date-time"; return true; }
             }
 
             canonicalizedName = memberType;

--- a/src/DataModelGenerator/RewritingVisitorGenerator.cs
+++ b/src/DataModelGenerator/RewritingVisitorGenerator.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case DataModelTypeKind.BuiltInDictionary:
                 case DataModelTypeKind.BuiltInBoolean:
                 case DataModelTypeKind.BuiltInUri:
+                case DataModelTypeKind.BuiltInDateTime:
                 case DataModelTypeKind.Enum:
                 case DataModelTypeKind.BuiltInVersion:
                 // Don't visit builtins; overrides would inspect those directly.

--- a/src/DataModelGenerator/ToStringGenerator.cs
+++ b/src/DataModelGenerator/ToStringGenerator.cs
@@ -83,6 +83,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                     case DataModelTypeKind.Leaf:
                     case DataModelTypeKind.Base:
                     case DataModelTypeKind.BuiltInUri:
+                    case DataModelTypeKind.BuiltInDateTime:
                     case DataModelTypeKind.BuiltInVersion:
                         _codeWriter.WriteLine("sb.Append({0} == null ? \"{1}(null)\" : {0}.ToString());", sourceVariable, toStringEntry.Variable.CSharpName);
                         break;

--- a/src/DataModelGenerator/VisitorGenerator.cs
+++ b/src/DataModelGenerator/VisitorGenerator.cs
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.DataModelGenerator
                 case DataModelTypeKind.BuiltInDictionary:
                 case DataModelTypeKind.BuiltInBoolean:
                 case DataModelTypeKind.BuiltInUri:
+                case DataModelTypeKind.BuiltInDateTime:
                 case DataModelTypeKind.BuiltInVersion:
                 case DataModelTypeKind.Enum:
                 // Don't visit builtins; overrides would inspect those directly.

--- a/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void AlgorithmKindGroestl()
         {
-            string expected = "{\"version\":\"1.0.0-beta.1\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{\"analysisTargets\":[{\"uri\":null,\"hashes\":[{\"value\":null,\"algorithm\":\"Groestl\"}]}]},\"results\":[{\"ruleId\":null,\"locations\":null}]}]}";
+            string expected = "{\"version\":\"1.0.0-beta.1\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{\"analysisTargets\":[{\"uri\":null,\"hashes\":[{\"value\":null,\"algorithm\":\"Groestl\"}]}]},\"results\":[{\"locations\":null}]}]}";
             string actual = GetJson(uut =>
             {
                 var runInfo = new RunInfo();

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         [TestMethod]
         public void ResultLogJsonWriter_AcceptsIssuesAndToolInfo()
         {
-            string expected = "{\"version\":\"1.0.0-beta.1\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{},\"results\":[{\"ruleId\":null,\"locations\":null}]}]}";
+            string expected = "{\"version\":\"1.0.0-beta.1\",\"runLogs\":[{\"toolInfo\":{\"name\":null},\"runInfo\":{},\"results\":[{\"locations\":null}]}]}";
             string actual = GetJson(uut =>
             {
                 uut.WriteToolAndRunInfo(s_defaultToolInfo, s_defaultRunInfo);

--- a/src/Sarif/GrammarFiles/Sarif.g4
+++ b/src/Sarif/GrammarFiles/Sarif.g4
@@ -103,8 +103,7 @@ toolInfo :
         the code analysis product is a native Windows program, this value SHOULD be the first
         three values for product version in the VS_VERSION_INFO structure. If the tool is a .NET
         application, this value SHOULD be the first three dotted version values of AssemblyVersion.
-        }
-		@pattern {[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z-]+)?(\\+[0-9A-Za-z-]+)?}
+        }		
     */
     version?
 
@@ -122,6 +121,23 @@ toolInfo :
 		@pattern {[0-9]+(\\.[0-9]+){3}}
     */
     fileVersion?
+
+	/**
+		@name {RunStartTime}
+        @summary {
+		An optional string specifying the date and time at which the run started.
+		}
+	*/
+	runStartTime?
+
+	/**
+	@name {RunEndTime}
+    @summary {
+	An optional string specifying the date and time at which the run ended.
+	}
+	*/
+	runEndTime?
+
 ;
 
 /**
@@ -1139,3 +1155,5 @@ specifierId : STRING;
 shortDescription : STRING;
 fullDescription : STRING;
 arguments : STRING*;
+runStartTime : DATETIME;
+runEndTime : DATETIME;


### PR DESCRIPTION
@lgolding @rtaket 

Added runStartTime and runEndTime, which are expressed in the schema as format == 'date-time', in C# as DateTime objects.