### PR TITLE
Update the Tools.OpenSARIFFile command to accept a log file as a parameter.

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommandPackage.vsct
+++ b/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommandPackage.vsct
@@ -68,6 +68,7 @@
       <Button guid="guidOpenSarifFileCommandPackageCmdSet" id="OpenSarifFileCommandId" priority="0x0100" type="Button">
         <Parent guid="guidOpenSarifFileCommandPackageCmdSet" id="OpenFileSubMenuGroup" />
         <!--<Icon guid="guidImages" id="bmpPic1" />-->
+        <CommandFlag>AllowParams</CommandFlag>
         <Strings>
           <ButtonText>Open SARIF file...</ButtonText>
         </Strings>

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -203,6 +203,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
@michaelcfanning 

This will enable opening a SARIF file from the command line.
e.g.
"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe" /Command "Tools.OpenSARIFFile C:\Temp\Newtonsoft.Json.dll.sarif.json"
