### PR TITLE
Optional unique identifier for a result. Intended to permit correlati…

### DIFF
--- a/src/Sarif/Autogenerated/Result.cs
+++ b/src/Sarif/Autogenerated/Result.cs
@@ -69,6 +69,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string CodeSnippet { get; set; }
 
         /// <summary>
+        /// A unique identifer for the result.
+        /// </summary>
+        [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
+        public string Id { get; set; }
+
+        /// <summary>
         /// A string that contributes to the unique identity of the result.
         /// </summary>
         [DataMember(Name = "toolFingerprint", IsRequired = false, EmitDefaultValue = false)]
@@ -146,6 +152,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="codeSnippet">
         /// An initialization value for the <see cref="P: CodeSnippet" /> property.
         /// </param>
+        /// <param name="id">
+        /// An initialization value for the <see cref="P: Id" /> property.
+        /// </param>
         /// <param name="toolFingerprint">
         /// An initialization value for the <see cref="P: ToolFingerprint" /> property.
         /// </param>
@@ -173,9 +182,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="tags">
         /// An initialization value for the <see cref="P: Tags" /> property.
         /// </param>
-        public Result(string ruleId, ResultLevel level, string message, FormattedRuleMessage formattedRuleMessage, IEnumerable<Location> locations, string codeSnippet, string toolFingerprint, IEnumerable<Stack> stacks, IEnumerable<CodeFlow> codeFlows, IEnumerable<AnnotatedCodeLocation> relatedLocations, SuppressionStates suppressionStates, BaselineState baselineState, IEnumerable<Fix> fixes, IDictionary<string, SerializedPropertyInfo> properties, IEnumerable<string> tags)
+        public Result(string ruleId, ResultLevel level, string message, FormattedRuleMessage formattedRuleMessage, IEnumerable<Location> locations, string codeSnippet, string id, string toolFingerprint, IEnumerable<Stack> stacks, IEnumerable<CodeFlow> codeFlows, IEnumerable<AnnotatedCodeLocation> relatedLocations, SuppressionStates suppressionStates, BaselineState baselineState, IEnumerable<Fix> fixes, IDictionary<string, SerializedPropertyInfo> properties, IEnumerable<string> tags)
         {
-            Init(ruleId, level, message, formattedRuleMessage, locations, codeSnippet, toolFingerprint, stacks, codeFlows, relatedLocations, suppressionStates, baselineState, fixes, properties, tags);
+            Init(ruleId, level, message, formattedRuleMessage, locations, codeSnippet, id, toolFingerprint, stacks, codeFlows, relatedLocations, suppressionStates, baselineState, fixes, properties, tags);
         }
 
         /// <summary>
@@ -194,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.RuleId, other.Level, other.Message, other.FormattedRuleMessage, other.Locations, other.CodeSnippet, other.ToolFingerprint, other.Stacks, other.CodeFlows, other.RelatedLocations, other.SuppressionStates, other.BaselineState, other.Fixes, other.Properties, other.Tags);
+            Init(other.RuleId, other.Level, other.Message, other.FormattedRuleMessage, other.Locations, other.CodeSnippet, other.Id, other.ToolFingerprint, other.Stacks, other.CodeFlows, other.RelatedLocations, other.SuppressionStates, other.BaselineState, other.Fixes, other.Properties, other.Tags);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -215,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Result(this);
         }
 
-        private void Init(string ruleId, ResultLevel level, string message, FormattedRuleMessage formattedRuleMessage, IEnumerable<Location> locations, string codeSnippet, string toolFingerprint, IEnumerable<Stack> stacks, IEnumerable<CodeFlow> codeFlows, IEnumerable<AnnotatedCodeLocation> relatedLocations, SuppressionStates suppressionStates, BaselineState baselineState, IEnumerable<Fix> fixes, IDictionary<string, SerializedPropertyInfo> properties, IEnumerable<string> tags)
+        private void Init(string ruleId, ResultLevel level, string message, FormattedRuleMessage formattedRuleMessage, IEnumerable<Location> locations, string codeSnippet, string id, string toolFingerprint, IEnumerable<Stack> stacks, IEnumerable<CodeFlow> codeFlows, IEnumerable<AnnotatedCodeLocation> relatedLocations, SuppressionStates suppressionStates, BaselineState baselineState, IEnumerable<Fix> fixes, IDictionary<string, SerializedPropertyInfo> properties, IEnumerable<string> tags)
         {
             RuleId = ruleId;
             Level = level;
@@ -244,6 +253,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             CodeSnippet = codeSnippet;
+            Id = id;
             ToolFingerprint = toolFingerprint;
             if (stacks != null)
             {

--- a/src/Sarif/Autogenerated/ResultEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultEqualityComparer.cs
@@ -74,6 +74,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.Id != right.Id)
+            {
+                return false;
+            }
+
             if (left.ToolFingerprint != right.ToolFingerprint)
             {
                 return false;
@@ -260,6 +265,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.CodeSnippet != null)
                 {
                     result = (result * 31) + obj.CodeSnippet.GetHashCode();
+                }
+
+                if (obj.Id != null)
+                {
+                    result = (result * 31) + obj.Id.GetHashCode();
                 }
 
                 if (obj.ToolFingerprint != null)

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -565,6 +565,11 @@
           "type": "string"
         },
 
+        "id": {
+          "description": "A unique identifer for the result.",
+          "type": "string"
+        },
+
         "toolFingerprint": {
           "description": "A string that contributes to the unique identity of the result.",
           "type": "string"


### PR DESCRIPTION
…on of results with external data (such as side-car annotation files). @lgolding (please merge if this looks right).