### PR TITLE
Diff using value type comparison semantics instead of reference equality

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -14,5 +14,6 @@
 * Persist mime-type for files in SarifLogger
 * Remove stack persistence for configuration notification exceptions
 * Reclassify 'could not parse target' as a configuration notification
+* Fix diffing visitor to diff using value type semantics rather than by reference equality
 
 

--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "-developer";                       
+        public const string Prerelease = "-beta";                       
         public const string AssemblyVersion = "1.5.20";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            

--- a/src/Sarif.UnitTests/Readers/ResultDiffingVisitorTests.cs
+++ b/src/Sarif.UnitTests/Readers/ResultDiffingVisitorTests.cs
@@ -14,20 +14,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void ResultDiffingVisitor_DetectsAbsentAndNewResults()
         {
-            var result1 = new Result
-            {
-                RuleId = "TST0001"
-            };
-
-            var result2 = new Result
-            {
-                RuleId = "TST0002"
-            };
-
-            var result3 = new Result
-            {
-                RuleId = "TST0003"
-            };
+            var result1 = new Result { RuleId = "TST0001" };
+            var result2 = new Result { RuleId = "TST0002" };
+            var result3 = new Result { RuleId = "TST0003" };
 
             var sarifLog = new SarifLog
             {
@@ -45,6 +34,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             };
 
             var visitor = new ResultDiffingVisitor(sarifLog);
+
+            result2 = new Result { RuleId = "TST0002" };
+            result3 = new Result { RuleId = "TST0003" };
+
 
             var newResults = new Result[]
             {

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -78,18 +78,17 @@ namespace Microsoft.CodeAnalysis.Sarif
             using (var tempFile = new TempFile(".cpp"))
             using (var textWriter = new StringWriter(sb))            
             {
-                File.WriteAllText(tempFile.Name, "#include \"windows.h\";");
                 file = tempFile.Name;
+                File.WriteAllText(file, "#include \"windows.h\";");
 
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
-                    analysisTargets: new string[] { tempFile.Name },
+                    analysisTargets: new string[] { file },
                     verbose: false,
                     computeTargetsHash: true,
                     logEnvironment: false,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null)) { }
-
             }
 
             string result = sb.ToString();

--- a/src/Sarif/Readers/ResultDiffingVisitor.cs
+++ b/src/Sarif/Readers/ResultDiffingVisitor.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
     {
         public ResultDiffingVisitor(SarifLog sarifLog)
         {
-            this.AbsentResults = new HashSet<Result>(ResultEqualityComparer.Instance);
-            this.SharedResults = new HashSet<Result>(ResultEqualityComparer.Instance);
-            this.NewResults = new HashSet<Result>(ResultEqualityComparer.Instance);
+            this.AbsentResults = new HashSet<Result>(Result.ValueComparer);
+            this.SharedResults = new HashSet<Result>(Result.ValueComparer);
+            this.NewResults = new HashSet<Result>(Result.ValueComparer);
 
             VisitSarifLog(sarifLog);
         }
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             this.AbsentResults = this.SharedResults;
 
-            this.SharedResults = new HashSet<Result>(ResultEqualityComparer.Instance);
+            this.SharedResults = new HashSet<Result>(Result.ValueComparer);
 
             foreach (Result result in this.NewResults)
             {

--- a/src/Sarif/Readers/ResultDiffingVisitor.cs
+++ b/src/Sarif/Readers/ResultDiffingVisitor.cs
@@ -9,14 +9,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
     {
         public ResultDiffingVisitor(SarifLog sarifLog)
         {
-            this.AbsentResults = new HashSet<Result>();
-            this.SharedResults = new HashSet<Result>();
-            this.NewResults    = new HashSet<Result>();
+            this.AbsentResults = new HashSet<Result>(ResultEqualityComparer.Instance);
+            this.SharedResults = new HashSet<Result>(ResultEqualityComparer.Instance);
+            this.NewResults = new HashSet<Result>(ResultEqualityComparer.Instance);
 
             VisitSarifLog(sarifLog);
         }
 
-        public HashSet<Result> NewResults    { get; set; }
+        public HashSet<Result> NewResults { get; set; }
         public HashSet<Result> AbsentResults { get; set; }
         public HashSet<Result> SharedResults { get; set; }
 
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             this.AbsentResults = this.SharedResults;
 
-            this.SharedResults = new HashSet<Result>();
+            this.SharedResults = new HashSet<Result>(ResultEqualityComparer.Instance);
 
             foreach (Result result in this.NewResults)
             {
@@ -56,11 +56,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 }
             }
 
-            return 
+            return
                 this.AbsentResults.Count == 0 &&
                 this.NewResults.Count == 0;
-       
+
         }
     }
-
 }

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "-developer";                       
+        public const string Prerelease = "-beta";                       
         public const string AssemblyVersion = "1.5.20";       
         public const string FileVersion = "1.5.20" + ".0";    
         public const string Version = AssemblyVersion + Prerelease;            


### PR DESCRIPTION
@lgolding. Oops! Test was not authored in a way such that reference equality worked. Now fixed.