### PR TITLE
Allow null rule descriptor

### DIFF
--- a/src/Sarif.Driver/Sdk/SarifLogger.cs
+++ b/src/Sarif.Driver/Sdk/SarifLogger.cs
@@ -155,7 +155,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                     throw new InvalidOperationException();
                 }
             }
-            this.ruleDescriptors.Add(rule);
+
+            if (rule != null)
+            {
+                this.ruleDescriptors.Add(rule);
+            }
+
             _issueLogJsonWriter.WriteResult(result);
         }
 
@@ -173,7 +178,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public void Log(ResultKind messageKind, IAnalysisContext context, Region region, string formatSpecifierId, params string[] arguments)
         {
-            this.ruleDescriptors.Add(context.Rule);
+            if (context.Rule != null)
+            {
+                this.ruleDescriptors.Add(context.Rule);
+            }
 
             formatSpecifierId = RuleUtilities.NormalizeFormatSpecifierId(context.Rule.Id, formatSpecifierId);
             LogJsonIssue(messageKind, context.TargetUri?.LocalPath, region, context.Rule.Id, formatSpecifierId, arguments);


### PR DESCRIPTION
@michaelcfanning This took me a while to debug. The roslyn analyzer code was passing null as the IRuleDescriptor and that ends up crashing much later on Dispose when we write out the rule metadata. Oddly, we are creating a rule descriptor for each roslyn diagnostic in binskim, but dropping it on the floor and passing null. I unblocked things by actually passing the rule descriptor. Still, since rule metadata is optional (correct?) we should tolerate null. (If I'm wrong and it's not optional, we should throw up-front and not null-ref much later.)