### PR TITLE
Upgrade to latest schema

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -58,7 +58,7 @@ if "%ERRORLEVEL%" NEQ "0" (
 goto ExitFailed
 )
 
-msbuild /verbosity:minimal /target:rebuild src\Everything.sln /p:"Configuration=Release" /p:"Platform=Any CPU" /filelogger /fileloggerparameters:Verbosity=normal
+msbuild /verbosity:minimal /target:rebuild src\Everything.sln /p:"Configuration=Release" /p:"Platform=Any CPU" /filelogger /fileloggerparameters:Verbosity=detailed
 
 if "%ERRORLEVEL%" NEQ "0" (
 goto ExitFailed

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -478,9 +478,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         {
             Run run = AnalyzeFile(this.GetType().Assembly.Location);
 
-            int issueCount = 0;
-            SarifHelpers.ValidateRun(run, (issue) => { issueCount++; });
-            Assert.Equal(1, issueCount);
+            int resultCount = 0;
+            SarifHelpers.ValidateRun(run, (issue) => { resultCount++; });
+            Assert.Equal(1, resultCount);
         }
     }
 }

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -430,10 +430,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             }
         }
 
-        public RunLog AnalyzeFile(string fileName)
+        public Run AnalyzeFile(string fileName)
         {
             string path = Path.GetTempFileName();
-            RunLog runLog = null;
+            Run run = null;
 
             try
             {
@@ -461,25 +461,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
                 SarifLog log = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(path), settings);
                 Assert.NotNull(log);
-                Assert.Equal<int>(1, log.RunLogs.Count);
+                Assert.Equal<int>(1, log.Runs.Count);
 
-                runLog = log.RunLogs[0];
+                run = log.Runs[0];
             }
             finally
             {
                 File.Delete(path);
             }
 
-            return runLog;
+            return run;
         }
 
         [Fact]
         public void AnalyzeCommand_EndToEndAnalysisWithNoIssues()
         {
-            RunLog runLog = AnalyzeFile(this.GetType().Assembly.Location);
+            Run run = AnalyzeFile(this.GetType().Assembly.Location);
 
             int issueCount = 0;
-            SarifHelpers.ValidateRunLog(runLog, (issue) => { issueCount++; });
+            SarifHelpers.ValidateRun(run, (issue) => { issueCount++; });
             Assert.Equal(1, issueCount);
         }
     }

--- a/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
+++ b/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Sarif.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
-    internal class ExceptionRaisingRule : IRuleDescriptor, ISkimmer<TestAnalysisContext>
+    internal class ExceptionRaisingRule : IRule, ISkimmer<TestAnalysisContext>
     {
         internal static ExceptionCondition s_exceptionCondition;
 
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             }
         }
 
-        public IDictionary<string, string> FormatSpecifiers
+        public IDictionary<string, string> MessageFormats
         {
             get
             {

--- a/src/Sarif.Driver.UnitTests/SarifHelpers.cs
+++ b/src/Sarif.Driver.UnitTests/SarifHelpers.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
     internal static class SarifHelpers
     {
-        public static void ValidateRunLog(RunLog runLog, Action<Result> resultAction)
+        public static void ValidateRun(Run run, Action<Result> resultAction)
         {
-            ValidateTool(runLog.Tool);
+            ValidateTool(run.Tool);
 
-            foreach (Result result in runLog.Results) { resultAction(result); }
+            foreach (Result result in run.Results) { resultAction(result); }
         }
 
         public static void ValidateTool(Tool tool)

--- a/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
@@ -16,10 +16,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
     public class FormatForVisualStudioTests
     {
         private const string TestRuleId = "TST0001";
-        private const string TestFormatSpecifier = "testFormatSpecifier";
+        private const string TestFormatId = "testFormatSpecifier";
         private const string TestAnalysisTarget = @"C:\dir\file";
 
-        private static readonly RuleDescriptor TestRule = new RuleDescriptor(
+        private static readonly Rule TestRule = new Rule(
             TestRuleId,
             "ThisIsATest",
             "short description",
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             null,           // options
             new Dictionary<string, string>
             {
-                [TestFormatSpecifier] = "First: {0}, Second: {1}"
+                [TestFormatId] = "First: {0}, Second: {1}"
             },
             null,           // helpUri
             null,           // properties
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                 },
                 FormattedMessage = new FormattedMessage
                 {
-                    SpecifierId = TestFormatSpecifier,
+                    FormatId = TestFormatId,
                     Arguments = new List<string>
                     {
                         "42",

--- a/src/Sarif.Driver.UnitTests/TestAnalysisContext.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalysisContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public PropertyBag Policy { get; set; }
 
-        public IRuleDescriptor Rule { get; set; }
+        public IRule Rule { get; set; }
 
         public Exception TargetLoadException { get; set; }
 

--- a/src/Sarif.Driver.UnitTests/TestMessageLogger.cs
+++ b/src/Sarif.Driver.UnitTests/TestMessageLogger.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         {
         }
 
-        public void Log(IRuleDescriptor rule, Result result)
+        public void Log(IRule rule, Result result)
         {
             NoteTestResult(result.Kind, result.Locations[0].AnalysisTarget.Uri.LocalPath);
         }

--- a/src/Sarif.Driver/Sdk/AggregatingLogger.cs
+++ b/src/Sarif.Driver/Sdk/AggregatingLogger.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             }
         }
 
-        public void Log(IRuleDescriptor rule, Result result)
+        public void Log(IRule rule, Result result)
         {
             foreach (IAnalysisLogger logger in Loggers)
             {

--- a/src/Sarif.Driver/Sdk/AnalysisContext.cs
+++ b/src/Sarif.Driver/Sdk/AnalysisContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         public IAnalysisLogger Logger { get; set; }
 
-        public IRuleDescriptor Rule { get; set; }
+        public IRule Rule { get; set; }
 
         public PropertyBag Policy { get; set; }
 

--- a/src/Sarif.Driver/Sdk/ConsoleLogger.cs
+++ b/src/Sarif.Driver/Sdk/ConsoleLogger.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             }
         }
 
-        public void Log(IRuleDescriptor rule, Result result)
+        public void Log(IRule rule, Result result)
         {
             string message = result.GetMessageText(rule, concise: false);
 
@@ -176,8 +176,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             if (region != null)
             {
                 // TODO 
-                if (region.CharOffset > 0 ||
-                    region.ByteOffset > 0 ||
+                if (region.Offset > 0 ||
                     region.StartColumn == 0)
                 {
                     throw new NotImplementedException();

--- a/src/Sarif.Driver/Sdk/Errors.cs
+++ b/src/Sarif.Driver/Sdk/Errors.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         private const string ERR0999 = "ERR0998";
         private const string ERR1001 = "ERR1001";
 
-        public static IRuleDescriptor InvalidConfiguration = new RuleDescriptor()
+        public static IRule InvalidConfiguration = new Rule()
         {
             Id = ERR0997,
             Name = nameof(InvalidConfiguration),
             FullDescription = SdkResources.ERR0997_InvalidConfiguration_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.ERR0997_ExceptionAccessingFile),
                     nameof(SdkResources.ERR0997_ExceptionLoadingPdb),
@@ -37,12 +37,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                }, ERR0997)
         };
 
-        public static IRuleDescriptor RuleDisabled = new RuleDescriptor()
+        public static IRule RuleDisabled = new Rule()
         {
             Id = ERR0998,
             Name = nameof(RuleDisabled),
             FullDescription = SdkResources.ERR0998_RuleDisabled_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.ERR0998_ExceptionInCanAnalyze),
                     nameof(SdkResources.ERR0998_ExceptionInInitialize),
@@ -50,23 +50,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
                 }, ERR0998)
         };
 
-        public static IRuleDescriptor AnalysisHalted = new RuleDescriptor()
+        public static IRule AnalysisHalted = new Rule()
         {
             Id = ERR0999,
             Name = nameof(AnalysisHalted),
             FullDescription = SdkResources.ERR0999_AnalysisHalted_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.ERR0999_UnhandledEngineException)
                 }, ERR0999)
         };
 
-        public static IRuleDescriptor ParseError = new RuleDescriptor()
+        public static IRule ParseError = new Rule()
         {
             Id = ERR1001,
             Name = nameof(ParseError),
             FullDescription = SdkResources.ERR1001_ParseError_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.ERR1001_Default)
                 }, ERR1001)

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         {
             var log = new SarifLog();
 
-            log.Version = SarifVersion.OneZeroZeroBetaTwo;
+            log.Version = SarifVersion.OneZeroZeroBetaThree;
 
             // The SARIF spec currently requires an array
             // of run logs with at least one member

--- a/src/Sarif.Driver/Sdk/IAnalysisContext.cs
+++ b/src/Sarif.Driver/Sdk/IAnalysisContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         bool IsValidAnalysisTarget { get;  }
 
-        IRuleDescriptor Rule { get; set; }
+        IRule Rule { get; set; }
 
         PropertyBag Policy { get; set; }
         

--- a/src/Sarif.Driver/Sdk/IAnalysisLogger.cs
+++ b/src/Sarif.Driver/Sdk/IAnalysisLogger.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         /// </summary>
         /// <param name="rule"></param>
         /// <param name="result"></param>
-        void Log(IRuleDescriptor rule, Result result);
+        void Log(IRule rule, Result result);
 
         /// <summary>
         /// Log a simple message for display to users (which 

--- a/src/Sarif.Driver/Sdk/ISkimmer.cs
+++ b/src/Sarif.Driver/Sdk/ISkimmer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Sarif.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
-    public interface ISkimmer<TContext> : IRuleDescriptor
+    public interface ISkimmer<TContext> : IRule
     {
         /// <summary>
         /// Initialize method for skimmer instance. This method will only 

--- a/src/Sarif.Driver/Sdk/Notes.cs
+++ b/src/Sarif.Driver/Sdk/Notes.cs
@@ -10,25 +10,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
         private const string MSG1001 = "MSG1001";
         private const string MSG1002 = "MSG1002";
 
-        public static IRuleDescriptor AnalyzingTarget = new RuleDescriptor()
+        public static IRule AnalyzingTarget = new Rule()
         {
             // Analyzing {0}...
             Id = MSG1001,
             Name = nameof(AnalyzingTarget),
             FullDescription = SdkResources.MSG1001_AnalyzingTarget_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.MSG1001_AnalyzingTarget),
                 }, MSG1001)
         };
 
-        public static IRuleDescriptor InvalidTarget = new RuleDescriptor()
+        public static IRule InvalidTarget = new Rule()
         {
             // A file was skipped as it does not appear to be a valid target for analysis.
             Id = MSG1002,
             Name = nameof(InvalidTarget),
             FullDescription = SdkResources.MSG1002_InvalidTarget_Description,
-            FormatSpecifiers = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
+            MessageFormats = RuleUtilities.BuildDictionary(SdkResources.ResourceManager,
                 new string[] {
                     nameof(SdkResources.MSG1002_InvalidFileType),
                     nameof(SdkResources.MSG1002_InvalidMetadata)

--- a/src/Sarif.Driver/Sdk/RuleUtilities.cs
+++ b/src/Sarif.Driver/Sdk/RuleUtilities.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 {
     public static class RuleUtilities
     {
-        public static Result BuildResult(ResultKind messageKind, IAnalysisContext context, Region region, string formatSpecifierId, params string[] arguments)
+        public static Result BuildResult(ResultKind messageKind, IAnalysisContext context, Region region, string formatId, params string[] arguments)
         {
             string[] messageArguments = arguments;
 
-            formatSpecifierId = RuleUtilities.NormalizeFormatSpecifierId(context.Rule.Id, formatSpecifierId);
+            formatId = RuleUtilities.NormalizeFormatId(context.Rule.Id, formatId);
 
             string targetPath = context.TargetUri?.LocalPath;
 
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
             result.FormattedMessage = new FormattedMessage()
             {
-                SpecifierId = formatSpecifierId,
+                FormatId = formatId,
                 Arguments = messageArguments
             };
 
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             {
                 string resourceValue = resourceManager.GetString(resourceName);
 
-                string normalizedResourceName = NormalizeFormatSpecifierId(ruleId, resourceName);
+                string normalizedResourceName = NormalizeFormatId(ruleId, resourceName);
 
                 // We need to use the non-normalized key to retrieve the resource value
                 dictionary[normalizedResourceName] = resourceValue;
@@ -75,13 +75,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             return dictionary;
         }
 
-        public static string NormalizeFormatSpecifierId(string ruleId, string formatSpecifierId)
+        public static string NormalizeFormatId(string ruleId, string formatId)
         {
-            if (!string.IsNullOrEmpty(ruleId) && formatSpecifierId.StartsWith(ruleId + "_"))
+            if (!string.IsNullOrEmpty(ruleId) && formatId.StartsWith(ruleId + "_"))
             {
-                formatSpecifierId = formatSpecifierId.Substring(ruleId.Length + 1);
+                formatId = formatId.Substring(ruleId.Length + 1);
             }
-            return formatSpecifierId;
+            return formatId;
         }
     }
 }

--- a/src/Sarif.Driver/Sdk/SkimmerBase.cs
+++ b/src/Sarif.Driver/Sdk/SkimmerBase.cs
@@ -16,27 +16,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
 
         abstract public Uri HelpUri { get;  }
 
-        private IDictionary<string, string> formatSpecifiers;
+        private IDictionary<string, string> messageFormats;
 
         abstract protected ResourceManager ResourceManager { get; }
 
-        abstract protected IEnumerable<string> FormatSpecifierIds { get; }
+        abstract protected IEnumerable<string> FormatIds { get; }
 
-        virtual public IDictionary<string, string> FormatSpecifiers
+        virtual public IDictionary<string, string> MessageFormats
         {
             get
             {
-                if (this.formatSpecifiers == null)
+                if (this.messageFormats == null)
                 {
-                    this.formatSpecifiers = InitializeFormatSpecifiers();
+                    this.messageFormats = InitializeMessageFormats();
                 }
-                return this.formatSpecifiers;
+                return this.messageFormats;
             }
         }
 
-        private Dictionary<string, string> InitializeFormatSpecifiers()
+        private Dictionary<string, string> InitializeMessageFormats()
         {
-            return RuleUtilities.BuildDictionary(ResourceManager, FormatSpecifierIds, Id);
+            return RuleUtilities.BuildDictionary(ResourceManager, FormatIds, Id);
         }
 
         abstract public string Id { get; }

--- a/src/Sarif.Driver/Sdk/StatisticsLogger.cs
+++ b/src/Sarif.Driver/Sdk/StatisticsLogger.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             _targetsCount++;
         }
 
-        public void Log(IRuleDescriptor rule, Result result)
+        public void Log(IRule rule, Result result)
         {
             Log(result.Kind, result.RuleId);
         }

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/androidTest/java/microsoft/androidstudioformatexample/ApplicationTest.java": [
-            {
-              "uri": "app/src/androidTest/java/microsoft/androidstudioformatexample/ApplicationTest.java",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/androidTest/java/microsoft/androidstudioformatexample/ApplicationTest.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -1,61 +1,51 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "gradle.properties": [
-            {
-              "uri": "gradle.properties",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "gradle/wrapper/gradle-wrapper.properties": [
-            {
-              "uri": "gradle/wrapper/gradle-wrapper.properties",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "gradlew": [
-            {
-              "uri": "gradlew",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "gradlew.bat": [
-            {
-              "uri": "gradlew.bat",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/build.gradle": [
-            {
-              "uri": "app/build.gradle",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/AndroidManifest.xml": [
-            {
-              "uri": "app/src/main/AndroidManifest.xml",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/res/values-w820dp/dimens.xml": [
-            {
-              "uri": "app/src/main/res/values-w820dp/dimens.xml",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "gradle.properties": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "gradle/wrapper/gradle-wrapper.properties": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "gradlew": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "gradlew.bat": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/build.gradle": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/AndroidManifest.xml": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/res/values-w820dp/dimens.xml": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "gradle/wrapper/gradle-wrapper.properties": [
-            {
-              "uri": "gradle/wrapper/gradle-wrapper.properties",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "local.properties": [
-            {
-              "uri": "local.properties",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "gradle/wrapper/gradle-wrapper.properties": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "local.properties": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
-            {
-              "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml": [
-            {
-              "uri": "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
-            {
-              "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
-            {
-              "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
-            {
-              "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "AndroidStudio"
       },
-      "run": {
-        "files": {
-          "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
-            {
-              "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
-              "mimeType": "text/x-java-source"
-            }
-          ],
-          "yammer-droid-2/src/main/java/com/yammer/droid/ui/MessageUIBean.java": [
-            {
-              "uri": "yammer-droid-2/src/main/java/com/yammer/droid/ui/MessageUIBean.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ],
+        "yammer-droid-2/src/main/java/com/yammer/droid/ui/MessageUIBean.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcparam.c": [
-            {
-              "uri": "jcparam.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcparam.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcparam.c": [
-            {
-              "uri": "jcparam.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcparam.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jmemmgr.c": [
-            {
-              "uri": "jmemmgr.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jmemmgr.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcparam.c": [
-            {
-              "uri": "jcparam.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcparam.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jquant1.c": [
-            {
-              "uri": "jquant1.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jquant1.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcparam.c": [
-            {
-              "uri": "jcparam.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcparam.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcmaster.c": [
-            {
-              "uri": "jcmaster.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcmaster.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcmarker.c": [
-            {
-              "uri": "jcmarker.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcmarker.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jcparam.c": [
-            {
-              "uri": "jcparam.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jcparam.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/RealLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/ClangAnalyzer/RealLog.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Clang"
       },
-      "run": {
-        "files": {
-          "jmemmgr.c": [
-            {
-              "uri": "jmemmgr.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "jmemmgr.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
@@ -1,218 +1,182 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "CppCheck",
         "version": "1.66.0"
       },
-      "run": {
-        "files": {
-          "adler32.c": [
-            {
-              "uri": "adler32.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "crc32.c": [
-            {
-              "uri": "crc32.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "deflate.c": [
-            {
-              "uri": "deflate.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "gzlib.c": [
-            {
-              "uri": "gzlib.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "gzread.c": [
-            {
-              "uri": "gzread.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "gzwrite.c": [
-            {
-              "uri": "gzwrite.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "inflate.c": [
-            {
-              "uri": "inflate.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "inftrees.c": [
-            {
-              "uri": "inftrees.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "trees.c": [
-            {
-              "uri": "trees.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "zutil.c": [
-            {
-              "uri": "zutil.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\infback9\\inftree9.c": [
-            {
-              "uri": "contrib\\infback9\\inftree9.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\inflate86\\inffas86.c": [
-            {
-              "uri": "contrib\\inflate86\\inffas86.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\iostream2\\zstream_test.cpp": [
-            {
-              "uri": "contrib\\iostream2\\zstream_test.cpp",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\masmx64\\inffas8664.c": [
-            {
-              "uri": "contrib\\masmx64\\inffas8664.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\iowin32.c": [
-            {
-              "uri": "contrib\\minizip\\iowin32.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\miniunz.c": [
-            {
-              "uri": "contrib\\minizip\\miniunz.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\minizip.c": [
-            {
-              "uri": "contrib\\minizip\\minizip.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\mztools.c": [
-            {
-              "uri": "contrib\\minizip\\mztools.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\unzip.c": [
-            {
-              "uri": "contrib\\minizip\\unzip.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\zip.c": [
-            {
-              "uri": "contrib\\minizip\\zip.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\minizip\\crypt.h": [
-            {
-              "uri": "contrib\\minizip\\crypt.h",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\puff\\puff.c": [
-            {
-              "uri": "contrib\\puff\\puff.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\puff\\pufftest.c": [
-            {
-              "uri": "contrib\\puff\\pufftest.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\testzlib\\testzlib.c": [
-            {
-              "uri": "contrib\\testzlib\\testzlib.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "contrib\\untgz\\untgz.c": [
-            {
-              "uri": "contrib\\untgz\\untgz.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\enough.c": [
-            {
-              "uri": "examples\\enough.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\gun.c": [
-            {
-              "uri": "examples\\gun.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\gzappend.c": [
-            {
-              "uri": "examples\\gzappend.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\gzjoin.c": [
-            {
-              "uri": "examples\\gzjoin.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\gzlog.c": [
-            {
-              "uri": "examples\\gzlog.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "examples\\zran.c": [
-            {
-              "uri": "examples\\zran.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "test\\example.c": [
-            {
-              "uri": "test\\example.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "test\\infcover.c": [
-            {
-              "uri": "test\\infcover.c",
-              "mimeType": "text/x-cpp"
-            }
-          ],
-          "test\\minigzip.c": [
-            {
-              "uri": "test\\minigzip.c",
-              "mimeType": "text/x-cpp"
-            }
-          ]
-        }
+      "files": {
+        "adler32.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "crc32.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "deflate.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "gzlib.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "gzread.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "gzwrite.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "inflate.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "inftrees.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "trees.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "zutil.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\infback9\\inftree9.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\inflate86\\inffas86.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\iostream2\\zstream_test.cpp": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\masmx64\\inffas8664.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\iowin32.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\miniunz.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\minizip.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\mztools.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\unzip.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\zip.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\minizip\\crypt.h": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\puff\\puff.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\puff\\pufftest.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\testzlib\\testzlib.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "contrib\\untgz\\untgz.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\enough.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\gun.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\gzappend.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\gzjoin.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\gzlog.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "examples\\zran.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "test\\example.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "test\\infcover.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ],
+        "test\\minigzip.c": [
+          {
+            "mimeType": "text/x-cpp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_java.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_java.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Fortify"
       },
-      "run": {
-        "files": {
-          "bannedAPIs.java": [
-            {
-              "uri": "bannedAPIs.java",
-              "mimeType": "text/x-java-source"
-            }
-          ]
-        }
+      "files": {
+        "bannedAPIs.java": [
+          {
+            "mimeType": "text/x-java-source"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Fortify"
       },
-      "run": {
-        "files": {
-          "bannedAPIs.m": [
-            {
-              "uri": "bannedAPIs.m",
-              "mimeType": "application/octet-stream"
-            }
-          ]
-        }
+      "files": {
+        "bannedAPIs.m": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "Fortify"
       },
-      "run": {
-        "files": {
-          "bannedAPIs.m": [
-            {
-              "uri": "bannedAPIs.m",
-              "mimeType": "application/octet-stream"
-            }
-          ]
-        }
+      "files": {
+        "bannedAPIs.m": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
@@ -1,25 +1,21 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"
       },
-      "run": {
-        "files": {
-          "file:///d:/SecDevTools/Main/bin/x86/Debug/FxCop/FxCopTestData/Crypto/SecurityCryptographyRuleTests.dll": [
-            {
-              "uri": "file:///d:/SecDevTools/Main/bin/x86/Debug/FxCop/FxCopTestData/Crypto/SecurityCryptographyRuleTests.dll",
-              "mimeType": "application/octet-stream"
-            }
-          ],
-          "file:///d:/SecDevTools/Main/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs": [
-            {
-              "uri": "file:///d:/SecDevTools/Main/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ]
-        }
+      "files": {
+        "file:///d:/SecDevTools/Main/bin/x86/Debug/FxCop/FxCopTestData/Crypto/SecurityCryptographyRuleTests.dll": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ],
+        "file:///d:/SecDevTools/Main/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopExceptions.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopExceptions.xml.sarif
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopNoTargets.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopNoTargets.xml.sarif
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopReportResource.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCopReportResource.xml.sarif
@@ -1,19 +1,16 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"
       },
-      "run": {
-        "files": {
-          "$(ProjectDir)/SpecifyCultureInfo/Microsoft.TeamFoundation.Build.Client.dll": [
-            {
-              "uri": "$(ProjectDir)/SpecifyCultureInfo/Microsoft.TeamFoundation.Build.Client.dll",
-              "mimeType": "application/octet-stream"
-            }
-          ]
-        }
+      "files": {
+        "$(ProjectDir)/SpecifyCultureInfo/Microsoft.TeamFoundation.Build.Client.dll": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/SarifConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
@@ -1,217 +1,181 @@
 {
-  "version": "1.0.0-beta.2",
-  "runLogs": [
+  "version": "1.0.0-beta.3",
+  "runs": [
     {
       "tool": {
         "name": "FxCop"
       },
-      "run": {
-        "files": {
-          "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll": [
-            {
-              "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll",
-              "mimeType": "application/octet-stream"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DSACannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DSACannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/MD5CannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/MD5CannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RC2CannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RC2CannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RijndaelCannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RijndaelCannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RIPEMD160IsNotRecommended.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RIPEMD160IsNotRecommended.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RSAProviderNeeds2048bitKey.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RSAProviderNeeds2048bitKey.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/SHA1CannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/SHA1CannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/TripleDESCannotBeUsed.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/TripleDESCannotBeUsed.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll": [
-            {
-              "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll",
-              "mimeType": "application/octet-stream"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlReader.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlReader.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlTextReader.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlTextReader.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseLoadXml.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseLoadXml.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseSetInnerXml.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseSetInnerXml.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseXslTransform.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseXslTransform.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewClassesDerivedFromXmlTextReader.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewClassesDerivedFromXmlTextReader.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDataViewConnectionString.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDataViewConnectionString.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDtdProcessingAssignment.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDtdProcessingAssignment.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewTrustedXsltUse.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewTrustedXsltUse.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_Data.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_Data.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_DocumentContent.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_DocumentContent.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/TextReaderImplNeedsSettingsAndResolver.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/TextReaderImplNeedsSettingsAndResolver.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXml.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXml.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXmlSchema.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXmlSchema.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXml.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXml.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXmlSchema.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXmlSchema.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDeserialize.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDeserialize.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForLoad.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForLoad.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForSchemaRead.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForSchemaRead.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForValidatingReader.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForValidatingReader.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForXPathDocument.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForXPathDocument.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlSecureResolver.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlSecureResolver.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ],
-          "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAddStringsToXmlSchema.cs": [
-            {
-              "uri": "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAddStringsToXmlSchema.cs",
-              "mimeType": "text/x-csharp"
-            }
-          ]
-        }
+      "files": {
+        "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DESCannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/DSACannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/MD5CannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RC2CannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RijndaelCannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RIPEMD160IsNotRecommended.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/RSAProviderNeeds2048bitKey.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/SHA1CannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityCryptographyRuleTests/TripleDESCannotBeUsed.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll": [
+          {
+            "mimeType": "application/octet-stream"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlReader.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAllowDtdOnXmlTextReader.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseLoadXml.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseSetInnerXml.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotUseXslTransform.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewClassesDerivedFromXmlTextReader.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDataViewConnectionString.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewDtdProcessingAssignment.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewTrustedXsltUse.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_Data.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/ReviewWebControlForSet_DocumentContent.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/TextReaderImplNeedsSettingsAndResolver.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXml.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataSetReadXmlSchema.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXml.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDataTableReadXmlSchema.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForDeserialize.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForLoad.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForSchemaRead.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForValidatingReader.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlReaderForXPathDocument.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/UseXmlSecureResolver.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ],
+        "file:///c:/MSECTools/SecDevMain/src/FxCop/Source/FxCopTestData/SecurityXmlRuleTests/DoNotAddStringsToXmlSchema.cs": [
+          {
+            "mimeType": "text/x-csharp"
+          }
+        ]
       },
       "results": [
         {

--- a/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         private const string EmptyResult = @"{
-  ""version"": ""1.0.0-beta.2"",
-  ""runLogs"": [
+  ""version"": ""1.0.0-beta.3"",
+  ""runs"": [
     {
       ""tool"": {
         ""name"": ""AndroidStudio""

--- a/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
@@ -37,8 +37,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         private const string empty = @"{
-  ""version"": ""1.0.0-beta.2"",
-  ""runLogs"": [
+  ""version"": ""1.0.0-beta.3"",
+  ""runs"": [
     {
       ""tool"": {
         ""name"": ""Clang""

--- a/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             const string source = "<results> <cppcheck version=\"12.34\" /> <errors>   </errors> </results>";
             const string expected = @"{
-  ""version"": ""1.0.0-beta.2"",
-  ""runLogs"": [
+  ""version"": ""1.0.0-beta.3"",
+  ""runs"": [
     {
       ""tool"": {
         ""name"": ""CppCheck"",

--- a/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
@@ -45,17 +45,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void AlgorithmKindGroestl()
         {
-            string expected = "{\"version\":\"1.0.0-beta.2\",\"runLogs\":[{\"tool\":{\"name\":null},\"run\":{\"files\":{\"http://abc/\":[{\"uri\":\"http://abc/\",\"hashes\":[{\"value\":null,\"algorithm\":\"Groestl\"}]}]}},\"results\":[{}]}]}";
+            string expected = "{\"version\":\"1.0.0-beta.3\",\"runs\":[{\"tool\":{\"name\":null},\"files\":{\"http://abc/\":[{\"hashes\":[{\"value\":null,\"algorithm\":\"Groestl\"}]}]},\"results\":[{}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
 
-                run.Files = new Dictionary<Uri, IList<FileReference>> {
-                    [new Uri("http://abc/")] = new List<FileReference>
+                uut.WriteTool(s_defaultTool);
+
+                var files = new Dictionary<Uri, IList<FileData>> {
+                    [new Uri("http://abc/")] = new List<FileData>
                     {
-                        new FileReference()
+                        new FileData()
                         {
-                            Uri = new Uri("http://abc/"),
                             Hashes = new[]
                             {
                                 new Hash()
@@ -67,9 +68,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                     }
                 };
 
-                uut.WriteTool(s_defaultTool);
-                uut.WriteRun(run);
-                uut.WriteResult(s_defaultResult);
+                uut.WriteFiles(files);
+
+                uut.WriteResults(new[] { s_defaultResult });
             });
             Assert.AreEqual(expected, actual);
         }

--- a/src/Sarif.Validation/ResultLogBuilder.cs
+++ b/src/Sarif.Validation/ResultLogBuilder.cs
@@ -23,13 +23,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Validation
 
         private const string UnknownErrorFormatSpecifier = "unknownError";
 
-        private static readonly RuleDescriptor UnknownErrorRule = new RuleDescriptor(
+        private static readonly Rule UnknownErrorRule = new Rule(
             "SV0001",
             "UnknownError",
             Resources.UnknownErrorRuleDescription,
             Resources.UnknownErrorRuleDescription,
             null,           // options
-            new Dictionary<string, string>           // formatSpecifiers
+            new Dictionary<string, string>           // messageFormats
             {
                 [UnknownErrorFormatSpecifier] = Resources.UnknownErrorMessageFormat
             },
@@ -39,13 +39,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Validation
 
         private const string JsonSyntaxErrorFormatSpecifier = "syntaxError";
 
-        private static readonly RuleDescriptor JsonSyntaxErrorRule = new RuleDescriptor(
+        private static readonly Rule JsonSyntaxErrorRule = new Rule(
             "SV0002",
             "JsonSyntaxError",
             Resources.JsonSyntaxErrorRuleDescription,
             Resources.JsonSyntaxErrorRuleDescription,
             null,           // options
-            new Dictionary<string, string>           // formatSpecifiers
+            new Dictionary<string, string>           // messageFormats
             {
                 [JsonSyntaxErrorFormatSpecifier] = Resources.JsonSyntaxErrorMessageFormat
             },
@@ -55,13 +55,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Validation
 
         private const string JsonSchemaValidationErrorFormatSpecifier = "validationError";
 
-        private static readonly RuleDescriptor JsonSchemaValidationErrorRule = new RuleDescriptor(
+        private static readonly Rule JsonSchemaValidationErrorRule = new Rule(
             "SV0003",
             "JsonSchemaValidationError",
             Resources.JsonSchemaValidationErrorRuleDescription,
             Resources.JsonSchemaValidationErrorRuleDescription,
             null,           // options
-            new Dictionary<string, string>           // formatSpecifiers
+            new Dictionary<string, string>           // messageFormats
             {
                 [JsonSchemaValidationErrorFormatSpecifier] = Resources.JsonSchemaValidationErrorMessageFormat
             },
@@ -129,14 +129,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Validation
 
         private void LogError(JsonError error)
         {
-            IRuleDescriptor rule = GetRuleDescriptorForError(error);
+            IRule rule = GetRuleForError(error);
             Result result = MakeResultFromError(error);
 
             _logger.Log(rule, result);
             _messages.Add(result.FormatForVisualStudio(rule));
         }
 
-        private static IRuleDescriptor GetRuleDescriptorForError(JsonError error)
+        private static IRule GetRuleForError(JsonError error)
         {
             switch (error.Kind)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Validation
             {
                 region = new Region
                 {
-                    CharOffset = error.Start,
+                    Offset = error.Start,
                     Length = error.Length
                 };
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorListService.cs
@@ -68,9 +68,9 @@ namespace SarifViewer
 
         private static void ProcessSarifLog(SarifLog sarifLog)
         {
-            foreach (RunLog runLog in sarifLog.RunLogs)
+            foreach (Run run in sarifLog.Runs)
             {
-                Instance.WriteRunLogToErrorList(runLog);
+                Instance.WriteRunToErrorList(run);
             }
 
             SarifTableDataSource.Instance.BringToFront();
@@ -83,22 +83,22 @@ namespace SarifViewer
 
         private Dictionary<string, NewLineIndex> documentToLineIndexMap;
 
-        private IRuleDescriptor GetRule(RunLog runLog, string ruleId)
+        private IRule GetRule(Run runLog, string ruleId)
         {
             if (runLog.Rules == null)
             {
                 return null;
             }
 
-            foreach (IRuleDescriptor ruleDescriptor in runLog.Rules)
+            foreach (IRule rule in runLog.Rules)
             {
-                if (ruleDescriptor.Id == ruleId) { return ruleDescriptor; }
+                if (rule.Id == ruleId) { return rule; }
             }
 
             throw new InvalidOperationException();
         }
 
-        private void WriteRunLogToErrorList(RunLog runLog)
+        private void WriteRunToErrorList(Run runLog)
         {
             List<SarifError> sarifErrors = new List<SarifError>();
 
@@ -110,7 +110,7 @@ namespace SarifViewer
                 string category, document, shortMessage, fullMessage;
                 Region region;
                 NewLineIndex newLineIndex;
-                IRuleDescriptor rule = null;
+                IRule rule = null;
 
                 category = null;
 

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -1,5 +1,5 @@
 {
-  "RuleDescriptor.Options": [
+  "Rule.Options": [
     {
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
@@ -9,7 +9,7 @@
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
   ],
-  "FileReference.Properties": [
+  "FileData.Properties": [
     {
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
@@ -24,12 +24,12 @@
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
   ],
-  "RuleDescriptor.FormatSpecifiers": [
+  "Rule.MessageFormats": [
     {
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
   ],
-  "RuleDescriptor.Properties": [
+  "Rule.Properties": [
     {
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
@@ -45,7 +45,7 @@
       "$type": "Microsoft.Json.Schema.ToDotNet.DictionaryHint, Microsoft.Json.Schema.ToDotNet"
     }
   ],
-  "ruleDescriptor": [
+  "rule": [
     {
       "$type": "Microsoft.Json.Schema.ToDotNet.InterfaceHint, Microsoft.Json.Schema.ToDotNet",
       "description": "Interface exposed by objects that provide information about analysis rules."

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -58,7 +58,7 @@
       "description": "Possible values for the SARIF schema version.",
       "zeroValue": "Unknown",
       "enum": [
-        "OneZeroZeroBetaTwo"
+        "OneZeroZeroBetaThree"
       ]
     }
   ],

--- a/src/Sarif/Converters/AndroidStudioConverter.cs
+++ b/src/Sarif/Converters/AndroidStudioConverter.cs
@@ -69,14 +69,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var fileInfoFactory = new FileInfoFactory(uri => MimeType.Java);
-            Dictionary<Uri, IList<FileReference>> fileInfoDictionary = fileInfoFactory.Create(results);
-
-            var run = fileInfoDictionary != null && fileInfoDictionary.Count > 0
-                ? new Run { Files = fileInfoDictionary }
-                : null;
+            Dictionary<Uri, IList<FileData>> fileDictionary = fileInfoFactory.Create(results);
 
             output.WriteTool(tool);
-            if (run != null) { output.WriteRun(run); }
+            if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }
 
             output.OpenResults();
             output.WriteResults(results);

--- a/src/Sarif/Converters/ClangAnalyzerConverter.cs
+++ b/src/Sarif/Converters/ClangAnalyzerConverter.cs
@@ -61,14 +61,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 };
 
                 var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
-                Dictionary<Uri, IList<FileReference>> fileInfoDictionary = fileInfoFactory.Create(results);
-
-                var run = fileInfoDictionary != null && fileInfoDictionary.Count > 0
-                    ? new Run { Files = fileInfoDictionary }
-                    : null;
+                Dictionary<Uri, IList<FileData>> fileDictionary = fileInfoFactory.Create(results);
 
                 output.WriteTool(tool);
-                if (run != null) { output.WriteRun(run); }
+                if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }
 
                 output.OpenResults();
                 output.WriteResults(results);

--- a/src/Sarif/Converters/CppCheckConverter.cs
+++ b/src/Sarif/Converters/CppCheckConverter.cs
@@ -120,14 +120,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var fileInfoFactory = new FileInfoFactory(uri => MimeType.Cpp);
-            Dictionary<Uri, IList<FileReference>> fileInfoDictionary = fileInfoFactory.Create(results);
-
-            var run = fileInfoDictionary != null && fileInfoDictionary.Count > 0
-                ? new Run { Files = fileInfoDictionary }
-                : null;
+            Dictionary<Uri, IList<FileData>> fileDictionary = fileInfoFactory.Create(results);
 
             issueWriter.WriteTool(tool);
-            if (run != null) { issueWriter.WriteRun(run); }
+            if (fileDictionary != null && fileDictionary.Count > 0) { issueWriter.WriteFiles(fileDictionary); }
 
             issueWriter.OpenResults();
             issueWriter.WriteResults(results);

--- a/src/Sarif/Converters/FileInfoFactory.cs
+++ b/src/Sarif/Converters/FileInfoFactory.cs
@@ -8,16 +8,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FileInfoFactory
     {
-        private readonly Dictionary<Uri, IList<FileReference>> _fileInfoDictionary;
+        private readonly Dictionary<Uri, IList<FileData>> _fileInfoDictionary;
         private readonly Func<Uri, string> _mimeTypeClassifier;
 
         internal FileInfoFactory(Func<Uri, string> mimeTypeClassifier)
         {
             _mimeTypeClassifier = mimeTypeClassifier;
-            _fileInfoDictionary = new Dictionary<Uri, IList<FileReference>>();
+            _fileInfoDictionary = new Dictionary<Uri, IList<FileData>>();
         }
 
-        internal Dictionary<Uri, IList<FileReference>> Create(IEnumerable<Result> results)
+        internal Dictionary<Uri, IList<FileData>> Create(IEnumerable<Result> results)
         {
             foreach (Result result in results)
             {
@@ -27,12 +27,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         if (location.AnalysisTarget != null)
                         {
-                            AddFileReference(location.AnalysisTarget);
+                            AddFile(location.AnalysisTarget);
                         }
 
                         if (location.ResultFile != null)
                         {
-                            AddFileReference(location.ResultFile);
+                            AddFile(location.ResultFile);
                         }
                     }
                 }
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         foreach (AnnotatedCodeLocation stackFrame in stack)
                         {
-                            AddFileReference(stackFrame.PhysicalLocation);
+                            AddFile(stackFrame.PhysicalLocation);
                         }
                     }
 
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         foreach (AnnotatedCodeLocation codeLocation in codeFlow)
                         {
-                            AddFileReference(codeLocation.PhysicalLocation);
+                            AddFile(codeLocation.PhysicalLocation);
                         }
                     }
                 }
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 {
                     foreach (AnnotatedCodeLocation relatedLocation in result.RelatedLocations)
                     {
-                        AddFileReference(relatedLocation.PhysicalLocation);
+                        AddFile(relatedLocation.PhysicalLocation);
                     }
                 }
             }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return _fileInfoDictionary;
         }
 
-        private void AddFileReference(PhysicalLocation physicalLocation)
+        private void AddFile(PhysicalLocation physicalLocation)
         {
             Uri key = physicalLocation.Uri;
 
@@ -80,11 +80,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 _fileInfoDictionary.Add(
                     key,
-                    new List<FileReference>
+                    new List<FileData>
                     {
-                        new FileReference
+                        new FileData
                         {
-                            Uri = physicalLocation.Uri,
                             MimeType = _mimeTypeClassifier(key)
                         }
                     });

--- a/src/Sarif/Converters/FortifyConverter.cs
+++ b/src/Sarif/Converters/FortifyConverter.cs
@@ -70,14 +70,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
-            Dictionary<Uri, IList<FileReference>> fileInfoDictionary = fileInfoFactory.Create(results);
-
-            var run = fileInfoDictionary != null && fileInfoDictionary.Count > 0
-                ? new Run { Files = fileInfoDictionary }
-                : null;
+            Dictionary<Uri, IList<FileData>> fileDictionary = fileInfoFactory.Create(results);
 
             output.WriteTool(tool);
-            if (run != null) { output.WriteRun(run); }
+            if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }
 
             output.OpenResults();
             output.WriteResults(results);

--- a/src/Sarif/Converters/FxCopConverter.cs
+++ b/src/Sarif/Converters/FxCopConverter.cs
@@ -53,14 +53,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
-            Dictionary<Uri, IList<FileReference>> fileInfoDictionary = fileInfoFactory.Create(results);
-
-            var run = fileInfoDictionary != null && fileInfoDictionary.Count > 0
-                ? new Run { Files = fileInfoDictionary }
-                : null;
+            Dictionary<Uri, IList<FileData>> fileDictionary = fileInfoFactory.Create(results);
 
             output.WriteTool(tool);
-            if (run != null) { output.WriteRun(run); }
+            if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }
 
             output.OpenResults();
             output.WriteResults(results);

--- a/src/Sarif/IResultLogWriter.cs
+++ b/src/Sarif/IResultLogWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -32,6 +33,17 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="info"/> is null.</exception>
         /// <param name="run">The run information to write.</param>
         void WriteRun(Run run);
+
+        /// <summary>
+        /// Write information about scanned files to the log. This information may appear
+        /// after the results, as the full list of scanned files might not be known until
+        /// all results have been generated.
+        /// </summary>
+        /// <param name="fileDictionary">
+        /// A dictionary whose keys are the URIs of scanned files and whose values provide
+        /// information about those files.
+        /// </param>
+        void WriteFiles(Dictionary<Uri, IList<FileData>> fileDictionary);
 
         /// <summary>
         /// Initialize the results array associated with the current output log. SARIF producers that

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersionText)
             {
-                case V1_0_0_BETA_3: return SarifVersion.OneZeroZeroBetaTwo;
+                case V1_0_0_BETA_3: return SarifVersion.OneZeroZeroBetaThree;
             }
 
             return SarifVersion.Unknown;
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersion)
             {
-                case SarifVersion.OneZeroZeroBetaTwo: { return V1_0_0_BETA_3; }
+                case SarifVersion.OneZeroZeroBetaThree: { return V1_0_0_BETA_3; }
             }
             return "unknown";
         }

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return s_semVer200.IsMatch(versionString);
         }
 
-        private const string V1_0_0_BETA_2 = "1.0.0-beta.2";
+        private const string V1_0_0_BETA_3 = "1.0.0-beta.3";
 
         /// <summary>
         /// Returns an ISO 8601 compatible universal date time format string with
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersionText)
             {
-                case V1_0_0_BETA_2: return SarifVersion.OneZeroZeroBetaTwo;
+                case V1_0_0_BETA_3: return SarifVersion.OneZeroZeroBetaTwo;
             }
 
             return SarifVersion.Unknown;
@@ -46,12 +46,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersion)
             {
-                case SarifVersion.OneZeroZeroBetaTwo: { return V1_0_0_BETA_2; }
+                case SarifVersion.OneZeroZeroBetaTwo: { return V1_0_0_BETA_3; }
             }
             return "unknown";
         }
 
-        public static Dictionary<string, string> BuildFormatSpecifiers(IEnumerable<string> resourceNames, ResourceManager resourceManager)
+        public static Dictionary<string, string> BuildMessageFormats(IEnumerable<string> resourceNames, ResourceManager resourceManager)
         {
             // Note this dictionary provides for case-insensitive keys
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -1,28 +1,28 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.2)",
-  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.2). SARIF defines a standard format for the output of static analysis tools.",
+  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.3)",
+  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.3): a standard format for the output of static analysis tools.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
     "version": 
     {
-      "description": "The SARIF tool format version of this log file. This value should be set to 1.0.0-beta.2, currently. This is the third proposed revision of a file format that is not yet completely finalized.",
-      "enum": ["1.0.0-beta.2"]
+      "description": "The SARIF format version of this log file.",
+      "enum": ["1.0.0-beta.3"]
     },
 
-    "runLogs": 
+    "runs": 
     {
-      "description": "The set of runLogs contained in this SARIF log.",
+      "description": "The set of runs contained in this log file.",
       "type": "array",
       "minItems": 1,
       "items":
       {
-        "$ref": "#/definitions/runLog"
+        "$ref": "#/definitions/run"
       }
     }
   },
-  "required": ["version", "runLogs"],
+  "required": ["version", "runs"],
   "definitions":
   {
     "annotatedCodeLocation": 
@@ -77,7 +77,7 @@
 
         "replacements": 
         {
-          "description": "An array of replacement objects, each of which represents the replacement of a single range of bytes in a single file specified by the uri property.",
+          "description": "An array of replacement objects, each of which represents the replacement of a single range of bytes in a single file specified by 'uri'.",
           "type": "array",
           "minItems": 1,
           "items":
@@ -88,60 +88,60 @@
       },
       "required": ["uri", "replacements"]
     },
-    "fileReference": 
-    {
-      "description": "A fileReference object represents a single file",
+    "fileData": {
+      "description": "Represents a single file. In some cases, this file might be nested within another file.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "uri": 
-        {
-          "description": "The location of the file as a valid URI",
-          "type": "string",
-          "format": "uri"
+        "pathFromParent": {
+          "description": "The path to the file within its containing file.",
+          "type": "string"
         },
 
-        "mimeType": 
-        {
-          "description": "The MIME content type (RFC 2045) of the file.",
+        "offsetFromParent": {
+          "description": "The offset in bytes of the file within its containing file.",
+          "type": "integer"
+        },
+
+        "length": {
+          "description": "The length of the file in bytes.",
+          "type": "integer"
+        },
+
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the file.",
           "type": "string",
           "pattern": "[^/]+/.+"
         },
 
-        "hashes": 
-        {
-          "description": "An optional array of hash objects, each of which specifies a hashed value for the file specified by the uri property, along with the name of the algorithm used to compute the hash.",
+        "hashes": {
+          "description": "An array of hash objects, each of which specifies a hashed value for the file, along with the name of the algorithm used to compute the hash.",
           "type": "array",
           "minItems": 1,
-          "items":
-          {
+          "items": {
             "$ref": "#/definitions/hash"
           }
         },
 
-        "properties": 
-        {
-          "description": "Key/value pairs that provide additional details about the file reference.",
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the file.",
           "type": "object",
-          "default": {}
+          "default": { }
         },
 
-        "tags": 
-        {
-          "description": "A unique set of strings that provide additional information for the associated file reference.",
+        "tags": {
+          "description": "A set of distinct strings that provide additional information about the file.",
           "type": "array",
-          "items":
-          {
+          "items": {
             "type": "string",
-            "default": []
+            "default": [ ]
           }
         }
-      },
-      "required": ["uri"]
+      }
     },
     "fix": 
     {
-      "description": "A proposed fix an a code defect represented by a result object. A fix specifies a set of file to modify. For each file, the fix specifies a set of bytes to remove and provides a set of new bytes to replace them.",
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of file to modify. For each file, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
@@ -165,19 +165,19 @@
     },
     "formattedMessage": 
     {
-      "description": "A formatted message object encapsulates information that can be used to construct a fully formatted message that describes an issue.",
+      "description": "Contains information that can be used to construct a formatted message that describes a result.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "specifierId": 
+        "formatId": 
         {
-          "description": "A string that identifies the format string used to format the message that describes this result. The value of specifierId must correspond to one of the names in the set of name/value pairs contained in the format specifiers property of the rule info object whose id property matches the rule id property of this issue.",
+          "description": "A string that identifies the message format used to format the message that describes this result. The value of formatId must correspond to one of the names in the set of name/value pairs contained in the 'messageFormats' property of the rule object whose 'id' property matches the 'ruleId' property of this result.",
           "type": "string"
         },
 
         "arguments": 
         {
-          "description": "An array of string values that will be used, in combination with a format specifier, to construct a result message.",
+          "description": "An array of strings that will be used, in combination with a message format, to construct a result message.",
           "type": "array",
           "items":
           {
@@ -185,7 +185,7 @@
           }
         }
       },
-      "required": ["specifierId", "arguments"]
+      "required": ["formatId"]
     },
     "hash": 
     {
@@ -195,13 +195,13 @@
       "properties": {
         "value": 
         {
-          "description": "The hash value of some file or collection of files, computed by the algorithm named in the algorithm property.",
+          "description": "The hash value of some file or collection of files, computed by the algorithm named in the 'algorithm' property.",
           "type": "string"
         },
 
         "algorithm": 
         {
-          "description": "A string specifying the name of the algorithm used to compute the hash value specified in the value property. This shall be one of the following: BLAKE-256, BLAKE-512, ECOH, FSB, GOST, Groestl, HAS-160, HAVAL, JH, MD2, MD4, MD5, MD6, RadioGatun, RIPEMD, RIPEMD-128, RIPEMD-160, RIPEMD-320, SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-3, Skein, Snefru, Spectral Hash, SWIFFT, Tiger, Whirlpool.",
+          "description": "A string specifying the name of the algorithm used to compute the hash value specified in the 'value' property.",
           "enum": [ "BLAKE-256","BLAKE-512","ECOH","FSB","GOST","Groestl","HAS-160","HAVAL","JH","MD2","MD4","MD5","MD6","RadioGatun","RIPEMD","RIPEMD-128","RIPEMD-160","RIPEMD-320","SHA-1","SHA-224","SHA-256","SHA-384","SHA-512","SHA-3","Skein","Snefru","Spectral Hash","SWIFFT","Tiger","Whirlpool"]
         }
       },
@@ -209,25 +209,25 @@
     },
     "location": 
     {
-      "description": "Specifies a location within a file, or within an object nested within a file (such as a location within an assembly contained in an appx file).",
+      "description": "Specifies the location where a static analysis tool produced a result.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "analysisTarget": 
         {
-          "description": "A source file that is associated with the item that the static analysis tool scanned. This may be a .dll in the case of a binary analysis tool like FxCop, or a C++ file in the case of a source analysis tool like PREfast. Note that the defect may not actually occur in this file.",
+          "description": "Identifies the file that the static analysis tool was instructed to scan. This need not be the same as the file where the result actually occurred.",
           "$ref": "#/definitions/physicalLocation"
         },
 
         "resultFile": 
         {
-          "description": "A source file that is associated with the current result if and only if that is not the same as the analysis target. This member will populated or not, in many cases, depending on whether PDBs associated with the analysis target are available. Examples include a C# file in the FxCop-like binary analysis case, or possibly a .H C++ file in the case of a source analysis tool like PREfast.",
+          "description": "Identifies the file where the static analysis tool produced the result.",
           "$ref": "#/definitions/physicalLocation"
         },
 
         "logicalLocation": 
         {
-          "description": "An object that specifies the logical location for which a result is produced.",
+          "description": "Specifies the logical location where the static analysis tool produced the result.",
           "type": "array",
           "items":
           {
@@ -237,44 +237,42 @@
 
         "fullyQualifiedLogicalName": 
         {
-          "description": "A string containing the language-specific logical name of the location where the result occurs; e.g. C: Foo C++: Namespace::Class::MemberFunction(int, double) const&& C++: Namespace::NonmemberFunction(int, double) C#: SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])",
+          "description": "A string that summarizes the information in logicalLocation in a format consistent with the programming language in which the programmatic constructs expressed by logicalLocation were expressed.",
           "type": "string"
         },
 
         "properties": 
         {
-          "description": "Key/value pairs that provide additional information about this location. This might be used to annotate specific stack frames or points in code with additional information, such as assumed values of variables at that point of execution, etc.",
+          "description": "Key/value pairs that provide additional information about the location.",
           "type": "object",
           "default": {}
         },
 
-        "tags": 
-        {
-          "description": "A unique set of strings that provide additional information for the associated location.",
+        "tags": {
+          "description": "A set of distinct strings that provide additional information about the location.",
           "type": "array",
-          "items":
-          {
+          "items": {
             "type": "string",
-            "default": []
+            "default": [ ]
           }
         }
       }
     },
     "logicalLocationComponent": 
     {
-      "description": "One level (e.g. namespace, function, etc.) of a logical location tree.",
+      "description": "A component of a logical location.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "name": 
         {
-          "description": "Name of the item specified by this location component.",
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
           "type": "string"
         },
 
         "kind": 
         {
-          "description": "The type of item this location refers to.",
+          "description": "The type of construct this logicalLocationComponent refers to. Should be one of 'method', 'module', 'namespace', 'package', 'resource', or 'type', if any of those accurately describe the construct.",
           "type": "string"
         }
       },
@@ -282,20 +280,20 @@
     },
     "physicalLocation": 
     {
-      "description": "A location that refers to a file.",
+      "description": "The physical location where a result was detected. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "uri": 
         {
-          "description": "Uri to the file specified by this location.",
+          "description": "Represents the location of the file as a valid URI.",
           "type": "string",
           "format": "uri"
         },
 
         "region": 
         {
-          "description": "The specific region within the analysis where the result was detected.",
+          "description": "The region within the file where the result was detected.",
           "$ref": "#/definitions/region"
         }
       },
@@ -303,55 +301,47 @@
     },
     "region": 
     {
-      "description": "Specifies a region within a file where a result was detected.",
+      "description": "A region within a file where a result was detected.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "startLine": 
         {
-          "description": "The starting line location associated with a region in the text file.",
+          "description": "The line number of first character in the region.",
           "type": "integer",
           "minimum": 1
         },
 
         "startColumn": 
         {
-          "description": "The starting column location associated with a region in the text file.",
+          "description": "The column number of the first character in the region.",
           "type": "integer",
           "minimum": 1
         },
 
         "endLine": 
         {
-          "description": "The ending line location associated with a region in the text file.",
+          "description": "The line number of the last character in the region.",
           "type": "integer",
           "minimum": 1
         },
 
         "endColumn": 
         {
-          "description": "The ending column location associated with a region in the text file.",
+          "description": "The column number of the last character in the region.",
           "type": "integer",
           "minimum": 1
         },
 
-        "charOffset": 
-        {
-          "description": "The zero-based offset (measured in characters) of the first character in the region from the beginning of the file.",
-          "type": "integer",
-          "minimum": 0
-        },
-
-        "byteOffset": 
-        {
-          "description": "The zero-based offset (measured in bytes) of the first byte in the region from the beginning of the file.",
+        "offset": {
+          "description": "The zero-based offset from the beginning of the file of the first byte or character in the region.",
           "type": "integer",
           "minimum": 0
         },
 
         "length": 
         {
-          "description": "The length of the region.",
+          "description": "The length of the region in bytes or characters.",
           "type": "integer",
           "minimum": 0
         }
@@ -359,7 +349,7 @@
     },
     "replacement": 
     {
-      "description": "The replacement of a single range of bytes in a file. Each instance specifies the location within the file where the replacement is to be made, the number of bytes to remove at that location, and a sequence of bytes to insert at that location.",
+      "description": "The replacement of a single range of bytes in a file. Specifies the location within the file where the replacement is to be made, the number of bytes to remove at that location, and a sequence of bytes to insert at that location.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
@@ -372,59 +362,59 @@
 
         "deletedLength": 
         {
-          "description": "An optional integer specifying the number of bytes to delete, start at the byte offset specified by the offset property, measured from the beginning of the file.",
+          "description": "Specifies the number of bytes to delete, starting at the byte offset specified by offset, measured from the beginning of the file.",
           "type": "integer",
           "minimum": 1
         },
 
         "insertedBytes": 
         {
-          "description": "An optional string that specifies the byte sequence to be inserted at the byte offset specified by the offset property, measured from the beginning of the file.",
+          "description": "An optional string that specifies the byte sequence to be inserted at the byte offset specified by the 'offset' property, measured from the beginning of the file.",
           "type": "string"
         }
       },
-      "required": ["offset", "deletedLength", "insertedBytes"]
+      "required": ["offset"]
     },
     "result": 
     {
-      "description": "Represents one or more observations about an analysis target produced by a static analysis tool.",
+      "description": "A single result produced by a static analysis tool.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "ruleId": 
         {
-          "description": "An opaque, stable identifier that uniquely identifies the specific rule associated with the result (e.g., CA2001).",
+          "description": "A stable, opaque identifier for the rule that was evaluated to produce the result.",
           "type": "string"
         },
 
         "kind": 
         {
-          "description": "A string specifying the kind of observation this result represents. This shall be one of the following: warning, error, pass, pending, note, notApplicable, internalError. If this member is not present, its implied value is 'warning'.",
+          "description": "The kind of observation this result represents. If this property is not present, its implied value is 'warning'.",
           "default": "warning",
-          "enum": [ "error","warning","pass","note","notApplicable","internalError","configurationError"]
+          "enum": [ "pass", "warning", "error", "notApplicable", "configurationError", "internalError", "note" ]
         },
 
         "fullMessage": 
         {
-          "description": "A string that comprehensively describes the result to the users.",
+          "description": "A string that describes the result.",
           "type": "string"
         },
 
         "shortMessage": 
         {
-          "description": "A short description that summarizes an issue to the user in one or two lines.",
+          "description": "A string that describes the result, displayed in user interface contexts where the available space is limited to a single line of text.",
           "type": "string"
         },
 
         "formattedMessage": 
         {
-          "description": "A formattedMessage object that can be used to construct a fully formatted message that describes the result. If the formatted message property is present on an result, the full message property shall not be present. If the full message property is present on an result, the formatted message property shall not be present",
+          "description": "A 'formattedMessage' object that can be used to construct a formatted message that describes the result. If the formatted message property is present on an result, the full message property shall not be present. If the full message property is present on an result, the formatted message property shall not be present",
           "$ref": "#/definitions/formattedMessage"
         },
 
         "locations": 
         {
-          "description": "Specifies one or more peer locations where an issue is located. Note that this is not used to point to multiple instances of the same issue; separate instances should have separate issue objects. For example, a misspelled partial class in C# may list all the source lines on which the partial class is declared as separate top-level locations. However, two independent misspellings of the same word need to be top level issues.",
+          "description": "Specifies one or more locations where the result occurred. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
           "type": "array",
           "minItems": 1,
           "items":
@@ -435,13 +425,13 @@
 
         "toolFingerprint": 
         {
-          "description": "A string that baselining mechanisms can merge with other data to help uniquely identify this issue, run-over-run.",
+          "description": "A string that contributes to the process of uniquely identifying the result.",
           "type": "string"
         },
 
         "stacks": 
         {
-          "description": "A grouped set of locations, if available, that represent stacks associated with this result.",
+          "description": "An array of arrays of 'annotatedCodeLocation' objects, each inner array of which describes a single call stack.",
           "type": "array",
           "minItems": 1,
           "items":
@@ -457,7 +447,7 @@
 
         "codeFlows": 
         {
-          "description": "A grouped set of location, if available, that comprise annotated code flows through code which are associated with this result.",
+          "description": "An array of arrays of 'annotatedCodeLocation` objects, each inner array of which describes a single code flow (a possible execution path through the code).",
           "type": "array",
           "minItems": 1,
           "items":
@@ -484,13 +474,13 @@
 
         "isSuppressedInSource": 
         {
-          "description": "A flag that indicates whether or not this result was suppressed in source code.",
+          "description": "A flag indicating whether or not this result was suppressed in source code.",
           "type": "boolean"
         },
 
         "fixes": 
         {
-          "description": "An array of fix objects, if available, that can be applied in order to correct this result.",
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
           "type": "array",
           "minItems": 1,
           "items":
@@ -501,14 +491,14 @@
 
         "properties": 
         {
-          "description": "Key/value pairs that provide additional details about the result.",
+          "description": "Key/value pairs that provide additional information about the result.",
           "type": "object",
           "default": {}
         },
 
         "tags": 
         {
-          "description": "A unique set of strings that provide additional information for the associated result.",
+          "description": "A set of distinct strings that provide additional information about the result.",
           "type": "array",
           "items":
           {
@@ -518,45 +508,45 @@
         }
       }
     },
-    "ruleDescriptor": 
+    "rule": 
     {
-      "description": "An object that contains information about an analysis rule.",
+      "description": "Describes an analysis rule.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "id": 
         {
-          "description": "A string that contains a stable, opaque identifier for a rule.",
+          "description": "A stable, opaque identifier for the rule.",
           "type": "string"
         },
 
         "name": 
         {
-          "description": "An optional string that contains a rule identifier that is understandable to an end user.",
+          "description": "A rule identifier that is understandable to an end user.",
           "type": "string"
         },
 
         "shortDescription": 
         {
-          "description": "A string that contains a concise description of the rule. The short description property should be a single sentence that is understandable when displayed in user interface contexts where the available space is limited to a single line of text.",
+          "description": "A concise description of the rule. Should be a single sentence that is understandable when displayed in user interface contexts where the available space is limited to a single line of text.",
           "type": "string"
         },
 
         "fullDescription": 
         {
-          "description": "A string whose value is a string that describes the rule. The fullDescription property should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.",
+          "description": "A string that describes the rule. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.",
           "type": "string"
         },
 
         "options": 
         {
-          "description": "A dictionary consisting of a set of name/value pairs with arbitrary names. The options objects shall describe the set of configurable options supported by the rule. The value within each name/value pair shall be a string, which may be the empty string. The value shall not be a dictionary or sub-object.",
+          "description": "A dictionary consisting of a set of name/value pairs with arbitrary names. Describes the set of configurable options supported by the rule. The value within each name/value pair shall be a string, which may be the empty string. The value shall not be a dictionary or sub-object.",
           "type": "object"
         },
 
-        "formatSpecifiers": 
+        "messageFormats": 
         {
-          "description": "A dictionary consisting of a set of name/value pairs with arbitrary names. The value within each name/value pair shall be a string that can be passed to a string formatting function (e.g., the C language printf function) to construct a formatted message in combination with an arbitrary number of additional function arguments.",
+          "description": "A set of name/value pairs with arbitrary names. The value within each name/value pair shall consist of plain text interspersed with placeholders, which can be use to construc a formatted message in combination with an arbitrary number of additional string arguments.",
           "type": "object"
         },
 
@@ -569,19 +559,17 @@
 
         "properties": 
         {
-          "description": "A dictionary consisting of a set of name/value pairs with arbitrary names. This allows tools to include information about the rule that is not explicitly specified in the SARIF format. The value within each name/value pair shall be a string, which may be the empty string. The value shall not be a dictionary or sub-object.",
+          "description": "Key/value pairs that provide additional information about the rule.",
           "type": "object",
           "default": {}
         },
 
-        "tags": 
-        {
-          "description": "A unique set of strings that provide additional information for the associated rule.",
+        "tags": {
+          "description": "A set of distinct strings that provide additional information about the rule.",
           "type": "array",
-          "items":
-          {
+          "items": {
             "type": "string",
-            "default": []
+            "default": [ ]
           }
         }
       },
@@ -589,141 +577,115 @@
     },
     "run": 
     {
-      "description": "A run object describes the invocation of the static analysis tool that produced the results specified in the containing runLog object. NOTE: The information in the run object makes it possible to precisely repeat a run of a static analysis tool, and to verify that the results reported in the log file were generated by an appropriate invocation of the tool.",
+      "description": "Describes a single run of a static analysis tool, and contains the output of that run.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "invocation": 
-        {
-          "description": "A string that describes any parameterization for the tool invocation. For command line tools this string may consist of the completely specified command line used to invoke the tool.",
-          "type": "string"
-        },
-
-        "files": 
-        {
-          "description": "A dictionary each of whose keys is a URI and each of whose values is an array of fileReference objects representing the location of a single file target scanned during the run.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/fileReference"
-            }
-          }
-        },
-
-        "runStartTime": 
-        {
-          "description": "An optional string specifying the date and time at which the run started.",
-          "type": "string",
-          "format": "date-time"
-        },
-
-        "runEndTime": 
-        {
-          "description": "An optional string specifying the date and time at which the run ended.",
-          "type": "string",
-          "format": "date-time"
-        },
-
-        "correlationId": 
-        {
-          "description": "An optional string identifier that allows the run to be associated with a larger automation process.",
-          "type": "string"
-        },
-
-        "architecture": 
-        {
-          "description": "An optional string identifier that specifies the hardware architecture for which the run was targeted.",
-          "type": "string"
-        },
-
-        "properties": 
-        {
-          "description": "Key/value pairs that provide additional details about the run.",
-          "type": "object",
-          "default": {}
-        },
-
-        "tags": 
-        {
-          "description": "A unique set of strings that provide additional information for the run.",
-          "type": "array",
-          "items":
-          {
-            "type": "string",
-            "default": []
-          }
-        }
-      }
-    },
-    "runLog": 
-    {
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "tool":
-        {
+        "tool": {
           "description": "Information about the tool or tool pipeline that generated the results in this log. A results log can only contain results produced by a single tool or tool pipeline. A results log can aggregate results from multiple tool log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.",
           "$ref": "#/definitions/tool"
         },
 
-        "run": 
-        {
-          "description": "A run object describes the invocation of the static analysis tool that produced the results specified in the containing runLog object.",
-          "$ref": "#/definitions/run"
+        "invocation": {
+          "description": "A string containing the runtime parameters with which the tool was invoked. For command line tools, this string may consist of the completely specified command line used to invoke the tool.",
+          "type": "string"
         },
 
-        "rules": 
-        {
+        "files": {
+          "description": "A dictionary each of whose keys is a URI and each of whose values is an array of file objects representing the location of a single file target scanned during the run.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/fileData"
+            }
+          }
+        },
+
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is merely exporting rules metadata. It must be present (but may be empty) in the event that a log file represents an actual scan.",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+
+        "rules": {
           "description": "An array of rule descriptor objects that describe all rules associated with an analysis tool or a specific run of an analysis tool.",
           "type": "array",
           "minItems": 1,
-          "items":
-          {
-            "$ref": "#/definitions/ruleDescriptor"
+          "items": {
+            "$ref": "#/definitions/rule"
           }
         },
 
-        "results": 
-        {
-          "description": "The set of results contained in an SARIF log. The results array can be omitted when a runLog is merely exporting rules metadata. It must be present (but may be empty) in the event that a log file represents an actual scan.",
+        "startTime": {
+          "description": "A string specifying the date and time at which the run started.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "endTime": {
+          "description": "A string specifying the date and time at which the run ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "correlationId": {
+          "description": "An identifier that allows the run to be associated with a larger automation process.",
+          "type": "string"
+        },
+
+        "architecture": {
+          "description": "An identifier that specifies the hardware architecture for which the run was targeted.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the run.",
+          "type": "object",
+          "default": { }
+        },
+
+        "tags": {
+          "description": "A set of distinct strings that provide additional information about the run.",
           "type": "array",
-          "minItems": 0,
-          "items":
-          {
-            "$ref": "#/definitions/result"
+          "items": {
+            "type": "string",
+            "default": [ ]
           }
         }
       },
-      "required": ["tool"]
+      "required": [ "tool" ]
     },
     "tool": 
     {
-      "description": "Information about the tool or tool pipeline that generated the results in this log.",
+      "description": "Describes that static analysis tool that was run.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "name": 
         {
-          "description": "The name of the tool or tool pipeline that generated the results in this log, e.g., FxCop.",
+          "description": "The name of the tool.",
           "type": "string"
         },
 
         "fullName": 
         {
-          "description": "The name of the tool along with its version and any other useful identifying information, such as its locale, e.g., 'CodeScanner 2.0, Developer Preview (en-US)'.",
+          "description": "The name of the tool along with its version and any other useful identifying information, such as its locale.",
           "type": "string"
         },
 
         "version": 
         {
-          "description": "A version that refers to the tool as a whole (as opposed to, for example, the build version of an individual binary in the tool).",
+          "description": "The tool version.",
           "type": "string"
         },
 
         "fileVersion": 
         {
-          "description": "For operating systems (such as Windows) that provide the data, the binary version of the primary tool exe.",
+          "description": "For operating systems (such as Windows) that provide such data, the binary version of the tool's primary executable file.",
           "type": "string",
           "pattern": "[0-9]+(\\.[0-9]+){3}"
         }

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             _jsonWriter.WriteStartObject(); // Begin: sarifLog
             _jsonWriter.WritePropertyName("version");
-            _jsonWriter.WriteValue(SarifVersion.OneZeroZeroBetaTwo.ConvertToText());
+            _jsonWriter.WriteValue(SarifVersion.OneZeroZeroBetaThree.ConvertToText());
 
             _jsonWriter.WritePropertyName("runs");
             _jsonWriter.WriteStartArray(); // Begin: runs

--- a/src/Sarif/Writers/ResultLogObjectWriter.cs
+++ b/src/Sarif/Writers/ResultLogObjectWriter.cs
@@ -75,6 +75,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             _run = run;
         }
 
+        /// <summary>
+        /// Write information about scanned files to the log. This information may appear
+        /// after the results, as the full list of scanned files might not be known until
+        /// all results have been generated.
+        /// </summary>
+        /// <param name="fileDictionary">
+        /// A dictionary whose keys are the URIs of scanned files and whose values provide
+        /// information about those files.
+        /// </param>
+        public void WriteFiles(Dictionary<Uri, IList<FileData>> fileDictionary)
+        {
+            throw new NotImplementedException();
+        }
+
         public void OpenResults() { }
 
         public void CloseResults() { }


### PR DESCRIPTION
This PR is INCOMPLETE:

1. I have not touched the C++ code (and it has no unit tests).

2. `IResultLogWriter` and its implementing classes do not handle the "loose" properties of the `run` object, as we discussed this morning. However, they do handle the `files` dictionary, which suffices for the converters, and so enables all the tests to pass.

Please take a look at what I have so far. I suggest we merge it in and then work on filling out `IResultLogWriter`.

@michaelcfanning 