### PR TITLE
Fix typo in tool properties code emit. Update to 1.5.8.

### DIFF
--- a/SetCurrentVersion.cmd
+++ b/SetCurrentVersion.cmd
@@ -6,4 +6,4 @@ set PRERELEASE_PREVIOUS=-beta
 set MAJOR=1
 set MINOR=5
 set PATCH=8
-set PRERELEASE=-developer
+set PRERELEASE=-beta

--- a/src/Sarif.Driver/Sdk/SarifLogger.cs
+++ b/src/Sarif.Driver/Sdk/SarifLogger.cs
@@ -50,11 +50,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver.Sdk
             if (!string.IsNullOrEmpty(fileVersion.FileName)) { tool.Properties["FileName"] = fileVersion.FileName; };
             if (!string.IsNullOrEmpty(fileVersion.Comments)) { tool.Properties["Comments"] = fileVersion.Comments; };
             if (!string.IsNullOrEmpty(fileVersion.CompanyName)) { tool.Properties["CompanyName"] = fileVersion.CompanyName; };
-            if (!string.IsNullOrEmpty(fileVersion.ProductVersion)) { tool.Properties["ProductVersion"] = fileVersion.ProductName; };
+            if (!string.IsNullOrEmpty(fileVersion.ProductName)) { tool.Properties["ProductName"] = fileVersion.ProductName; };
 
             if (!string.IsNullOrEmpty(fileVersion.ProductName) && fileVersion.ProductVersion != tool.Version)
             {
-                tool.Properties["ProductName"] = fileVersion.ProductVersion;
+                tool.Properties["ProductVersion"] = fileVersion.ProductVersion;
             };
 
             if (tool.Properties.Count == 0) { tool.Properties = null; }

--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
     public static class VersionConstants                                       
     {                                                                          
         public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.5.7";       
+        public const string AssemblyVersion = "1.5.8";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     public static class VersionConstants                                       
     {                                                                          
         public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.5.7";       
+        public const string AssemblyVersion = "1.5.8";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          


### PR DESCRIPTION
@lgolding @rtaket 

Let the storm of intraday updates begin, as is typical for RTM moments. BinSkim upgrade revealed an issue that resulted from my inability to wait for prior CR.