### PR TITLE
annotatedCodeLocation.kind 'usage', 'relativeTo' and invocation.analysisTarget

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -25,6 +25,7 @@
 * Update all converters to Sarif beta.5
 * Add option 'id' to each result, to allow correlation with external data, annotations, work items, etc.
 * Add flag to configure file hash computation to FileData.Create helper
-
+* Add 'relativeTo' conceptual base URI to all format URI properties (to allow all URIs to be relative)
+* Add 'analysisTarget' to invocation object, for cases where a single target is associated with a run
 
 

--- a/src/Sarif/Autogenerated/FileChange.cs
+++ b/src/Sarif/Autogenerated/FileChange.cs
@@ -38,6 +38,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri Uri { get; set; }
 
         /// <summary>
+        /// A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.
+        /// </summary>
+        [DataMember(Name = "relativeTo", IsRequired = false, EmitDefaultValue = false)]
+        public string RelativeTo { get; set; }
+
+        /// <summary>
         /// An array of replacement objects, each of which represents the replacement of a single range of bytes in a single file specified by 'uri'.
         /// </summary>
         [DataMember(Name = "replacements", IsRequired = true)]
@@ -56,12 +62,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="uri">
         /// An initialization value for the <see cref="P: Uri" /> property.
         /// </param>
+        /// <param name="relativeTo">
+        /// An initialization value for the <see cref="P: RelativeTo" /> property.
+        /// </param>
         /// <param name="replacements">
         /// An initialization value for the <see cref="P: Replacements" /> property.
         /// </param>
-        public FileChange(Uri uri, IEnumerable<Replacement> replacements)
+        public FileChange(Uri uri, string relativeTo, IEnumerable<Replacement> replacements)
         {
-            Init(uri, replacements);
+            Init(uri, relativeTo, replacements);
         }
 
         /// <summary>
@@ -80,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Uri, other.Replacements);
+            Init(other.Uri, other.RelativeTo, other.Replacements);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -101,13 +110,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new FileChange(this);
         }
 
-        private void Init(Uri uri, IEnumerable<Replacement> replacements)
+        private void Init(Uri uri, string relativeTo, IEnumerable<Replacement> replacements)
         {
             if (uri != null)
             {
                 Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
             }
 
+            RelativeTo = relativeTo;
             if (replacements != null)
             {
                 var destination_0 = new List<Replacement>();

--- a/src/Sarif/Autogenerated/FileChangeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FileChangeEqualityComparer.cs
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.RelativeTo != right.RelativeTo)
+            {
+                return false;
+            }
+
             if (!object.ReferenceEquals(left.Replacements, right.Replacements))
             {
                 if (left.Replacements == null || right.Replacements == null)
@@ -69,6 +74,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Uri != null)
                 {
                     result = (result * 31) + obj.Uri.GetHashCode();
+                }
+
+                if (obj.RelativeTo != null)
+                {
+                    result = (result * 31) + obj.RelativeTo.GetHashCode();
                 }
 
                 if (obj.Replacements != null)

--- a/src/Sarif/Autogenerated/FileData.cs
+++ b/src/Sarif/Autogenerated/FileData.cs
@@ -39,6 +39,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri Uri { get; set; }
 
         /// <summary>
+        /// A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.
+        /// </summary>
+        [DataMember(Name = "relativeTo", IsRequired = false, EmitDefaultValue = false)]
+        public string RelativeTo { get; set; }
+
+        /// <summary>
         /// The offset in bytes of the file within its containing file.
         /// </summary>
         [DataMember(Name = "offset", IsRequired = false, EmitDefaultValue = false)]
@@ -81,6 +87,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="uri">
         /// An initialization value for the <see cref="P: Uri" /> property.
         /// </param>
+        /// <param name="relativeTo">
+        /// An initialization value for the <see cref="P: RelativeTo" /> property.
+        /// </param>
         /// <param name="offset">
         /// An initialization value for the <see cref="P: Offset" /> property.
         /// </param>
@@ -96,9 +105,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P: Properties" /> property.
         /// </param>
-        public FileData(Uri uri, int offset, int length, string mimeType, IEnumerable<Hash> hashes, IDictionary<string, SerializedPropertyInfo> properties)
+        public FileData(Uri uri, string relativeTo, int offset, int length, string mimeType, IEnumerable<Hash> hashes, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(uri, offset, length, mimeType, hashes, properties);
+            Init(uri, relativeTo, offset, length, mimeType, hashes, properties);
         }
 
         /// <summary>
@@ -117,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Uri, other.Offset, other.Length, other.MimeType, other.Hashes, other.Properties);
+            Init(other.Uri, other.RelativeTo, other.Offset, other.Length, other.MimeType, other.Hashes, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -138,13 +147,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new FileData(this);
         }
 
-        private void Init(Uri uri, int offset, int length, string mimeType, IEnumerable<Hash> hashes, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(Uri uri, string relativeTo, int offset, int length, string mimeType, IEnumerable<Hash> hashes, IDictionary<string, SerializedPropertyInfo> properties)
         {
             if (uri != null)
             {
                 Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
             }
 
+            RelativeTo = relativeTo;
             Offset = offset;
             Length = length;
             MimeType = mimeType;

--- a/src/Sarif/Autogenerated/FileDataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FileDataEqualityComparer.cs
@@ -33,6 +33,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.RelativeTo != right.RelativeTo)
+            {
+                return false;
+            }
+
             if (left.Offset != right.Offset)
             {
                 return false;
@@ -107,6 +112,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Uri != null)
                 {
                     result = (result * 31) + obj.Uri.GetHashCode();
+                }
+
+                if (obj.RelativeTo != null)
+                {
+                    result = (result * 31) + obj.RelativeTo.GetHashCode();
                 }
 
                 result = (result * 31) + obj.Offset.GetHashCode();

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -38,6 +38,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri Uri { get; set; }
 
         /// <summary>
+        /// A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.
+        /// </summary>
+        [DataMember(Name = "relativeTo", IsRequired = false, EmitDefaultValue = false)]
+        public string RelativeTo { get; set; }
+
+        /// <summary>
         /// The region within the file where the result was detected.
         /// </summary>
         [DataMember(Name = "region", IsRequired = false, EmitDefaultValue = false)]
@@ -56,12 +62,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="uri">
         /// An initialization value for the <see cref="P: Uri" /> property.
         /// </param>
+        /// <param name="relativeTo">
+        /// An initialization value for the <see cref="P: RelativeTo" /> property.
+        /// </param>
         /// <param name="region">
         /// An initialization value for the <see cref="P: Region" /> property.
         /// </param>
-        public PhysicalLocation(Uri uri, Region region)
+        public PhysicalLocation(Uri uri, string relativeTo, Region region)
         {
-            Init(uri, region);
+            Init(uri, relativeTo, region);
         }
 
         /// <summary>
@@ -80,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Uri, other.Region);
+            Init(other.Uri, other.RelativeTo, other.Region);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -101,13 +110,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new PhysicalLocation(this);
         }
 
-        private void Init(Uri uri, Region region)
+        private void Init(Uri uri, string relativeTo, Region region)
         {
             if (uri != null)
             {
                 Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
             }
 
+            RelativeTo = relativeTo;
             if (region != null)
             {
                 Region = new Region(region);

--- a/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.RelativeTo != right.RelativeTo)
+            {
+                return false;
+            }
+
             if (!Region.ValueComparer.Equals(left.Region, right.Region))
             {
                 return false;
@@ -53,6 +58,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Uri != null)
                 {
                     result = (result * 31) + obj.Uri.GetHashCode();
+                }
+
+                if (obj.RelativeTo != null)
+                {
+                    result = (result * 31) + obj.RelativeTo.GetHashCode();
                 }
 
                 if (obj.Region != null)

--- a/src/Sarif/Autogenerated/Run.cs
+++ b/src/Sarif/Autogenerated/Run.cs
@@ -44,6 +44,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Invocation Invocation { get; set; }
 
         /// <summary>
+        /// The file that the analysis tool was instructed to scan. This member is only populated if the run is directated against a single analysis target.
+        /// </summary>
+        [DataMember(Name = "analysisTarget", IsRequired = false, EmitDefaultValue = false)]
+        public PhysicalLocation AnalysisTarget { get; set; }
+
+        /// <summary>
         /// A dictionary, each of whose keys is a URI and each of whose values is an array of file objects representing the location of a single file scanned during the run.
         /// </summary>
         [DataMember(Name = "files", IsRequired = false, EmitDefaultValue = false)]
@@ -107,6 +113,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="invocation">
         /// An initialization value for the <see cref="P: Invocation" /> property.
         /// </param>
+        /// <param name="analysisTarget">
+        /// An initialization value for the <see cref="P: AnalysisTarget" /> property.
+        /// </param>
         /// <param name="files">
         /// An initialization value for the <see cref="P: Files" /> property.
         /// </param>
@@ -131,9 +140,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="correlationId">
         /// An initialization value for the <see cref="P: CorrelationId" /> property.
         /// </param>
-        public Run(Tool tool, Invocation invocation, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
+        public Run(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
         {
-            Init(tool, invocation, files, logicalLocations, results, toolNotifications, configurationNotifications, rules, id, correlationId);
+            Init(tool, invocation, analysisTarget, files, logicalLocations, results, toolNotifications, configurationNotifications, rules, id, correlationId);
         }
 
         /// <summary>
@@ -152,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Tool, other.Invocation, other.Files, other.LogicalLocations, other.Results, other.ToolNotifications, other.ConfigurationNotifications, other.Rules, other.Id, other.CorrelationId);
+            Init(other.Tool, other.Invocation, other.AnalysisTarget, other.Files, other.LogicalLocations, other.Results, other.ToolNotifications, other.ConfigurationNotifications, other.Rules, other.Id, other.CorrelationId);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -173,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Run(this);
         }
 
-        private void Init(Tool tool, Invocation invocation, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
+        private void Init(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
         {
             if (tool != null)
             {
@@ -183,6 +192,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (invocation != null)
             {
                 Invocation = new Invocation(invocation);
+            }
+
+            if (analysisTarget != null)
+            {
+                AnalysisTarget = new PhysicalLocation(analysisTarget);
             }
 
             if (files != null)

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -37,6 +37,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (!PhysicalLocation.ValueComparer.Equals(left.AnalysisTarget, right.AnalysisTarget))
+            {
+                return false;
+            }
+
             if (!object.ReferenceEquals(left.Files, right.Files))
             {
                 if (left.Files == null || right.Files == null || left.Files.Count != right.Files.Count)
@@ -229,6 +234,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Invocation != null)
                 {
                     result = (result * 31) + obj.Invocation.ValueGetHashCode();
+                }
+
+                if (obj.AnalysisTarget != null)
+                {
+                    result = (result * 31) + obj.AnalysisTarget.ValueGetHashCode();
                 }
 
                 if (obj.Files != null)

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -346,6 +346,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 node.Tool = VisitNullChecked(node.Tool);
                 node.Invocation = VisitNullChecked(node.Invocation);
+                node.AnalysisTarget = VisitNullChecked(node.AnalysisTarget);
                 if (node.Files != null)
                 {
                     var keys = node.Files.Keys.ToArray();

--- a/src/Sarif/Autogenerated/StackFrame.cs
+++ b/src/Sarif/Autogenerated/StackFrame.cs
@@ -45,6 +45,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri Uri { get; set; }
 
         /// <summary>
+        /// A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.
+        /// </summary>
+        [DataMember(Name = "relativeTo", IsRequired = false, EmitDefaultValue = false)]
+        public string RelativeTo { get; set; }
+
+        /// <summary>
         /// The line of the location to which this stack frame refers.
         /// </summary>
         [DataMember(Name = "line", IsRequired = false, EmitDefaultValue = false)]
@@ -114,6 +120,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="uri">
         /// An initialization value for the <see cref="P: Uri" /> property.
         /// </param>
+        /// <param name="relativeTo">
+        /// An initialization value for the <see cref="P: RelativeTo" /> property.
+        /// </param>
         /// <param name="line">
         /// An initialization value for the <see cref="P: Line" /> property.
         /// </param>
@@ -141,9 +150,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P: Properties" /> property.
         /// </param>
-        public StackFrame(string message, Uri uri, int line, int column, string module, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
+        public StackFrame(string message, Uri uri, string relativeTo, int line, int column, string module, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(message, uri, line, column, module, fullyQualifiedLogicalName, logicalLocationKey, address, offset, parameters, properties);
+            Init(message, uri, relativeTo, line, column, module, fullyQualifiedLogicalName, logicalLocationKey, address, offset, parameters, properties);
         }
 
         /// <summary>
@@ -162,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Message, other.Uri, other.Line, other.Column, other.Module, other.FullyQualifiedLogicalName, other.LogicalLocationKey, other.Address, other.Offset, other.Parameters, other.Properties);
+            Init(other.Message, other.Uri, other.RelativeTo, other.Line, other.Column, other.Module, other.FullyQualifiedLogicalName, other.LogicalLocationKey, other.Address, other.Offset, other.Parameters, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -183,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new StackFrame(this);
         }
 
-        private void Init(string message, Uri uri, int line, int column, string module, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(string message, Uri uri, string relativeTo, int line, int column, string module, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Message = message;
             if (uri != null)
@@ -191,6 +200,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
             }
 
+            RelativeTo = relativeTo;
             Line = line;
             Column = column;
             Module = module;

--- a/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
@@ -38,6 +38,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.RelativeTo != right.RelativeTo)
+            {
+                return false;
+            }
+
             if (left.Line != right.Line)
             {
                 return false;
@@ -137,6 +142,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Uri != null)
                 {
                     result = (result * 31) + obj.Uri.GetHashCode();
+                }
+
+                if (obj.RelativeTo != null)
+                {
+                    result = (result * 31) + obj.RelativeTo.GetHashCode();
                 }
 
                 result = (result * 31) + obj.Line.GetHashCode();

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -796,7 +796,7 @@
         },
 
         "analysisTarget": {
-          "description": "The file that the analysis tool was instructed to scan. This member is only populated if the run is directated against a single analysis target.",
+          "description": "The file that the analysis tool was instructed to scan. This member is only populated if the run is directed against a single analysis target.",
           "$ref": "#/definitions/physicalLocation"
         },
 

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -46,7 +46,7 @@
 
         "kind": {
           "description": "A descriptive identifier that categorizes the annotation.",
-          "enum": [ "branch", "call", "callReturn", "declaration", "functionEnter", "functionExit", "sanitizer", "sink", "source", "use" ]
+          "enum": [ "branch", "call", "callReturn", "declaration", "functionEnter", "functionExit", "sanitizer", "sink", "source", "usage" ]
         },
 
         "properties": {
@@ -147,6 +147,11 @@
           "format": "uri"
         },
 
+        "relativeTo": {
+          "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
+          "type": "string"
+        },
+
         "replacements": {
           "description": "An array of replacement objects, each of which represents the replacement of a single range of bytes in a single file specified by 'uri'.",
           "type": "array",
@@ -168,6 +173,11 @@
           "description": "The path to the file within its containing file.",
           "type": "string",
           "format": "uri"
+        },
+
+        "relativeTo": {
+          "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
+          "type": "string"
         },
 
         "offset": {
@@ -490,6 +500,11 @@
           "type": "string",
           "format": "uri"
         },
+        
+        "relativeTo": {
+          "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
+          "type": "string"
+        },
 
         "region": {
           "description": "The region within the file where the result was detected.",
@@ -780,6 +795,11 @@
           "$ref": "#/definitions/invocation"
         },
 
+        "analysisTarget": {
+          "description": "The file that the analysis tool was instructed to scan. This member is only populated if the run is directated against a single analysis target.",
+          "$ref": "#/definitions/physicalLocation"
+        },
+
         "files": {
           "description": "A dictionary, each of whose keys is a URI and each of whose values is an array of file objects representing the location of a single file scanned during the run.",
           "type": "object",
@@ -903,6 +923,11 @@
           "description": "The uri of the source code file to which this stack frame refers.",
           "type": "string",
           "format": "uri"
+        },
+
+        "relativeTo": {
+          "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
+          "type": "string"
         },
 
         "line": {


### PR DESCRIPTION
Change annotatedCodeLocation.kind 'use' member name to 'usage'. Provide 'relativeTo' member to associate a conceptual base address with all uri members. Add analysisTarget property of type physicalLocation to invocation object, to be populated in cases where the analysis run is associated with a single scan target.