### PR TITLE
Partially implement tags API, fix suppression states, advance schema …

### DIFF
--- a/src/PREfastXmlSarifConverter/PREfastXmlSarifConverter.cpp
+++ b/src/PREfastXmlSarifConverter/PREfastXmlSarifConverter.cpp
@@ -407,7 +407,7 @@ extern "C"
 HRESULT __stdcall Convert(const std::deque<XmlDefect> defectList, BSTR bstrOutputFile, BSTR* pbstrSarifText)
 {
     SarifLog issueLog;
-    issueLog.SetVersion(L"1.0.0-beta.4");
+    issueLog.SetVersion(L"1.0.0-beta.5");
     issueLog.SetSchema(L"http://json.schemastore.org/sarif-1.0.0");
 
     // Set Tool

--- a/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
+++ b/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
@@ -95,14 +95,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             }
         }
 
-        public IList<string> Tags
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
-
         public void Analyze(TestAnalysisContext context)
         {
             if (_exceptionCondition == ExceptionCondition.InvokingAnalyze)

--- a/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/ExportRulesMetadataCommandBase.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var log = new SarifLog();
 
-            SarifVersion sarifVersion = SarifVersion.OneZeroZeroBetaFour;
+            SarifVersion sarifVersion = SarifVersion.OneZeroZeroBetaFive;
             log.SchemaUri = sarifVersion.ConvertToSchemaUri();
             log.Version = sarifVersion;
 

--- a/src/Sarif.Driver/Sdk/SkimmerBase.cs
+++ b/src/Sarif.Driver/Sdk/SkimmerBase.cs
@@ -82,8 +82,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public IDictionary<string, string> Options { get; }
 
-        public IList<string> Tags { get; }
-
         public virtual void Initialize(TContext context) { }
 
         public virtual AnalysisApplicability CanAnalyze(TContext context, out string reasonIfNotApplicable)

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0-beta.5",
   "version": "1.0.0-beta.5",
   "runs": [
     {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-001.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-001.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-002.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-002.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-003.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-003.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-005.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-005.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-008.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-008.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-010.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-010.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-013.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-013.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-014.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-014.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-017.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-017.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-020.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-020.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-021.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-021.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-022.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-022.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-023.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-023.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-024.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-024.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-031.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-031.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-032.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-032.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-035.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-035.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-036.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-036.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-037.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-037.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-039.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-039.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-040.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-040.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-041.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-041.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-042.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-042.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-043.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-043.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-045.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-045.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-046.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-046.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-047.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-047.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-048.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-048.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-049.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-049.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-050.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-050.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-051.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-051.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-052.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-052.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-054.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-054.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-055.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-055.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-057.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-057.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-058.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-058.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-059.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-059.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-060.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-060.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-061.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-061.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-062.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-062.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-063.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-063.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-065.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-065.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-066.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-066.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-067.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-067.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-070.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-070.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-071.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-071.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-072.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-072.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-073.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-073.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-074.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-074.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-075.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-075.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-076.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-076.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-077.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-077.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-078.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-078.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-079.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-079.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-080.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-080.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-081.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-081.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-082.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-082.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-083.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-083.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-084.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-084.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-085.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-085.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-086.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-086.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-087.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-087.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-088.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-088.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-090.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-090.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-091.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-091.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-092.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-092.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-093.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-093.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-094.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-094.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-095.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-095.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-096.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-096.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-097.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-097.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-100.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-100.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-101.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-101.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-102.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-102.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-103.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-103.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-104.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-104.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-106.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-106.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-107.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-107.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-108.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-108.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-109.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-109.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-111.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-111.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-112.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-112.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-113.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-113.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-116.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-116.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-117.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-117.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-121.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-121.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-122.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-122.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-123.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-123.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-126.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-126.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-127.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-127.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-128.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-128.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-129.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-129.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-130.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-130.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-131.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-131.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-132.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-132.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-134.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-134.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-136.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-136.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-137.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-137.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-138.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-138.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-139.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-139.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-140.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-140.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-146.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-146.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-150.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-150.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-152.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-152.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-155.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-155.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-156.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-156.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-157.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-157.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-160.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-160.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-162.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-162.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-163.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-163.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-166.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-166.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-167.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-167.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-168.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-168.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-169.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-169.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-170.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-170.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-171.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-171.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-172.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-172.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-173.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-173.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-178.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-178.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-179.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-179.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-180.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-180.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-181.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-181.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-182.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-182.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-185.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-185.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-186.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-186.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-188.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-188.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-192.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-192.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-193.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-193.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-194.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-194.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-201.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-201.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-203.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-203.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205.xml.sarif
@@ -1,5 +1,5 @@
 {
-"version":"1.0.0-beta.4",
+"version":"1.0.0-beta.5",
 "$schema":"http://json.schemastore.org/sarif-1.0.0",
 "runs":[
   {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/LocalizedBundleDoubleNesting.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/LocalizedBundleDoubleNesting.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromAppX.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromAppX.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryNoTrailingSlash.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryNoTrailingSlash.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryTrailingSlash.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryTrailingSlash.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/RelatedLocations.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/RelatedLocations.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/SimpleBundleDoubleNesting.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/SimpleBundleDoubleNesting.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "runs": [
     {
       "tool": {

--- a/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         private const string EmptyResult = @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {

--- a/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private const string EmptyResult = @"{
   ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
-  ""version"": ""1.0.0-beta.4"",
+  ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {
       ""tool"": {

--- a/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         private const string empty = @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {

--- a/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/ClangAnalyzerConverterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private const string empty = @"{
   ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
-  ""version"": ""1.0.0-beta.4"",
+  ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {
       ""tool"": {

--- a/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             const string source = "<results> <cppcheck version=\"12.34\" /> <errors>   </errors> </results>";
             const string expected = @"{
   ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
-  ""version"": ""1.0.0-beta.4"",
+  ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {
       ""tool"": {

--- a/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/CppCheckConverterTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             const string source = "<results> <cppcheck version=\"12.34\" /> <errors>   </errors> </results>";
             const string expected = @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {

--- a/src/Sarif.UnitTests/Core/TagsTests.cs
+++ b/src/Sarif.UnitTests/Core/TagsTests.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CodeAnalysis.Sarif.Core
+{
+    [TestClass]
+    public class TagsTests
+    {
+    }
+}

--- a/src/Sarif.UnitTests/Core/TagsTests.cs
+++ b/src/Sarif.UnitTests/Core/TagsTests.cs
@@ -142,5 +142,45 @@ namespace Microsoft.CodeAnalysis.Sarif.Core
 
             _testObject.Tags.Count.Should().Be(0);
         }
+
+        [TestMethod]
+        public void Tags_IsProperSubsetOf_ReturnsFalseWhenEmptyAndOtherIsEmpty()
+        {
+            _testObject.Tags.IsProperSubsetOf(new string[0]).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Tags_IsProperSubsetOf_ReturnsTrueWhenEmptyAndOtherIsNonEmpty()
+        {
+            _testObject.Tags.IsProperSubsetOf(new[] { "x" }).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Tags_IsProperSubsetOf_ReturnsFalseWhenNonEmptyAndOtherHasSameElements()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+
+            _testObject.Tags.IsProperSubsetOf(new[] { "x", "y" }).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Tags_IsProperSubsetOf_ReturnsTrueWhenNonEmptyAndIsProperSupersetOfOther()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+
+            _testObject.Tags.IsProperSubsetOf(new[] { "z", "y", "x" }).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Tags_IsProperSubsetOf_ReturnsFalseWhenEachSideHasSomeDifferentElements()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+            _testObject.Tags.Add("z");
+
+            _testObject.Tags.IsProperSubsetOf(new[] { "y", "z", "q" }).Should().BeFalse();
+        }
     }
 }

--- a/src/Sarif.UnitTests/Core/TagsTests.cs
+++ b/src/Sarif.UnitTests/Core/TagsTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif.Readers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CodeAnalysis.Sarif.Core
@@ -8,5 +11,136 @@ namespace Microsoft.CodeAnalysis.Sarif.Core
     [TestClass]
     public class TagsTests
     {
+        private readonly TagsTestClass _testObject = new TagsTestClass();
+
+        private class TagsTestClass : PropertyBagHolder
+        {
+            internal override IDictionary<string, SerializedPropertyInfo> Properties { get; set; }
+        }
+
+        [TestMethod]
+        public void Tags_IsInitiallyEmpty()
+        {
+            _testObject.Tags.Should().BeEmpty();
+            _testObject.Tags.Count.Should().Be(0);
+            _testObject.Tags.Contains("x").Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Tags_Add_AddsTag()
+        {
+            _testObject.Tags.Add("x");
+
+            _testObject.Tags.Count.Should().Be(1);
+            _testObject.Tags.Contains("x").Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Tags_Add_AddsTagsOnlyOnce()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("x");
+
+            _testObject.Tags.Count.Should().Be(1);
+            _testObject.Tags.Contains("x").Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Tags_Add_AddsMultipleTags()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+
+            _testObject.Tags.Count.Should().Be(2);
+            _testObject.Tags.Contains("x").Should().BeTrue();
+            _testObject.Tags.Contains("y").Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void Tags_Clear_ClearsTags()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+
+            _testObject.Tags.Clear();
+
+            _testObject.Tags.Count.Should().Be(0);
+            _testObject.Tags.Contains("x").Should().BeFalse();
+            _testObject.Tags.Contains("y").Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Tags_Clear_WorksOnEmptyTags()
+        {
+            _testObject.Tags.Clear();
+
+            _testObject.Tags.Count.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void Tags_CopyTo_CopiesToArray()
+        {
+            _testObject.Tags.Add("x");
+            _testObject.Tags.Add("y");
+            var array = new string[] { "a", "b", "c", "d" };
+
+            _testObject.Tags.CopyTo(array, 1);
+
+            array.Should().ContainInOrder("a", "x", "y", "d");
+        }
+
+        [TestMethod]
+        public void Tags_CopyTo_WorksOnEmptyTags()
+        {
+            var array = new string[] { "a", "b", "c", "d" };
+
+            _testObject.Tags.CopyTo(array, 1);
+
+            array.Should().ContainInOrder("a", "b", "c", "d");
+        }
+
+        [TestMethod]
+        public void Tags_ExceptWith_RemovesSpecifiedElements()
+        {
+            _testObject.Tags.Add("a");
+            _testObject.Tags.Add("b");
+            _testObject.Tags.Add("c");
+            _testObject.Tags.Add("d");
+
+            _testObject.Tags.ExceptWith(new[] { "b", "c", "e" });
+
+            _testObject.Tags.Count.Should().Be(2);
+            _testObject.Tags.Should().ContainInOrder("a", "d");
+        }
+
+        [TestMethod]
+        public void Tags_ExceptWith_WorksWithEmptyTags()
+        {
+            _testObject.Tags.ExceptWith(new[] { "b", "c", "e" });
+
+            _testObject.Tags.Count.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void Tags_IntersectWith_ReturnsCommonElements()
+        {
+            _testObject.Tags.Add("a");
+            _testObject.Tags.Add("b");
+            _testObject.Tags.Add("c");
+            _testObject.Tags.Add("d");
+
+            _testObject.Tags.IntersectWith(new[] { "b", "c", "e" });
+
+            _testObject.Tags.Count.Should().Be(2);
+            _testObject.Tags.Should().ContainInOrder("b", "c");
+        }
+
+        [TestMethod]
+        public void Tags_IntersectWith_WorksWithEmptyTags()
+        {
+            _testObject.Tags.IntersectWith(new[] { "b", "c", "e" });
+
+            _testObject.Tags.Count.Should().Be(0);
+        }
     }
 }

--- a/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             foreach (var testTuple in testTuples)
             {
                 string expected = 
-                    "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.4\",\"runs\":[{\"tool\":{\"name\":null},\"files\":{\"http://abc/\":[{\"hashes\":[{\"value\":null,\"algorithm\":\"" +
+                    "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"files\":{\"http://abc/\":[{\"hashes\":[{\"value\":null,\"algorithm\":\"" +
                     testTuple.Item2 +  
                     "\"}]}]},\"results\":[{}]}]}";
 

--- a/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
@@ -80,8 +80,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             foreach (var testTuple in testTuples)
             {
-                string expected = 
-                    "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"files\":{\"http://abc/\":[{\"hashes\":[{\"value\":null,\"algorithm\":\"" +
+                string expected =
+                    "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0-beta.5\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"files\":{\"http://abc/\":[{\"hashes\":[{\"value\":null,\"algorithm\":\"" +
                     testTuple.Item2 +  
                     "\"}]}]},\"results\":[{}]}]}";
 

--- a/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void SuppressionStatus_SuppressedInSource()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"suppressionStates\":[\"suppressedInSource\"]}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0-beta.5\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"suppressionStates\":[\"suppressedInSource\"]}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void BaselineState_None()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0-beta.5\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void BaselineState_Existing()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"baselineState\":\"existing\"}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0-beta.5\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"baselineState\":\"existing\"}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();

--- a/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         [TestMethod]
         public void SuppressionStatus_SuppressedInSource()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.4\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"suppressionStates\":[\"suppressedInSource\"]}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"suppressionStates\":[\"suppressedInSource\"]}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
@@ -56,9 +56,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         }
 
         [TestMethod]
-        public void SuppressionStatus_SuppressedInSourceAndBaseline()
+        public void BaselineState_None()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.4\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"suppressionStates\":[\"suppressedInSource\",\"suppressedInBaseline\"]}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
@@ -67,22 +67,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
                 uut.WriteResults(new[] { new Result
                     {
-                        SuppressionStates = SuppressionStates.SuppressedInSource | SuppressionStates.SuppressedInBaseline
+                        BaselineState = BaselineState.None
                     }
                 });
             });
             Assert.AreEqual(expected, actual);
 
             var sarifLog = JsonConvert.DeserializeObject<SarifLog>(actual);
-            Assert.AreEqual(
-                SuppressionStates.SuppressedInSource | SuppressionStates.SuppressedInBaseline, 
-                sarifLog.Runs[0].Results[0].SuppressionStates);
+            Assert.AreEqual(SuppressionStates.None, sarifLog.Runs[0].Results[0].SuppressionStates);
+            Assert.AreEqual(BaselineState.None, sarifLog.Runs[0].Results[0].BaselineState);
         }
 
         [TestMethod]
-        public void BaselineState_None()
+        public void BaselineState_Existing()
         {
-            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.4\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{}]}]}";
+            string expected = "{\"$schema\":\"http://json.schemastore.org/sarif-1.0.0\",\"version\":\"1.0.0-beta.5\",\"runs\":[{\"tool\":{\"name\":null},\"results\":[{\"baselineState\":\"existing\"}]}]}";
             string actual = GetJson(uut =>
             {
                 var run = new Run();
@@ -93,11 +92,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
                 uut.WriteResults(new[] { new Result
                     {
-                        BaselineState = Sarif.BaselineState.None
+                        BaselineState = BaselineState.Existing
                     }
                 });
             });
             Assert.AreEqual(expected, actual);
+
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(actual);
+            Assert.AreEqual(SuppressionStates.None, sarifLog.Runs[0].Results[0].SuppressionStates);
+            Assert.AreEqual(BaselineState.Existing, sarifLog.Runs[0].Results[0].BaselineState);
         }
     }
 }

--- a/src/Sarif.UnitTests/Sarif.UnitTests.csproj
+++ b/src/Sarif.UnitTests/Sarif.UnitTests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Converters\FxCopConverterTests.cs" />
     <Compile Include="Core\PropertyBagHolderTests.cs" />
     <Compile Include="Core\StackTests.cs" />
+    <Compile Include="Core\TagsTests.cs" />
     <Compile Include="EqualityComparerTests.cs" />
     <Compile Include="ExtensionsTests.cs" />
     <Compile Include="JsonTests.cs" />

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {}
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
   ""version"": """ + SchemaVersion + @""",
   ""runs"": [
     {

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
     public class ResultLogJsonWriterTests : JsonTests
     {
         private static readonly string SchemaVersion =
-            SarifUtilities.ConvertToText(SarifVersion.OneZeroZeroBetaFour);
+            SarifUtilities.ConvertToText(SarifVersion.OneZeroZeroBetaFive);
 
         private static readonly Tool s_defaultTool = new Tool();
         private static readonly Result s_defaultResult = new Result();

--- a/src/Sarif/Autogenerated/Location.cs
+++ b/src/Sarif/Autogenerated/Location.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public PhysicalLocation ResultFile { get; set; }
 
         /// <summary>
-        /// The fully qualified name of the logical location where the analysis tool produced the result. If 'localLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.
+        /// The fully qualified name of the logical location where the analysis tool produced the result. If 'logicalLocationKey' is not specified, this member is can used to retrieve the location logicalLocation from the logicalLocations dictionary, if one exists.
         /// </summary>
         [DataMember(Name = "fullyQualifiedLogicalName", IsRequired = false, EmitDefaultValue = false)]
         public string FullyQualifiedLogicalName { get; set; }

--- a/src/Sarif/Autogenerated/SarifVersion.cs
+++ b/src/Sarif/Autogenerated/SarifVersion.cs
@@ -12,6 +12,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     public enum SarifVersion
     {
         Unknown,
-        OneZeroZeroBetaFour
+        OneZeroZeroBetaFive
     }
 }

--- a/src/Sarif/Autogenerated/SuppressionStates.cs
+++ b/src/Sarif/Autogenerated/SuppressionStates.cs
@@ -14,7 +14,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     public enum SuppressionStates
     {
         None,
-        SuppressedInSource = 1,
-        SuppressedInBaseline = 2
+        SuppressedInSource = 1
     }
 }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -339,10 +339,9 @@
         "flags": true,
         "zeroValueName": "None",
         "memberNames": [
-          "SuppressedInSource",
-          "SuppressedInBaseline"
+          "SuppressedInSource"
         ],
-        "memberValues": [1, 2]
+        "memberValues": [1]
       }
     }
   ],
@@ -428,7 +427,7 @@
         "description": "Possible values for the SARIF schema version.",
         "zeroValueName": "Unknown",
         "memberNames": [
-          "OneZeroZeroBetaFour"
+          "OneZeroZeroBetaFive"
         ]
       }
     }

--- a/src/Sarif/Converters/FxCopConverter.cs
+++ b/src/Sarif/Converters/FxCopConverter.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
             else if ("ExcludedInProject".Equals(status))
             {
-                result.SuppressionStates = SuppressionStates.SuppressedInBaseline;
+                result.BaselineState = BaselineState.Existing;
             }
 
             result.RuleId = context.CheckId;

--- a/src/Sarif/Core/IPropertyBagHolder.cs
+++ b/src/Sarif/Core/IPropertyBagHolder.cs
@@ -10,9 +10,12 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public interface IPropertyBagHolder
     {
+        IList<string> PropertyNames { get; }
+        bool TryGetProperty(string propertyName, out string value);
         string GetProperty(string propertyName);
+        bool TryGetProperty<T>(string propertyName, out T value);
         T GetProperty<T>(string propertyName);
         void SetProperty<T>(string propertyName, T value);
-        IList<string> PropertyNames { get; }
+        void RemoveProperty(string propertyName);
     }
 }

--- a/src/Sarif/Core/StackFrame.cs
+++ b/src/Sarif/Core/StackFrame.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text;

--- a/src/Sarif/Core/Tags.cs
+++ b/src/Sarif/Core/Tags.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
@@ -27,7 +28,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                return GetTags().Count;
+                ISet<string> tags = GetTags();
+                return tags != null ? tags.Count : 0;
             }
         }
 
@@ -39,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             bool wasAdded = tags.Add(item);
             if (wasAdded)
             {
-                _propertyBagHolder.SetProperty("tags", tags);
+                SetTags(tags);
             }
 
             return wasAdded;
@@ -58,22 +60,36 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void CopyTo(string[] array, int arrayIndex)
         {
-            throw new NotImplementedException();
+            ISet<string> tags = GetTags();
+            if (tags != null)
+            {
+                tags.CopyTo(array, arrayIndex);
+            }
         }
 
         public void ExceptWith(IEnumerable<string> other)
         {
-            throw new NotImplementedException();
+            ISet<string> tags = GetTags();
+            if (tags != null)
+            {
+                tags.ExceptWith(other);
+                SetTags(tags);
+            }
         }
 
         public IEnumerator<string> GetEnumerator()
         {
-            return GetTags().GetEnumerator();
+            return GetEnumeratorCore();
         }
 
         public void IntersectWith(IEnumerable<string> other)
         {
-            throw new NotImplementedException();
+            ISet<string> tags = GetTags();
+            if (tags != null)
+            {
+                tags.IntersectWith(other);
+                SetTags(tags);
+            }
         }
 
         public bool IsProperSubsetOf(IEnumerable<string> other)
@@ -128,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetTags().GetEnumerator();
+            return GetEnumeratorCore();
         }
 
         private HashSet<string> GetTags()
@@ -136,7 +152,20 @@ namespace Microsoft.CodeAnalysis.Sarif
             HashSet<string> tags;
             return _propertyBagHolder.TryGetProperty(TagsPropertyName, out tags)
                 ? tags
-                : new HashSet<string>();
+                : null;
+        }
+
+        private void SetTags(ISet<string> tags)
+        {
+            _propertyBagHolder.SetProperty(TagsPropertyName, tags);
+        }
+
+        private IEnumerator<string> GetEnumeratorCore()
+        {
+            ISet<string> tags = GetTags();
+            return tags != null
+                ? tags.GetEnumerator()
+                : Enumerable.Empty<string>().GetEnumerator();
         }
     }
 }

--- a/src/Sarif/Core/Tags.cs
+++ b/src/Sarif/Core/Tags.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class Tags : ISet<string>
+    {
+        private const string TagsPropertyName = "tags";
+
+        private readonly IPropertyBagHolder _propertyBagHolder;
+
+        public Tags(IPropertyBagHolder propertyBagHolder)
+        {
+            if (propertyBagHolder == null)
+            {
+                throw new ArgumentNullException(nameof(propertyBagHolder));
+            }
+
+            _propertyBagHolder = propertyBagHolder;
+        }
+
+        public int Count
+        {
+            get
+            {
+                return GetTags().Count;
+            }
+        }
+
+        public bool IsReadOnly => false;
+
+        public bool Add(string item)
+        {
+            ISet<string> tags = GetTags() ?? new HashSet<string>();
+            bool wasAdded = tags.Add(item);
+            if (wasAdded)
+            {
+                _propertyBagHolder.SetProperty("tags", tags);
+            }
+
+            return wasAdded;
+        }
+
+        public void Clear()
+        {
+            _propertyBagHolder.RemoveProperty(TagsPropertyName);
+        }
+
+        public bool Contains(string item)
+        {
+            ISet<string> tags = GetTags();
+            return tags != null ? tags.Contains(item) : false;
+        }
+
+        public void CopyTo(string[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ExceptWith(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return GetTags().GetEnumerator();
+        }
+
+        public void IntersectWith(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSubsetOf(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSupersetOf(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Overlaps(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(string item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool SetEquals(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SymmetricExceptWith(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UnionWith(IEnumerable<string> other)
+        {
+            throw new NotImplementedException();
+        }
+
+        void ICollection<string>.Add(string item)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetTags().GetEnumerator();
+        }
+
+        private HashSet<string> GetTags()
+        {
+            HashSet<string> tags;
+            return _propertyBagHolder.TryGetProperty(TagsPropertyName, out tags)
+                ? tags
+                : new HashSet<string>();
+        }
+    }
+}

--- a/src/Sarif/Core/Tags.cs
+++ b/src/Sarif/Core/Tags.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     public class Tags : ISet<string>
     {
         private const string TagsPropertyName = "tags";
+        private static readonly ISet<string> Empty = new HashSet<string>();
 
         private readonly IPropertyBagHolder _propertyBagHolder;
 
@@ -37,14 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public bool Add(string item)
         {
-            ISet<string> tags = GetTags() ?? new HashSet<string>();
-            bool wasAdded = tags.Add(item);
-            if (wasAdded)
-            {
-                SetTags(tags);
-            }
-
-            return wasAdded;
+            return AddCore(item);
         }
 
         public void Clear()
@@ -94,7 +88,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public bool IsProperSubsetOf(IEnumerable<string> other)
         {
-            throw new NotImplementedException();
+            ISet<string> tags = GetTags() ?? new HashSet<string>();
+            return tags.IsProperSubsetOf(other);
         }
 
         public bool IsProperSupersetOf(IEnumerable<string> other)
@@ -139,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         void ICollection<string>.Add(string item)
         {
-            throw new NotImplementedException();
+            AddCore(item);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -147,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return GetEnumeratorCore();
         }
 
-        private HashSet<string> GetTags()
+        private ISet<string> GetTags()
         {
             HashSet<string> tags;
             return _propertyBagHolder.TryGetProperty(TagsPropertyName, out tags)
@@ -158,6 +153,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         private void SetTags(ISet<string> tags)
         {
             _propertyBagHolder.SetProperty(TagsPropertyName, tags);
+        }
+
+        private bool AddCore(string item)
+        {
+            ISet<string> tags = GetTags() ?? new HashSet<string>();
+            bool wasAdded = tags.Add(item);
+            if (wasAdded)
+            {
+                SetTags(tags);
+            }
+
+            return wasAdded;
         }
 
         private IEnumerator<string> GetEnumeratorCore()

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Core\PropertyBagHolder.cs" />
     <Compile Include="Core\Stack.cs" />
     <Compile Include="Core\StackFrame.cs" />
+    <Compile Include="Core\Tags.cs" />
     <Compile Include="Core\Tool.cs" />
     <Compile Include="Errors.cs" />
     <Compile Include="ExtensionMethods.cs" />

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         private const string V1_0_0 = "1.0.0";
-        private const string V1_0_0_BETA_4 = "1.0.0-beta.4";
+        private const string V1_0_0_BETA_5 = "1.0.0-beta.5";
 
         /// <summary>
         /// Returns an ISO 8601 compatible universal date time format string with
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersionText)
             {
-                case V1_0_0_BETA_4: return SarifVersion.OneZeroZeroBetaFour;
+                case V1_0_0_BETA_5: return SarifVersion.OneZeroZeroBetaFive;
             }
 
             return SarifVersion.Unknown;
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             switch (sarifVersion)
             {
-                case SarifVersion.OneZeroZeroBetaFour: { return V1_0_0_BETA_4; }
+                case SarifVersion.OneZeroZeroBetaFive: { return V1_0_0_BETA_5; }
             }
             return "unknown";
         }

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public static Uri ConvertToSchemaUri(this SarifVersion sarifVersion)
         {
-            return new Uri("http://json.schemastore.org/sarif-" + V1_0_0, UriKind.Absolute);
+            return new Uri("http://json.schemastore.org/sarif-" + V1_0_0_BETA_5, UriKind.Absolute);
         }
 
         public static Dictionary<string, string> BuildMessageFormats(IEnumerable<string> resourceNames, ResourceManager resourceManager)

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.4)",
-  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.4): a standard format for the output of static analysis and other tools.",
+  "title": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.5)",
+  "description": "Static Analysis Results Format (SARIF) Version 1.0 JSON Schema (Draft 1.0.0-beta.5): a standard format for the output of static analysis and other tools.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
@@ -11,7 +11,7 @@
     },
     "version": {
       "description": "The SARIF format version of this log file.",
-      "enum": [ "1.0.0-beta.4" ]
+      "enum": [ "1.0.0-beta.5" ]
     },
 
     "runs": {

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -622,7 +622,6 @@
           "items": {
             "description": "A flag value indicating one or more suppression conditions.",
             "enum": [
-              "suppressed",
               "suppressedInSource"
             ]
           }

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -556,6 +556,15 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Property &apos;{0}&apos; does not exist. Consider calling TryGetProperty instead..
+        /// </summary>
+        internal static string PropertyDoesNotExist {
+            get {
+                return ResourceManager.GetString("PropertyDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Object cannot be serialized until results serialization is completed..
         /// </summary>
         internal static string ResultsSerializationNotComplete {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -297,4 +297,7 @@
   <data name="CallGenericGetProperty" xml:space="preserve">
     <value>The non-generic GetProperty method only works for properties that are JSON strings. To retrieve a property with any other .NET type, call the generic method GetProperty&lt;T&gt;(string propertyName), where T is the .NET type of the object stored in the specified property.</value>
   </data>
+  <data name="PropertyDoesNotExist" xml:space="preserve">
+    <value>Property '{0}' does not exist. Consider calling TryGetProperty instead.</value>
+  </data>
 </root>

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             this.EnsureStateNotAlreadySet(Conditions.Disposed | Conditions.Initialized);
 
-            SarifVersion sarifVersion = SarifVersion.OneZeroZeroBetaFour;
+            SarifVersion sarifVersion = SarifVersion.OneZeroZeroBetaFive;
 
             _jsonWriter.WriteStartObject(); // Begin: sarifLog
             _jsonWriter.WritePropertyName("$schema");


### PR DESCRIPTION
…version

* Add a Tags API to PropertyBagHolder, partially implement
* Fix the CodeGenHints file to specify the correct enumeration constant names for SuppressionStates.
* Fix the FxCop converter to emit the correct SuppressionStates and BaselineState
* Advance the schema version to 1.0.0-beta.5

Also:
* Add more tests for PropertyBagHolder {Get/SetProperty} APIs.

@michaelcfanning @nguerrera 