### PR TITLE
Framework supports additional command line option validation

### DIFF
--- a/SetCurrentVersion.cmd
+++ b/SetCurrentVersion.cmd
@@ -1,4 +1,4 @@
 set MAJOR=1
-set MINOR=4
-set PATCH=34
+set MINOR=5
+set PATCH=0
 set PRERELEASE=-beta

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -76,6 +76,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         }
 
         [Fact]
+        public void InvalidCommandLineOption()
+        {
+            var options = new TestAnalyzeOptions
+            {
+                RegardOptionsAsInvalid = true
+            };
+
+            ExceptionTestHelper(
+                ExceptionCondition.ValidatingOptions,
+                RuntimeConditions.ExceptionInvalidCommandLineOption,
+                ExitReason.InvalidCommandLineOption,
+                options);
+        }
+
+        [Fact]
         public void NotApplicableToTarget()
         {
             var options = new TestAnalyzeOptions()

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
             ExceptionTestHelper(
                 ExceptionCondition.ValidatingOptions,
-                RuntimeConditions.ExceptionInvalidCommandLineOption,
+                RuntimeConditions.InvalidCommandLineOption,
                 ExitReason.InvalidCommandLineOption,
                 options);
         }

--- a/src/Sarif.Driver.UnitTests/ExceptionCondition.cs
+++ b/src/Sarif.Driver.UnitTests/ExceptionCondition.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         InvokingCanAnalyze,
         InvokingInitialize,
         ParsingTarget,
-        LoadingPdb
+        LoadingPdb,
+        ValidatingOptions
     }
 }

--- a/src/Sarif.Driver.UnitTests/TestAnalyzeCommand.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalyzeCommand.cs
@@ -26,5 +26,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             context.Options = options;
             return context;
         }
+
+        protected override void ValidateOptions(TestAnalysisContext context, TestAnalyzeOptions options)
+        {
+            if (options.RegardOptionsAsInvalid)
+            {
+                context.RuntimeErrors |= RuntimeConditions.ExceptionInvalidCommandLineOption;
+                ThrowExitApplicationException(context, ExitReason.InvalidCommandLineOption);
+            }
+        }
     }
 }

--- a/src/Sarif.Driver.UnitTests/TestAnalyzeCommand.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalyzeCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         {
             if (options.RegardOptionsAsInvalid)
             {
-                context.RuntimeErrors |= RuntimeConditions.ExceptionInvalidCommandLineOption;
+                context.RuntimeErrors |= RuntimeConditions.InvalidCommandLineOption;
                 ThrowExitApplicationException(context, ExitReason.InvalidCommandLineOption);
             }
         }

--- a/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
@@ -36,5 +36,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public bool RegardRequiredConfigurationAsMissing { get; set;  }
 
+        public bool RegardOptionsAsInvalid { get; set; }
     }
 }

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             return ((RuntimeErrors & RuntimeConditions.Fatal) == RuntimeConditions.NoErrors) ? SUCCESS : FAILURE;
         }
 
+        protected abstract void ValidateOptions(TContext context, TOptions analyzeOptions);
+
         private void Analyze(TOptions analyzeOptions, AggregatingLogger logger)
         {
             // 0. Log analysis initiation
@@ -67,25 +69,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             //    instances and will be passed on again for analysis.
             this.rootContext = CreateContext(analyzeOptions, logger, policy, RuntimeErrors);
 
-            // 3. Produce a comprehensive set of analysis targets 
+            // 3. Perform any command line argument validation beyond what
+            //    the command line parser library is capable of.
+            ValidateOptions(this.rootContext, analyzeOptions);
+
+            // 4. Produce a comprehensive set of analysis targets 
             HashSet<string> targets = CreateTargetsSet(analyzeOptions);
 
-            // 4. Proactively validate that we can locate and 
+            // 5. Proactively validate that we can locate and 
             //    access all analysis targets. Helper will return
             //    a list that potentially filters out files which
             //    did not exist, could not be accessed, etc.
             targets = ValidateTargetsExist(this.rootContext, targets);
 
-            // 5. Initialize report file, if configured.
+            // 6. Initialize report file, if configured.
             InitializeOutputFile(analyzeOptions, this.rootContext, targets);
 
-            // 6. Instantiate skimmers.
+            // 7. Instantiate skimmers.
             HashSet<ISkimmer<TContext>> skimmers = CreateSkimmers(this.rootContext);
 
-            // 7. Initialize skimmers. Initialize occurs a single time only.
+            // 8. Initialize skimmers. Initialize occurs a single time only.
             skimmers = InitializeSkimmers(skimmers, this.rootContext);
 
-            // 8. Run all analysis
+            // 9. Run all analysis
             AnalyzeTargets(analyzeOptions, skimmers, this.rootContext, targets);
 
             // 9. For test purposes, raise an unhandled exception if indicated
@@ -356,7 +362,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             return candidateSkimmers;
         }
 
-        private void ThrowExitApplicationException(TContext context, ExitReason exitReason, Exception innerException = null)
+        protected void ThrowExitApplicationException(TContext context, ExitReason exitReason, Exception innerException = null)
         {
             RuntimeErrors |= context.RuntimeErrors;
 

--- a/src/Sarif.Driver/Sdk/ExitReason.cs
+++ b/src/Sarif.Driver/Sdk/ExitReason.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         UnhandledExceptionInstantiatingSkimmers,
         UnhandledExceptionInEngine,
         NoRulesLoaded,
-        NoValidAnalysisTargets
+        NoValidAnalysisTargets,
+        InvalidCommandLineOption
     }
 }

--- a/src/Sarif.Driver/Sdk/RuntimeConditions.cs
+++ b/src/Sarif.Driver/Sdk/RuntimeConditions.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         NoValidAnalysisTargets = 0x400,
         RuleMissingRequiredConfiguration = 0x800,
         TargetParseError = 0x1000,
+        ExceptionInvalidCommandLineOption = 0x2000,
 
         Fatal = (Int32.MaxValue ^ NonFatal),
 

--- a/src/Sarif.Driver/Sdk/RuntimeConditions.cs
+++ b/src/Sarif.Driver/Sdk/RuntimeConditions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         NoValidAnalysisTargets = 0x400,
         RuleMissingRequiredConfiguration = 0x800,
         TargetParseError = 0x1000,
-        ExceptionInvalidCommandLineOption = 0x2000,
+        InvalidCommandLineOption = 0x2000,
 
         Fatal = (Int32.MaxValue ^ NonFatal),
 

--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
     public static class VersionConstants                                       
     {                                                                          
         public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.4.34";       
+        public const string AssemblyVersion = "1.5.0";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     public static class VersionConstants                                       
     {                                                                          
         public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.4.34";       
+        public const string AssemblyVersion = "1.5.0";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          


### PR DESCRIPTION
There is now hook for `AnalyzerCommandBase`-derived classes to perform command line option validation beyond what the CommandLineParser library is capable of.

We will use this in BinSkim to validate that the `--sympath` option points to a directory (not a file), and that the directory exists.

@michaelcfanning 