### PR TITLE
Provide optional 'kind' on annotatedCodeLocation that helps describe/…

### DIFF
--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -40,6 +40,11 @@
           "type": "string"
         },
 
+        "kind": {
+          "description": "A descriptive identifier that categorizes the annotation.",
+          "enum": [ "branchTrue", "branchFalse", "call", "callReturn", "declaration", "functionEnter", "functionExit", "sanitizer", "sink", "source", "use" ]
+        },
+
         "properties": {
           "description": "Key/value pairs that provide additional information about the code location.",
           "type": "object",
@@ -244,7 +249,7 @@
         },
 
         "algorithm": {
-          "description": "A string specifying the name of the algorithm used to compute the hash value specified in the 'value' property.",
+          "description": "The name of the algorithm used to compute the hash value specified in the 'value' property.",
           "enum": [ "authentihash", "blake256", "blake512", "ecoh", "fsb", "gost", "groestl", "has160", "haval", "jh", "md2", "md4", "md5", "md6", "radioGatun", "ripeMD", "ripeMD128", "ripeMD160", "ripeMD320", "sdhash", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3", "skein", "snefru", "spectralHash", "ssdeep", "swifft", "tiger", "tlsh", "whirlpool" ]
         }
       },


### PR DESCRIPTION
…categorize the annotation. @lgolding : need a final call on this. We are updating the PREfast converter, which will populate annotatedCodeLocation.kind if it exists. it's a near call but given that we intend to provide first-class support in a viewer experience that will consume this data, I am comfortable standardizing on this set. what's your thought?