### PR TITLE
Converter logical locations

### DIFF
--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -47,6 +47,7 @@
             {
               "resultFile": {
                 "uri": "app/src/androidTest/java/microsoft/androidstudioformatexample/ApplicationTest.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 10
                 }
@@ -66,6 +67,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 1
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -19,34 +19,25 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.ApplicationTest ApplicationTest()": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.ApplicationTest ApplicationTest()",
-            "kind": "member"
-          }
-        ],
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.MainActivity",
-            "kind": "type"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.ApplicationTest ApplicationTest()": {
+          "name": "microsoft.androidstudioformatexample.ApplicationTest ApplicationTest()",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "member"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity": {
+          "name": "microsoft.androidstudioformatexample.MainActivity",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "type"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -14,20 +14,20 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.NamespaceTypo",
-            "kind": "type"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": {
+          "name": "microsoft.androidstudioformatexample.NamespaceTypo",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "type"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -37,6 +37,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 3
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -14,20 +14,20 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()",
-            "kind": "member"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()": {
+          "name": "microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "member"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -37,6 +37,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 42
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -37,6 +37,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 31
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -14,20 +14,20 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity boolean onOptionsItemSelected(android.view.MenuItem item)": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.MainActivity boolean onOptionsItemSelected(android.view.MenuItem item)",
-            "kind": "member"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity boolean onOptionsItemSelected(android.view.MenuItem item)": {
+          "name": "microsoft.androidstudioformatexample.MainActivity boolean onOptionsItemSelected(android.view.MenuItem item)",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "member"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -70,16 +70,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle.properties"
+                "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 8
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -93,16 +94,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle.properties"
+                "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -116,16 +118,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle.properties"
+                "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -139,16 +142,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle.properties"
+                "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -162,16 +166,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -185,16 +190,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 5
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -208,16 +214,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -231,16 +238,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 31
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -254,16 +262,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 33
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -277,16 +286,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 34
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -300,16 +310,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -323,16 +334,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -346,16 +358,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -369,16 +382,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 43
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -392,16 +406,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 45
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -415,16 +430,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 46
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -438,16 +454,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 47
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -461,16 +478,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 60
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -484,16 +502,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 64
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -507,16 +526,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 73
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -530,16 +550,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 74
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -553,16 +574,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 76
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -576,16 +598,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 78
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -599,16 +622,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 85
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -622,16 +646,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 93
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -645,16 +670,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 94
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -668,16 +694,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 99
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -691,16 +718,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 110
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -714,16 +742,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 110
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -737,16 +766,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 113
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -760,16 +790,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 114
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -783,16 +814,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 115
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -806,16 +838,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 116
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -829,16 +862,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 118
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -852,16 +886,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -875,16 +910,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -898,16 +934,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -921,16 +958,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 121
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -944,16 +982,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 122
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -967,16 +1006,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 125
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -990,16 +1030,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 125
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1013,16 +1054,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 126
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1036,16 +1078,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 127
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1059,16 +1102,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 128
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1082,16 +1126,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 128
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1105,16 +1150,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 133
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1128,16 +1174,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 133
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1151,16 +1198,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 134
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1174,16 +1222,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 137
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1197,16 +1246,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 137
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1220,16 +1270,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 139
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1243,16 +1294,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 154
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1266,16 +1318,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 161
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1289,16 +1342,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 162
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1312,16 +1366,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 162
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1335,16 +1390,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew"
+                "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 164
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1358,16 +1414,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 9
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1381,16 +1438,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1404,16 +1462,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1427,16 +1486,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1450,16 +1510,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 20
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1473,16 +1534,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1496,16 +1558,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1519,16 +1582,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 32
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1542,16 +1606,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 38
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1565,16 +1630,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 46
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1588,16 +1654,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 49
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1611,16 +1678,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 51
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1634,16 +1702,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 52
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1657,16 +1726,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 52
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1680,16 +1750,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 60
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1703,16 +1774,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 63
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1726,16 +1798,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1749,16 +1822,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1772,16 +1846,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 79
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1795,16 +1870,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 79
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1818,16 +1894,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradlew.bat"
+                "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradlew.bat",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 88
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1841,16 +1918,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "app/build.gradle"
+                "uri": "app/build.gradle",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "app/build.gradle",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 8
                 }
               },
-              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/build.gradle",
-              "logicalLocationKey": "app"
+              "fullyQualifiedLogicalName": "app"
             }
           ],
           "properties": {
@@ -1864,16 +1942,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "app/src/main/AndroidManifest.xml"
+                "uri": "app/src/main/AndroidManifest.xml",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "app/src/main/AndroidManifest.xml",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/src/main/AndroidManifest.xml",
-              "logicalLocationKey": "app"
+              "fullyQualifiedLogicalName": "app"
             }
           ],
           "properties": {
@@ -1887,16 +1966,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "app/src/main/res/values-w820dp/dimens.xml"
+                "uri": "app/src/main/res/values-w820dp/dimens.xml",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "app/src/main/res/values-w820dp/dimens.xml",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 2
                 }
               },
-              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/src/main/res/values-w820dp/dimens.xml",
-              "logicalLocationKey": "app"
+              "fullyQualifiedLogicalName": "app"
             }
           ],
           "properties": {
@@ -1910,16 +1990,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java"
+                "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 4
                 }
               },
-              "fullyQualifiedLogicalName": "app\\microsoft.androidstudioformatexample\\file://$PROJECT_DIR$/app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
-              "logicalLocationKey": "app\\microsoft.androidstudioformatexample"
+              "fullyQualifiedLogicalName": "app\\microsoft.androidstudioformatexample"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -49,28 +49,19 @@
         ]
       },
       "logicalLocations": {
-        "AndroidStudioFormatExample": [
-          {
-            "name": "AndroidStudioFormatExample",
-            "kind": "module"
-          }
-        ],
-        "app": [
-          {
-            "name": "app",
-            "kind": "module"
-          }
-        ],
-        "app\\microsoft.androidstudioformatexample": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          }
-        ]
+        "AndroidStudioFormatExample": {
+          "name": "AndroidStudioFormatExample",
+          "kind": "module"
+        },
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -87,7 +78,8 @@
                   "startLine": 8
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -109,7 +101,8 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -131,7 +124,8 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -153,7 +147,8 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -175,7 +170,8 @@
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -197,7 +193,8 @@
                   "startLine": 5
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -219,7 +216,8 @@
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -241,7 +239,8 @@
                   "startLine": 31
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -263,7 +262,8 @@
                   "startLine": 33
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -285,7 +285,8 @@
                   "startLine": 34
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -307,7 +308,8 @@
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -329,7 +331,8 @@
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -351,7 +354,8 @@
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -373,7 +377,8 @@
                   "startLine": 43
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -395,7 +400,8 @@
                   "startLine": 45
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -417,7 +423,8 @@
                   "startLine": 46
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -439,7 +446,8 @@
                   "startLine": 47
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -461,7 +469,8 @@
                   "startLine": 60
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -483,7 +492,8 @@
                   "startLine": 64
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -505,7 +515,8 @@
                   "startLine": 73
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -527,7 +538,8 @@
                   "startLine": 74
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -549,7 +561,8 @@
                   "startLine": 76
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -571,7 +584,8 @@
                   "startLine": 78
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -593,7 +607,8 @@
                   "startLine": 85
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -615,7 +630,8 @@
                   "startLine": 93
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -637,7 +653,8 @@
                   "startLine": 94
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -659,7 +676,8 @@
                   "startLine": 99
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -681,7 +699,8 @@
                   "startLine": 110
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -703,7 +722,8 @@
                   "startLine": 110
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -725,7 +745,8 @@
                   "startLine": 113
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -747,7 +768,8 @@
                   "startLine": 114
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -769,7 +791,8 @@
                   "startLine": 115
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -791,7 +814,8 @@
                   "startLine": 116
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -813,7 +837,8 @@
                   "startLine": 118
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -835,7 +860,8 @@
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -857,7 +883,8 @@
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -879,7 +906,8 @@
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -901,7 +929,8 @@
                   "startLine": 121
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -923,7 +952,8 @@
                   "startLine": 122
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -945,7 +975,8 @@
                   "startLine": 125
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -967,7 +998,8 @@
                   "startLine": 125
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -989,7 +1021,8 @@
                   "startLine": 126
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1011,7 +1044,8 @@
                   "startLine": 127
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1033,7 +1067,8 @@
                   "startLine": 128
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1055,7 +1090,8 @@
                   "startLine": 128
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1077,7 +1113,8 @@
                   "startLine": 133
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1099,7 +1136,8 @@
                   "startLine": 133
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1121,7 +1159,8 @@
                   "startLine": 134
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1143,7 +1182,8 @@
                   "startLine": 137
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1165,7 +1205,8 @@
                   "startLine": 137
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1187,7 +1228,8 @@
                   "startLine": 139
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1209,7 +1251,8 @@
                   "startLine": 154
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1231,7 +1274,8 @@
                   "startLine": 161
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1253,7 +1297,8 @@
                   "startLine": 162
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1275,7 +1320,8 @@
                   "startLine": 162
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1297,7 +1343,8 @@
                   "startLine": 164
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1319,7 +1366,8 @@
                   "startLine": 9
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1341,7 +1389,8 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1363,7 +1412,8 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1385,7 +1435,8 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1407,7 +1458,8 @@
                   "startLine": 20
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1429,7 +1481,8 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1451,7 +1504,8 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1473,7 +1527,8 @@
                   "startLine": 32
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1495,7 +1550,8 @@
                   "startLine": 38
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1517,7 +1573,8 @@
                   "startLine": 46
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1539,7 +1596,8 @@
                   "startLine": 49
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1561,7 +1619,8 @@
                   "startLine": 51
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1583,7 +1642,8 @@
                   "startLine": 52
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1605,7 +1665,8 @@
                   "startLine": 52
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1627,7 +1688,8 @@
                   "startLine": 60
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1649,7 +1711,8 @@
                   "startLine": 63
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1671,7 +1734,8 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1693,7 +1757,8 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1715,7 +1780,8 @@
                   "startLine": 79
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1737,7 +1803,8 @@
                   "startLine": 79
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1759,7 +1826,8 @@
                   "startLine": 88
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradlew.bat",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -1781,7 +1849,8 @@
                   "startLine": 8
                 }
               },
-              "fullyQualifiedLogicalName": "app"
+              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/build.gradle",
+              "logicalLocationKey": "app"
             }
           ],
           "properties": {
@@ -1803,7 +1872,8 @@
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "app"
+              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/src/main/AndroidManifest.xml",
+              "logicalLocationKey": "app"
             }
           ],
           "properties": {
@@ -1825,7 +1895,8 @@
                   "startLine": 2
                 }
               },
-              "fullyQualifiedLogicalName": "app"
+              "fullyQualifiedLogicalName": "app\\file://$PROJECT_DIR$/app/src/main/res/values-w820dp/dimens.xml",
+              "logicalLocationKey": "app"
             }
           ],
           "properties": {
@@ -1847,7 +1918,8 @@
                   "startLine": 4
                 }
               },
-              "fullyQualifiedLogicalName": "app\\microsoft.androidstudioformatexample"
+              "fullyQualifiedLogicalName": "app\\microsoft.androidstudioformatexample\\file://$PROJECT_DIR$/app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+              "logicalLocationKey": "app\\microsoft.androidstudioformatexample"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -19,34 +19,25 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()",
-            "kind": "member"
-          }
-        ],
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.NamespaceTypo",
-            "kind": "type"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()": {
+          "name": "microsoft.androidstudioformatexample.MainActivity java.lang.String ForCanBeForeachExample()",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "member"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": {
+          "name": "microsoft.androidstudioformatexample.NamespaceTypo",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "type"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -47,6 +47,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 37
                 }
@@ -66,6 +67,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 6
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -19,12 +19,10 @@
         ]
       },
       "logicalLocations": {
-        "AndroidStudioFormatExample": [
-          {
-            "name": "AndroidStudioFormatExample",
-            "kind": "module"
-          }
-        ]
+        "AndroidStudioFormatExample": {
+          "name": "AndroidStudioFormatExample",
+          "kind": "module"
+        }
       },
       "results": [
         {
@@ -41,7 +39,8 @@
                   "startLine": 2
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -63,7 +62,8 @@
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -85,7 +85,8 @@
                   "startLine": 4
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -107,7 +108,8 @@
                   "startLine": 5
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -129,7 +131,8 @@
                   "startLine": 6
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -151,7 +154,8 @@
                   "startLine": 10
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/local.properties",
+              "logicalLocationKey": "AndroidStudioFormatExample"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 2
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -54,16 +55,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 3
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -77,16 +79,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 4
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -100,16 +103,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 5
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -123,16 +127,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "gradle/wrapper/gradle-wrapper.properties"
+                "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "gradle/wrapper/gradle-wrapper.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 6
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {
@@ -146,16 +151,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "local.properties"
+                "uri": "local.properties",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "local.properties",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 10
                 }
               },
-              "fullyQualifiedLogicalName": "AndroidStudioFormatExample\\file://$PROJECT_DIR$/local.properties",
-              "logicalLocationKey": "AndroidStudioFormatExample"
+              "fullyQualifiedLogicalName": "AndroidStudioFormatExample"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -47,6 +47,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/MainActivity.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 9
                 }
@@ -66,6 +67,7 @@
             {
               "resultFile": {
                 "uri": "app/src/main/java/microsoft/androidstudioformatexample/NamespaceTypo.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 6
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -19,34 +19,25 @@
         ]
       },
       "logicalLocations": {
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.MainActivity",
-            "kind": "type"
-          }
-        ],
-        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": [
-          {
-            "name": "app",
-            "kind": "module"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample",
-            "kind": "package"
-          },
-          {
-            "name": "microsoft.androidstudioformatexample.NamespaceTypo",
-            "kind": "type"
-          }
-        ]
+        "app": {
+          "name": "app",
+          "kind": "module"
+        },
+        "app\\microsoft.androidstudioformatexample": {
+          "name": "microsoft.androidstudioformatexample",
+          "parentKey": "app",
+          "kind": "package"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.MainActivity": {
+          "name": "microsoft.androidstudioformatexample.MainActivity",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "type"
+        },
+        "app\\microsoft.androidstudioformatexample\\microsoft.androidstudioformatexample.NamespaceTypo": {
+          "name": "microsoft.androidstudioformatexample.NamespaceTypo",
+          "parentKey": "app\\microsoft.androidstudioformatexample",
+          "kind": "type"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -40,7 +39,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -40,7 +39,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -34,7 +33,8 @@
               "analysisTarget": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -31,10 +31,10 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -14,12 +14,10 @@
         ]
       },
       "logicalLocations": {
-        "android20140909": [
-          {
-            "name": "android20140909",
-            "kind": "module"
-          }
-        ]
+        "android20140909": {
+          "name": "android20140909",
+          "kind": "module"
+        }
       },
       "results": [
         {
@@ -36,7 +34,8 @@
                   "startLine": 6
                 }
               },
-              "fullyQualifiedLogicalName": "android20140909"
+              "fullyQualifiedLogicalName": "android20140909\\file://$PROJECT_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml",
+              "logicalLocationKey": "android20140909"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -26,16 +26,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml"
+                "uri": "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 6
                 }
               },
-              "fullyQualifiedLogicalName": "android20140909\\file://$PROJECT_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services/4.4.52/res/values/wallet_styles.xml",
-              "logicalLocationKey": "android20140909"
+              "fullyQualifiedLogicalName": "android20140909"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -14,12 +14,10 @@
         ]
       },
       "logicalLocations": {
-        "com.northwindtraders.droid.model": [
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -36,7 +34,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -26,16 +26,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -40,7 +39,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -26,16 +26,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -14,12 +14,10 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        }
       },
       "results": [
         {
@@ -36,7 +34,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -40,7 +39,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "northwindtraders-droid-2\\com.northwindtraders.droid.model": [
-          {
-            "name": "northwindtraders-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.northwindtraders.droid.model",
-            "kind": "package"
-          }
-        ]
+        "northwindtraders-droid-2": {
+          "name": "northwindtraders-droid-2",
+          "kind": "module"
+        },
+        "northwindtraders-droid-2\\com.northwindtraders.droid.model": {
+          "name": "com.northwindtraders.droid.model",
+          "parentKey": "northwindtraders-droid-2",
+          "kind": "package"
+        }
       },
       "results": [
         {
@@ -40,7 +39,8 @@
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -31,16 +31,17 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java"
+                "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$"
               },
               "resultFile": {
                 "uri": "northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 242
                 }
               },
-              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model\\file://$PROJECT_DIR$/northwindtraders-droid-2/src/main/java/com/northwindtraders/droid/model/Model.java",
-              "logicalLocationKey": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
+              "fullyQualifiedLogicalName": "northwindtraders-droid-2\\com.northwindtraders.droid.model"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -37,6 +37,7 @@
             {
               "resultFile": {
                 "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 10
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -14,20 +14,20 @@
         ]
       },
       "logicalLocations": {
-        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": [
-          {
-            "name": "yammer-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.yammer.droid",
-            "kind": "package"
-          },
-          {
-            "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
-            "kind": "member"
-          }
-        ]
+        "yammer-droid-2": {
+          "name": "yammer-droid-2",
+          "kind": "module"
+        },
+        "yammer-droid-2\\com.yammer.droid": {
+          "name": "com.yammer.droid",
+          "parentKey": "yammer-droid-2",
+          "kind": "package"
+        },
+        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": {
+          "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
+          "parentKey": "yammer-droid-2\\com.yammer.droid",
+          "kind": "member"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -37,6 +37,7 @@
             {
               "resultFile": {
                 "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 10
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -14,20 +14,20 @@
         ]
       },
       "logicalLocations": {
-        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": [
-          {
-            "name": "yammer-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.yammer.droid",
-            "kind": "package"
-          },
-          {
-            "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
-            "kind": "member"
-          }
-        ]
+        "yammer-droid-2": {
+          "name": "yammer-droid-2",
+          "kind": "module"
+        },
+        "yammer-droid-2\\com.yammer.droid": {
+          "name": "com.yammer.droid",
+          "parentKey": "yammer-droid-2",
+          "kind": "package"
+        },
+        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": {
+          "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
+          "parentKey": "yammer-droid-2\\com.yammer.droid",
+          "kind": "member"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -19,34 +19,30 @@
         ]
       },
       "logicalLocations": {
-        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": [
-          {
-            "name": "yammer-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.yammer.droid",
-            "kind": "package"
-          },
-          {
-            "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
-            "kind": "member"
-          }
-        ],
-        "yammer-droid-2\\com.yammer.droid.ui\\com.yammer.droid.ui.MessageUIBean.TYPE TYPE(int position)": [
-          {
-            "name": "yammer-droid-2",
-            "kind": "module"
-          },
-          {
-            "name": "com.yammer.droid.ui",
-            "kind": "package"
-          },
-          {
-            "name": "com.yammer.droid.ui.MessageUIBean.TYPE TYPE(int position)",
-            "kind": "member"
-          }
-        ]
+        "yammer-droid-2": {
+          "name": "yammer-droid-2",
+          "kind": "module"
+        },
+        "yammer-droid-2\\com.yammer.droid": {
+          "name": "com.yammer.droid",
+          "parentKey": "yammer-droid-2",
+          "kind": "package"
+        },
+        "yammer-droid-2\\com.yammer.droid\\com.yammer.droid.AdditionOperationTest void testStuff()": {
+          "name": "com.yammer.droid.AdditionOperationTest void testStuff()",
+          "parentKey": "yammer-droid-2\\com.yammer.droid",
+          "kind": "member"
+        },
+        "yammer-droid-2\\com.yammer.droid.ui": {
+          "name": "com.yammer.droid.ui",
+          "parentKey": "yammer-droid-2",
+          "kind": "package"
+        },
+        "yammer-droid-2\\com.yammer.droid.ui\\com.yammer.droid.ui.MessageUIBean.TYPE TYPE(int position)": {
+          "name": "com.yammer.droid.ui.MessageUIBean.TYPE TYPE(int position)",
+          "parentKey": "yammer-droid-2\\com.yammer.droid.ui",
+          "kind": "member"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -52,6 +52,7 @@
             {
               "resultFile": {
                 "uri": "yammer-droid-2/src/test/java/com/yammer/droid/AdditionOperationTest.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 10
                 }
@@ -71,6 +72,7 @@
             {
               "resultFile": {
                 "uri": "yammer-droid-2/src/main/java/com/yammer/droid/ui/MessageUIBean.java",
+                "uriBaseId": "$PROJECT_DIR$",
                 "region": {
                   "startLine": 51
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopExampleReport2.xml.sarif
@@ -19,50 +19,29 @@
         ]
       },
       "logicalLocations": {
-        "SecurityCryptographyRuleTests": [
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          }
-        ],
-        "securitycryptographyruletests.dll": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DESCannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DESCannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DESCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#EncryptData(System.String,System.String,System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ]
+        "SecurityCryptographyRuleTests": {
+          "name": "SecurityCryptographyRuleTests",
+          "kind": "namespace"
+        },
+        "securitycryptographyruletests.dll": {
+          "name": "securitycryptographyruletests.dll",
+          "kind": "module"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests": {
+          "name": "SecurityCryptographyRuleTests",
+          "parentKey": "securitycryptographyruletests.dll",
+          "kind": "namespace"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed": {
+          "name": "DESCannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])": {
+          "name": "EncryptData(System.String,System.String,System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed",
+          "kind": "member"
+        }
       },
       "results": [
         {
@@ -104,7 +83,7 @@
               "analysisTarget": {
                 "uri": "file:///d:/SecDevTools/Main/bin/x86/Debug/FxCop/FxCopTestData/Crypto/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed"
             }
           ],
           "toolFingerprint": "DES#Type",
@@ -122,7 +101,7 @@
               "analysisTarget": {
                 "uri": "file:///d:/SecDevTools/Main/bin/x86/Debug/FxCop/FxCopTestData/Crypto/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -146,7 +125,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
@@ -19,100 +19,54 @@
         ]
       },
       "logicalLocations": {
-        "WpfApplication5": [
-          {
-            "name": "WpfApplication5",
-            "kind": "namespace"
-          }
-        ],
-        "wpfapplication5.exe": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          }
-        ],
-        "WpfApplication5.Frz": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          },
-          {
-            "name": "WpfApplication5",
-            "kind": "namespace"
-          },
-          {
-            "name": "Frz",
-            "kind": "type"
-          }
-        ],
-        "WpfApplication5.Frz.Baz()": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          },
-          {
-            "name": "WpfApplication5",
-            "kind": "namespace"
-          },
-          {
-            "name": "Frz",
-            "kind": "type"
-          },
-          {
-            "name": "#Baz()",
-            "kind": "member"
-          }
-        ],
-        "WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          },
-          {
-            "name": "WpfApplication5",
-            "kind": "namespace"
-          },
-          {
-            "name": "MainWindow",
-            "kind": "type"
-          },
-          {
-            "name": "#System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)",
-            "kind": "member"
-          }
-        ],
-        "WpfApplication5.Properties.Resources": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          },
-          {
-            "name": "WpfApplication5.Properties",
-            "kind": "namespace"
-          },
-          {
-            "name": "Resources",
-            "kind": "type"
-          }
-        ],
-        "WpfApplication5.Properties.Resources..ctor()": [
-          {
-            "name": "wpfapplication5.exe",
-            "kind": "module"
-          },
-          {
-            "name": "WpfApplication5.Properties",
-            "kind": "namespace"
-          },
-          {
-            "name": "Resources",
-            "kind": "type"
-          },
-          {
-            "name": "#.ctor()",
-            "kind": "member"
-          }
-        ]
+        "WpfApplication5": {
+          "name": "WpfApplication5",
+          "kind": "namespace"
+        },
+        "wpfapplication5.exe": {
+          "name": "wpfapplication5.exe",
+          "kind": "module"
+        },
+        "wpfapplication5.exe!WpfApplication5": {
+          "name": "WpfApplication5",
+          "parentKey": "wpfapplication5.exe",
+          "kind": "namespace"
+        },
+        "wpfapplication5.exe!WpfApplication5.Frz": {
+          "name": "Frz",
+          "parentKey": "wpfapplication5.exe!WpfApplication5",
+          "kind": "type"
+        },
+        "wpfapplication5.exe!WpfApplication5.Frz.Baz()": {
+          "name": "Baz()",
+          "parentKey": "wpfapplication5.exe!WpfApplication5.Frz",
+          "kind": "member"
+        },
+        "wpfapplication5.exe!WpfApplication5.MainWindow": {
+          "name": "MainWindow",
+          "parentKey": "wpfapplication5.exe!WpfApplication5",
+          "kind": "type"
+        },
+        "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)": {
+          "name": "System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)",
+          "parentKey": "wpfapplication5.exe!WpfApplication5.MainWindow",
+          "kind": "member"
+        },
+        "wpfapplication5.exe!WpfApplication5.Properties": {
+          "name": "WpfApplication5.Properties",
+          "parentKey": "wpfapplication5.exe",
+          "kind": "namespace"
+        },
+        "wpfapplication5.exe!WpfApplication5.Properties.Resources": {
+          "name": "Resources",
+          "parentKey": "wpfapplication5.exe!WpfApplication5.Properties",
+          "kind": "type"
+        },
+        "wpfapplication5.exe!WpfApplication5.Properties.Resources..ctor()": {
+          "name": ".ctor()",
+          "parentKey": "wpfapplication5.exe!WpfApplication5.Properties.Resources",
+          "kind": "member"
+        }
       },
       "results": [
         {
@@ -199,7 +153,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Frz"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Frz"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -223,7 +177,7 @@
                   "startLine": 11
                 }
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Frz.Baz()"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Frz.Baz()"
             }
           ],
           "toolFingerprint": "Baz#Member",
@@ -247,7 +201,7 @@
                   "startLine": 11
                 }
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Frz.Baz()"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Frz.Baz()"
             }
           ],
           "properties": {
@@ -263,7 +217,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
           ],
           "suppressionStates": ["suppressedInSource"],
@@ -279,7 +233,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
           ],
           "suppressionStates": ["suppressedInSource"],
@@ -295,7 +249,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
           ],
           "suppressionStates": ["suppressedInSource"],
@@ -311,7 +265,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Properties.Resources"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources"
             }
           ],
           "properties": {
@@ -327,7 +281,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Properties.Resources"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources"
             }
           ],
           "properties": {
@@ -343,7 +297,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
-              "fullyQualifiedLogicalName": "WpfApplication5.Properties.Resources..ctor()"
+              "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources..ctor()"
             }
           ],
           "suppressionStates": ["suppressedInSource"],

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportOneMessage.xml.sarif
@@ -7,12 +7,10 @@
         "name": "FxCop"
       },
       "logicalLocations": {
-        "SecurityCryptographyRuleTests": [
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          }
-        ]
+        "SecurityCryptographyRuleTests": {
+          "name": "SecurityCryptographyRuleTests",
+          "kind": "namespace"
+        }
       },
       "results": [
         {

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportResource.xml.sarif
@@ -14,16 +14,15 @@
         ]
       },
       "logicalLocations": {
-        "OMStrings.resources": [
-          {
-            "name": "microsoft.teamfoundation.build.client.dll",
-            "kind": "module"
-          },
-          {
-            "name": "OMStrings.resources",
-            "kind": "resource"
-          }
-        ]
+        "microsoft.teamfoundation.build.client.dll": {
+          "name": "microsoft.teamfoundation.build.client.dll",
+          "kind": "module"
+        },
+        "microsoft.teamfoundation.build.client.dll!OMStrings.resources": {
+          "name": "OMStrings.resources",
+          "parentKey": "microsoft.teamfoundation.build.client.dll",
+          "kind": "resource"
+        }
       },
       "results": [
         {
@@ -34,7 +33,7 @@
               "analysisTarget": {
                 "uri": "$(ProjectDir)/SpecifyCultureInfo/Microsoft.TeamFoundation.Build.Client.dll"
               },
-              "fullyQualifiedLogicalName": "OMStrings.resources"
+              "fullyQualifiedLogicalName": "microsoft.teamfoundation.build.client.dll!OMStrings.resources"
             }
           ],
           "toolFingerprint": "Logon#StringResourceShouldBeCompoundWord",

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCop_issueLog1_raw.xml.sarif
@@ -179,2126 +179,736 @@
         ]
       },
       "logicalLocations": {
-        "FxCopUnsafeXml": [
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          }
-        ],
-        "SecurityCryptographyRuleTests": [
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          }
-        ],
-        "SecurityXmlRuleTests": [
-          {
-            "name": "SecurityXmlRuleTests",
-            "kind": "namespace"
-          }
-        ],
-        "securitycryptographyruletests.dll": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DESCannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DESCannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DESCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#EncryptData(System.String,System.String,System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DSACannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DSACannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DSACannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DSACannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.DSACannotBeUsed.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DSACannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.MD5CannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "MD5CannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.MD5CannotBeUsed.GetMd5Hash(System.Security.Cryptography.MD5,System.String)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "MD5CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#GetMd5Hash(System.Security.Cryptography.MD5,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "MD5CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main(System.String[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.MD5CannotBeUsed.VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "MD5CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RC2CannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RC2CannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RC2CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RC2CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RC2CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RC2Impl..ctor()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RC2Impl",
-            "kind": "type"
-          },
-          {
-            "name": "#.ctor()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RijndaelCannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RijndaelCannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RijndaelCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RijndaelCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#EncryptStringToBytes(System.String,System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RijndaelCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RIPEMD160IsNotRecommended",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RIPEMD160IsNotRecommended",
-            "kind": "type"
-          },
-          {
-            "name": "#Main(System.String[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RIPEMD160IsNotRecommended",
-            "kind": "type"
-          },
-          {
-            "name": "#PrintByteArray(System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RSAProviderNeeds2048bitKey",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RSAProviderNeeds2048bitKey",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RSAProviderNeeds2048bitKey",
-            "kind": "type"
-          },
-          {
-            "name": "#RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "RSAProviderNeeds2048bitKey",
-            "kind": "type"
-          },
-          {
-            "name": "#RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.SHA1CannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "SHA1CannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "SHA1CannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.TripleDESCannotBeUsed": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "TripleDESCannotBeUsed",
-            "kind": "type"
-          }
-        ],
-        "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "TripleDESCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "TripleDESCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#EncryptStringToBytes(System.String,System.Byte[],System.Byte[])",
-            "kind": "member"
-          }
-        ],
-        "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()": [
-          {
-            "name": "securitycryptographyruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityCryptographyRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "TripleDESCannotBeUsed",
-            "kind": "type"
-          },
-          {
-            "name": "#Main()",
-            "kind": "member"
-          }
-        ],
-        "securityxmlruletests.dll": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test1206P(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test6(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test1205P(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test4(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test5(System.String,System.Boolean)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test6(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAllowDtdOnXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Test7(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseLoadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseLoadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseSetInnerXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseSetInnerXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseSetInnerXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseSetInnerXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseXslTransform..ctor()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseXslTransform",
-            "kind": "type"
-          },
-          {
-            "name": "#.ctor()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.DoNotUseXslTransform.xslTransform": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotUseXslTransform",
-            "kind": "type"
-          },
-          {
-            "name": "#xslTransform",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewClassesDerivedFromXmlTextReader",
-            "kind": "type"
-          },
-          {
-            "name": "#Method()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewDataViewConnectionString",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1216(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewDtdProcessingAssignment",
-            "kind": "type"
-          },
-          {
-            "name": "#Test(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewDtdProcessingAssignment",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewTrustedXsltUse",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewWebControlForSet_Data": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewWebControlForSet_Data",
-            "kind": "type"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewWebControlForSet_Data",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod34(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewWebControlForSet_DocumentContent",
-            "kind": "type"
-          }
-        ],
-        "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "ReviewWebControlForSet_DocumentContent",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "TextReaderImplNeedsSettingsAndResolver",
-            "kind": "type"
-          }
-        ],
-        "FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "TextReaderImplNeedsSettingsAndResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataSetReadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1214(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataSetReadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1214Ok(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataSetReadXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1215(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataSetReadXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1215Ok(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataTableReadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.IO.Stream)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataTableReadXml",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataTableReadXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.IO.Stream)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDataTableReadXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDeserialize",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1221(System.IO.Stream)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForDeserialize",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1221Ok(System.Xml.XmlTextReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForLoad",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForLoad",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForLoad",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForLoad",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForSchemaRead",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod18(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForSchemaRead",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod19(System.Xml.XmlTextReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForValidatingReader",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1213(System.IO.Stream)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForValidatingReader",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod1213Ok(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForXPathDocument",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod16(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlReaderForXPathDocument",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod17(System.Xml.XmlReader)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest1()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest2()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest3()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest3()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest4()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest4()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest5()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#LoadTest6()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest1()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#SuppresionTest1()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#SuppresionTest2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#SuppresionTest3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TransformTest1(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TransformTest2(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TransformTest3(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TransformTest4(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#TransformTest5(System.String)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest1()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest2()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest2()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest3()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest4(System.Xml.XmlSecureResolver)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest4(System.Xml.XmlSecureResolver)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest5()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest5()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest6()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest7()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest7()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlDocumentTest8()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest1()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest10()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest2()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest3(System.Xml.XmlSecureResolver)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest4(System.Xml.XmlSecureResolver)",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest5()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest6()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest7()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest8()",
-            "kind": "member"
-          }
-        ],
-        "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "FxCopUnsafeXml",
-            "kind": "namespace"
-          },
-          {
-            "name": "UseXmlSecureResolver",
-            "kind": "type"
-          },
-          {
-            "name": "#XmlReaderTest9(System.Xml.XmlReaderSettings)",
-            "kind": "member"
-          }
-        ],
-        "SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityXmlRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAddStringsToXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.String,System.String)",
-            "kind": "member"
-          }
-        ],
-        "SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.Xml.Schema.XmlSchema)": [
-          {
-            "name": "securityxmlruletests.dll",
-            "kind": "module"
-          },
-          {
-            "name": "SecurityXmlRuleTests",
-            "kind": "namespace"
-          },
-          {
-            "name": "DoNotAddStringsToXmlSchema",
-            "kind": "type"
-          },
-          {
-            "name": "#TestMethod(System.Xml.Schema.XmlSchema)",
-            "kind": "member"
-          }
-        ]
+        "FxCopUnsafeXml": {
+          "name": "FxCopUnsafeXml",
+          "kind": "namespace"
+        },
+        "SecurityCryptographyRuleTests": {
+          "name": "SecurityCryptographyRuleTests",
+          "kind": "namespace"
+        },
+        "SecurityXmlRuleTests": {
+          "name": "SecurityXmlRuleTests",
+          "kind": "namespace"
+        },
+        "securitycryptographyruletests.dll": {
+          "name": "securitycryptographyruletests.dll",
+          "kind": "module"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests": {
+          "name": "SecurityCryptographyRuleTests",
+          "parentKey": "securitycryptographyruletests.dll",
+          "kind": "namespace"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed": {
+          "name": "DESCannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])": {
+          "name": "EncryptData(System.String,System.String,System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed": {
+          "name": "DSACannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)": {
+          "name": "DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)": {
+          "name": "DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed": {
+          "name": "MD5CannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.GetMd5Hash(System.Security.Cryptography.MD5,System.String)": {
+          "name": "GetMd5Hash(System.Security.Cryptography.MD5,System.String)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])": {
+          "name": "Main(System.String[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)": {
+          "name": "VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed": {
+          "name": "RC2CannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])": {
+          "name": "DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)": {
+          "name": "EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2Impl": {
+          "name": "RC2Impl",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2Impl..ctor()": {
+          "name": ".ctor()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2Impl",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed": {
+          "name": "RijndaelCannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])": {
+          "name": "DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])": {
+          "name": "EncryptStringToBytes(System.String,System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended": {
+          "name": "RIPEMD160IsNotRecommended",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])": {
+          "name": "Main(System.String[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])": {
+          "name": "PrintByteArray(System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey": {
+          "name": "RSAProviderNeeds2048bitKey",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)": {
+          "name": "RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)": {
+          "name": "RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed": {
+          "name": "SHA1CannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed": {
+          "name": "TripleDESCannotBeUsed",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests",
+          "kind": "type"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])": {
+          "name": "DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])": {
+          "name": "EncryptStringToBytes(System.String,System.Byte[],System.Byte[])",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed",
+          "kind": "member"
+        },
+        "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()": {
+          "name": "Main()",
+          "parentKey": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll": {
+          "name": "securityxmlruletests.dll",
+          "kind": "module"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml": {
+          "name": "FxCopUnsafeXml",
+          "parentKey": "securityxmlruletests.dll",
+          "kind": "namespace"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader": {
+          "name": "DoNotAllowDtdOnXmlReader",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)": {
+          "name": "Test1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)": {
+          "name": "Test1206P(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)": {
+          "name": "Test2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)": {
+          "name": "Test3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)": {
+          "name": "Test6(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader": {
+          "name": "DoNotAllowDtdOnXmlTextReader",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)": {
+          "name": "Test1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)": {
+          "name": "Test1205P(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)": {
+          "name": "Test2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)": {
+          "name": "Test3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)": {
+          "name": "Test4(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)": {
+          "name": "Test5(System.String,System.Boolean)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)": {
+          "name": "Test6(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)": {
+          "name": "Test7(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml": {
+          "name": "DoNotUseLoadXml",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)": {
+          "name": "TestMethod(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)": {
+          "name": "TestMethod1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml": {
+          "name": "DoNotUseSetInnerXml",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)": {
+          "name": "TestMethod(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)": {
+          "name": "TestMethod1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)": {
+          "name": "TestMethod2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)": {
+          "name": "TestMethod3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform": {
+          "name": "DoNotUseXslTransform",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform..ctor()": {
+          "name": ".ctor()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform.xslTransform": {
+          "name": "xslTransform",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader": {
+          "name": "ReviewClassesDerivedFromXmlTextReader",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()": {
+          "name": "Method()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString": {
+          "name": "ReviewDataViewConnectionString",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)": {
+          "name": "TestMethod1216(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment": {
+          "name": "ReviewDtdProcessingAssignment",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)": {
+          "name": "Test(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)": {
+          "name": "TestMethod(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse": {
+          "name": "ReviewTrustedXsltUse",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()": {
+          "name": "TestMethod()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data": {
+          "name": "ReviewWebControlForSet_Data",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)": {
+          "name": "TestMethod34(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent": {
+          "name": "ReviewWebControlForSet_DocumentContent",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)": {
+          "name": "TestMethod(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver": {
+          "name": "TextReaderImplNeedsSettingsAndResolver",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)": {
+          "name": "TestMethod(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml": {
+          "name": "UseXmlReaderForDataSetReadXml",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)": {
+          "name": "TestMethod1214(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)": {
+          "name": "TestMethod1214Ok(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema": {
+          "name": "UseXmlReaderForDataSetReadXmlSchema",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)": {
+          "name": "TestMethod1215(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)": {
+          "name": "TestMethod1215Ok(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml": {
+          "name": "UseXmlReaderForDataTableReadXml",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)": {
+          "name": "TestMethod(System.IO.Stream)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)": {
+          "name": "TestMethod1(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema": {
+          "name": "UseXmlReaderForDataTableReadXmlSchema",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)": {
+          "name": "TestMethod(System.IO.Stream)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)": {
+          "name": "TestMethod1(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize": {
+          "name": "UseXmlReaderForDeserialize",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)": {
+          "name": "TestMethod1221(System.IO.Stream)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)": {
+          "name": "TestMethod1221Ok(System.Xml.XmlTextReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad": {
+          "name": "UseXmlReaderForLoad",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)": {
+          "name": "TestMethod(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)": {
+          "name": "TestMethod1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)": {
+          "name": "TestMethod2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)": {
+          "name": "TestMethod3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead": {
+          "name": "UseXmlReaderForSchemaRead",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)": {
+          "name": "TestMethod18(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)": {
+          "name": "TestMethod19(System.Xml.XmlTextReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader": {
+          "name": "UseXmlReaderForValidatingReader",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)": {
+          "name": "TestMethod1213(System.IO.Stream)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)": {
+          "name": "TestMethod1213Ok(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument": {
+          "name": "UseXmlReaderForXPathDocument",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)": {
+          "name": "TestMethod16(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)": {
+          "name": "TestMethod17(System.Xml.XmlReader)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver": {
+          "name": "UseXmlSecureResolver",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()": {
+          "name": "LoadTest1()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()": {
+          "name": "LoadTest2()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest3()": {
+          "name": "LoadTest3()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest4()": {
+          "name": "LoadTest4()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()": {
+          "name": "LoadTest5()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()": {
+          "name": "LoadTest6()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest1()": {
+          "name": "SuppresionTest1()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest2(System.String)": {
+          "name": "SuppresionTest2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)": {
+          "name": "SuppresionTest3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)": {
+          "name": "TransformTest1(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)": {
+          "name": "TransformTest2(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)": {
+          "name": "TransformTest3(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)": {
+          "name": "TransformTest4(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)": {
+          "name": "TransformTest5(System.String)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()": {
+          "name": "XmlDocumentTest1()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest2()": {
+          "name": "XmlDocumentTest2()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()": {
+          "name": "XmlDocumentTest3()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest4(System.Xml.XmlSecureResolver)": {
+          "name": "XmlDocumentTest4(System.Xml.XmlSecureResolver)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest5()": {
+          "name": "XmlDocumentTest5()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()": {
+          "name": "XmlDocumentTest6()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest7()": {
+          "name": "XmlDocumentTest7()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()": {
+          "name": "XmlDocumentTest8()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()": {
+          "name": "XmlReaderTest1()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()": {
+          "name": "XmlReaderTest10()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()": {
+          "name": "XmlReaderTest2()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)": {
+          "name": "XmlReaderTest3(System.Xml.XmlSecureResolver)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)": {
+          "name": "XmlReaderTest4(System.Xml.XmlSecureResolver)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()": {
+          "name": "XmlReaderTest5()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()": {
+          "name": "XmlReaderTest6()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()": {
+          "name": "XmlReaderTest7()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()": {
+          "name": "XmlReaderTest8()",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)": {
+          "name": "XmlReaderTest9(System.Xml.XmlReaderSettings)",
+          "parentKey": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!SecurityXmlRuleTests": {
+          "name": "SecurityXmlRuleTests",
+          "parentKey": "securityxmlruletests.dll",
+          "kind": "namespace"
+        },
+        "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema": {
+          "name": "DoNotAddStringsToXmlSchema",
+          "parentKey": "securityxmlruletests.dll!SecurityXmlRuleTests",
+          "kind": "type"
+        },
+        "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)": {
+          "name": "TestMethod(System.String,System.String)",
+          "parentKey": "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema",
+          "kind": "member"
+        },
+        "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.Xml.Schema.XmlSchema)": {
+          "name": "TestMethod(System.Xml.Schema.XmlSchema)",
+          "parentKey": "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema",
+          "kind": "member"
+        }
       },
       "results": [
         {
@@ -2382,7 +992,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed"
             }
           ],
           "toolFingerprint": "DES#Type",
@@ -2400,7 +1010,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -2424,7 +1034,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -2447,7 +1057,7 @@
                   "startLine": 26
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -2470,7 +1080,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "toolFingerprint": "ExceptionEdge",
@@ -2494,7 +1104,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "toolFingerprint": "ExceptionEdge",
@@ -2518,7 +1128,7 @@
                   "startLine": 26
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -2542,7 +1152,7 @@
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -2565,7 +1175,7 @@
                   "startLine": 29
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -2589,7 +1199,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DESCannotBeUsed.EncryptData(System.String,System.String,System.Byte[],System.Byte[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -2607,7 +1217,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed"
             }
           ],
           "toolFingerprint": "DSA#Type",
@@ -2625,7 +1235,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -2649,7 +1259,7 @@
                   "startLine": 69
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "properties": {
@@ -2672,7 +1282,7 @@
                   "startLine": 73
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "properties": {
@@ -2695,7 +1305,7 @@
                   "startLine": 58
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "DSA#Member",
@@ -2719,7 +1329,7 @@
                   "startLine": 58
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "DSA#MemberParameter",
@@ -2743,7 +1353,7 @@
                   "startLine": 58
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Hash#MemberParameter",
@@ -2767,7 +1377,7 @@
                   "startLine": 58
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Hash#MemberParameter",
@@ -2791,7 +1401,7 @@
                   "startLine": 58
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSASignHash(System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Alg#MemberParameter",
@@ -2815,7 +1425,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "DSA#Member",
@@ -2839,7 +1449,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "DSA#MemberParameter",
@@ -2863,7 +1473,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Hash#MemberParameter",
@@ -2887,7 +1497,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Hash#MemberParameter",
@@ -2911,7 +1521,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Signed#MemberParameter",
@@ -2935,7 +1545,7 @@
                   "startLine": 92
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.DSAVerifyHash(System.Byte[],System.Byte[],System.Security.Cryptography.DSAParameters,System.String)"
             }
           ],
           "toolFingerprint": "Alg#MemberParameter",
@@ -2959,7 +1569,7 @@
                   "startLine": 47
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -2983,7 +1593,7 @@
                   "startLine": 43
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.DSACannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.DSACannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3001,7 +1611,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -3025,7 +1635,7 @@
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.GetMd5Hash(System.Security.Cryptography.MD5,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.GetMd5Hash(System.Security.Cryptography.MD5,System.String)"
             }
           ],
           "properties": {
@@ -3048,7 +1658,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "properties": {
@@ -3071,7 +1681,7 @@
                   "startLine": 20
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3095,7 +1705,7 @@
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3119,7 +1729,7 @@
                   "startLine": 26
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3143,7 +1753,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3167,7 +1777,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "properties": {
@@ -3190,7 +1800,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.Main(System.String[])"
             }
           ],
           "toolFingerprint": "args",
@@ -3214,7 +1824,7 @@
                   "startLine": 57
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.MD5CannotBeUsed.VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.MD5CannotBeUsed.VerifyMd5Hash(System.Security.Cryptography.MD5,System.String,System.String)"
             }
           ],
           "properties": {
@@ -3231,7 +1841,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -3255,7 +1865,7 @@
                   "startLine": 48
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
             }
           ],
           "toolFingerprint": "Alg#MemberParameter",
@@ -3279,7 +1889,7 @@
                   "startLine": 48
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
             }
           ],
           "toolFingerprint": "sym#MemberParameter",
@@ -3303,7 +1913,7 @@
                   "startLine": 48
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
             }
           ],
           "toolFingerprint": "bytes#LanguageIndependentMemberParameter",
@@ -3327,7 +1937,7 @@
                   "startLine": 49
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
             }
           ],
           "toolFingerprint": "0",
@@ -3351,7 +1961,7 @@
                   "startLine": 50
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.DecryptBytes(System.Security.Cryptography.SymmetricAlgorithm,System.Byte[])"
             }
           ],
           "toolFingerprint": "1",
@@ -3375,7 +1985,7 @@
                   "startLine": 39
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
             }
           ],
           "toolFingerprint": "Alg#MemberParameter",
@@ -3399,7 +2009,7 @@
                   "startLine": 39
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
             }
           ],
           "toolFingerprint": "sym#MemberParameter",
@@ -3423,7 +2033,7 @@
                   "startLine": 39
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
             }
           ],
           "toolFingerprint": "string#LanguageIndependentMemberParameter",
@@ -3447,7 +2057,7 @@
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.EncryptString(System.Security.Cryptography.SymmetricAlgorithm,System.String)"
             }
           ],
           "toolFingerprint": "0",
@@ -3471,7 +2081,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -3495,7 +2105,7 @@
                   "startLine": 31
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3519,7 +2129,7 @@
                   "startLine": 34
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3543,7 +2153,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -3566,7 +2176,7 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2CannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -3583,7 +2193,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RC2Impl..ctor()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RC2Impl..ctor()"
             }
           ],
           "properties": {
@@ -3600,7 +2210,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -3624,7 +2234,7 @@
                   "startLine": 117
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3647,7 +2257,7 @@
                   "startLine": 117
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3670,7 +2280,7 @@
                   "startLine": 97
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3693,7 +2303,7 @@
                   "startLine": 73
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3716,7 +2326,7 @@
                   "startLine": 73
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3739,7 +2349,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -3762,7 +2372,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -3786,7 +2396,7 @@
                   "startLine": 31
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -3810,7 +2420,7 @@
                   "startLine": 32
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -3834,7 +2444,7 @@
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -3857,7 +2467,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RijndaelCannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -3874,7 +2484,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended"
             }
           ],
           "toolFingerprint": "RIPEMD#Type",
@@ -3892,7 +2502,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -3916,7 +2526,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -3940,7 +2550,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.Write(System.String)#KnownValue",
@@ -3964,7 +2574,7 @@
                   "startLine": 51
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -3988,7 +2598,7 @@
                   "startLine": 47
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -4012,7 +2622,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "properties": {
@@ -4035,7 +2645,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.Main(System.String[])"
             }
           ],
           "toolFingerprint": "0",
@@ -4059,7 +2669,7 @@
                   "startLine": 62
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])"
             }
           ],
           "toolFingerprint": "System.Console.Write(System.String)#KnownValue",
@@ -4077,7 +2687,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RIPEMD160IsNotRecommended.PrintByteArray(System.Byte[])"
             }
           ],
           "toolFingerprint": "0",
@@ -4095,7 +2705,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
             }
           ],
           "toolFingerprint": "RSA#Type",
@@ -4113,7 +2723,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
             }
           ],
           "toolFingerprint": "bit#Type",
@@ -4131,7 +2741,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -4155,7 +2765,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
             }
           ],
           "properties": {
@@ -4178,7 +2788,7 @@
                   "startLine": 47
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String)#KnownValue",
@@ -4202,7 +2812,7 @@
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -4226,7 +2836,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "Data#MemberParameter",
@@ -4250,7 +2860,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "Do#MemberParameter",
@@ -4274,7 +2884,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "OAEP#MemberParameter",
@@ -4298,7 +2908,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "RSA#Member",
@@ -4322,7 +2932,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSADecrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "RSA#MemberParameter",
@@ -4346,7 +2956,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "Data#MemberParameter",
@@ -4370,7 +2980,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "Do#MemberParameter",
@@ -4394,7 +3004,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "OAEP#MemberParameter",
@@ -4418,7 +3028,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "RSA#Member",
@@ -4442,7 +3052,7 @@
                   "startLine": 53
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.RSAProviderNeeds2048bitKey.RSAEncrypt(System.Byte[],System.Security.Cryptography.RSAParameters,System.Boolean)"
             }
           ],
           "toolFingerprint": "RSA#MemberParameter",
@@ -4460,7 +3070,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.SHA1CannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed"
             }
           ],
           "toolFingerprint": "SHA#Type",
@@ -4484,7 +3094,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -4508,7 +3118,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -4531,7 +3141,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "result",
@@ -4555,7 +3165,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.SHA1CannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -4572,7 +3182,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed"
             }
           ],
           "toolFingerprint": "DES#Type",
@@ -4590,7 +3200,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityCryptographyRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed"
             }
           ],
           "toolFingerprint": "CSharp2_0",
@@ -4614,7 +3224,7 @@
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4637,7 +3247,7 @@
                   "startLine": 119
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4660,7 +3270,7 @@
                   "startLine": 99
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.DecryptStringFromBytes(System.Byte[],System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4683,7 +3293,7 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4706,7 +3316,7 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4729,7 +3339,7 @@
                   "startLine": 55
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.EncryptStringToBytes(System.String,System.Byte[],System.Byte[])"
             }
           ],
           "properties": {
@@ -4752,7 +3362,7 @@
                   "startLine": 39
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -4776,7 +3386,7 @@
                   "startLine": 32
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -4800,7 +3410,7 @@
                   "startLine": 33
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
             }
           ],
           "toolFingerprint": "System.Console.WriteLine(System.String,System.Object)#KnownValue",
@@ -4824,7 +3434,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -4847,7 +3457,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
+              "fullyQualifiedLogicalName": "securitycryptographyruletests.dll!SecurityCryptographyRuleTests.TripleDESCannotBeUsed.Main()"
             }
           ],
           "properties": {
@@ -4887,7 +3497,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -4911,7 +3521,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
             }
           ],
           "properties": {
@@ -4934,7 +3544,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
             }
           ],
           "toolFingerprint": "reader",
@@ -4958,7 +3568,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -4982,7 +3592,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5006,7 +3616,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
             }
           ],
           "properties": {
@@ -5029,7 +3639,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
             }
           ],
           "properties": {
@@ -5052,7 +3662,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
             }
           ],
           "properties": {
@@ -5075,7 +3685,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test1206P(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -5099,7 +3709,7 @@
                   "startLine": 29
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5123,7 +3733,7 @@
                   "startLine": 27
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
             }
           ],
           "properties": {
@@ -5146,7 +3756,7 @@
                   "startLine": 29
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test2(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -5170,7 +3780,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5194,7 +3804,7 @@
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
             }
           ],
           "properties": {
@@ -5217,7 +3827,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test3(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -5241,7 +3851,7 @@
                   "startLine": 45
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5265,7 +3875,7 @@
                   "startLine": 43
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
             }
           ],
           "properties": {
@@ -5288,7 +3898,7 @@
                   "startLine": 49
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
             }
           ],
           "properties": {
@@ -5311,7 +3921,7 @@
                   "startLine": 45
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlReader.Test6(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -5335,7 +3945,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5359,7 +3969,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1(System.String)"
             }
           ],
           "properties": {
@@ -5382,7 +3992,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5406,7 +4016,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
             }
           ],
           "properties": {
@@ -5429,7 +4039,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
             }
           ],
           "properties": {
@@ -5452,7 +4062,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test1205P(System.String)"
             }
           ],
           "toolFingerprint": "reader",
@@ -5476,7 +4086,7 @@
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5500,7 +4110,7 @@
                   "startLine": 28
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test2(System.String)"
             }
           ],
           "properties": {
@@ -5523,7 +4133,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5547,7 +4157,7 @@
                   "startLine": 35
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test3(System.String)"
             }
           ],
           "properties": {
@@ -5570,7 +4180,7 @@
                   "startLine": 44
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5594,7 +4204,7 @@
                   "startLine": 42
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test4(System.String)"
             }
           ],
           "properties": {
@@ -5617,7 +4227,7 @@
                   "startLine": 51
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5641,7 +4251,7 @@
                   "startLine": 51
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
             }
           ],
           "properties": {
@@ -5664,7 +4274,7 @@
                   "startLine": 49
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test5(System.String,System.Boolean)"
             }
           ],
           "properties": {
@@ -5687,7 +4297,7 @@
                   "startLine": 62
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -5711,7 +4321,7 @@
                   "startLine": 60
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test6(System.String)"
             }
           ],
           "properties": {
@@ -5734,7 +4344,7 @@
                   "startLine": 78
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
             }
           ],
           "toolFingerprint": "ExceptionEdge",
@@ -5758,7 +4368,7 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
             }
           ],
           "toolFingerprint": "s#MemberParameterMoreMeaningfulName",
@@ -5782,7 +4392,7 @@
                   "startLine": 75
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
             }
           ],
           "properties": {
@@ -5805,7 +4415,7 @@
                   "startLine": 77
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotAllowDtdOnXmlTextReader.Test7(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -5829,7 +4439,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -5852,7 +4462,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -5875,7 +4485,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -5899,7 +4509,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -5922,7 +4532,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -5945,7 +4555,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseLoadXml.TestMethod1(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -5969,7 +4579,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -5992,7 +4602,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -6015,7 +4625,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -6039,7 +4649,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -6062,7 +4672,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -6085,7 +4695,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
             }
           ],
           "toolFingerprint": "doc",
@@ -6109,7 +4719,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod1(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -6133,7 +4743,7 @@
                   "startLine": 34
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
             }
           ],
           "properties": {
@@ -6156,7 +4766,7 @@
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
             }
           ],
           "properties": {
@@ -6179,7 +4789,7 @@
                   "startLine": 31
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod2(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -6203,7 +4813,7 @@
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
             }
           ],
           "properties": {
@@ -6226,7 +4836,7 @@
                   "startLine": 38
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
             }
           ],
           "properties": {
@@ -6249,7 +4859,7 @@
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
             }
           ],
           "toolFingerprint": "doc",
@@ -6273,7 +4883,7 @@
                   "startLine": 40
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseSetInnerXml.TestMethod3(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -6297,7 +4907,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseXslTransform..ctor()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform..ctor()"
             }
           ],
           "properties": {
@@ -6314,7 +4924,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.DoNotUseXslTransform.xslTransform"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.DoNotUseXslTransform.xslTransform"
             }
           ],
           "properties": {
@@ -6337,7 +4947,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6361,7 +4971,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
             }
           ],
           "properties": {
@@ -6384,7 +4994,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
             }
           ],
           "properties": {
@@ -6407,7 +5017,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewClassesDerivedFromXmlTextReader.Method()"
             }
           ],
           "properties": {
@@ -6430,7 +5040,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6454,7 +5064,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6478,7 +5088,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "toolFingerprint": "src#MemberParameter",
@@ -6502,7 +5112,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "properties": {
@@ -6525,7 +5135,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "properties": {
@@ -6548,7 +5158,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "properties": {
@@ -6571,7 +5181,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDataViewConnectionString.TestMethod1216(System.String)"
             }
           ],
           "properties": {
@@ -6594,7 +5204,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6618,7 +5228,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
             }
           ],
           "properties": {
@@ -6641,7 +5251,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
             }
           ],
           "toolFingerprint": "reader",
@@ -6665,7 +5275,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.Test(System.String)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -6689,7 +5299,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -6712,7 +5322,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -6735,7 +5345,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewDtdProcessingAssignment.TestMethod(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "0",
@@ -6759,7 +5369,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
             }
           ],
           "properties": {
@@ -6782,7 +5392,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
             }
           ],
           "toolFingerprint": "xsltSettings",
@@ -6806,7 +5416,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewTrustedXsltUse.TestMethod()"
             }
           ],
           "properties": {
@@ -6823,7 +5433,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_Data"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data"
             }
           ],
           "toolFingerprint": "Type",
@@ -6847,7 +5457,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6871,7 +5481,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
             }
           ],
           "properties": {
@@ -6894,7 +5504,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_Data.TestMethod34(System.String)"
             }
           ],
           "properties": {
@@ -6911,7 +5521,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent"
             }
           ],
           "toolFingerprint": "Type",
@@ -6935,7 +5545,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -6959,7 +5569,7 @@
                   "startLine": 12
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -6982,7 +5592,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.ReviewWebControlForSet_DocumentContent.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -6999,7 +5609,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver"
             }
           ],
           "toolFingerprint": "Impl#Type",
@@ -7023,7 +5633,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -7046,7 +5656,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.TextReaderImplNeedsSettingsAndResolver.TestMethod(System.String)"
             }
           ],
           "toolFingerprint": "content",
@@ -7070,7 +5680,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7094,7 +5704,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
             }
           ],
           "properties": {
@@ -7117,7 +5727,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
             }
           ],
           "properties": {
@@ -7140,7 +5750,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214(System.String)"
             }
           ],
           "properties": {
@@ -7163,7 +5773,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7187,7 +5797,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7210,7 +5820,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXml.TestMethod1214Ok(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7233,7 +5843,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7257,7 +5867,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
             }
           ],
           "properties": {
@@ -7280,7 +5890,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
             }
           ],
           "properties": {
@@ -7303,7 +5913,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215(System.String)"
             }
           ],
           "properties": {
@@ -7326,7 +5936,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7350,7 +5960,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7373,7 +5983,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataSetReadXmlSchema.TestMethod1215Ok(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7396,7 +6006,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7420,7 +6030,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7443,7 +6053,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7466,7 +6076,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7489,7 +6099,7 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7513,7 +6123,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7536,7 +6146,7 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXml.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7559,7 +6169,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7583,7 +6193,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7606,7 +6216,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7629,7 +6239,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7652,7 +6262,7 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7676,7 +6286,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7699,7 +6309,7 @@
                   "startLine": 24
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDataTableReadXmlSchema.TestMethod1(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -7722,7 +6332,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7745,7 +6355,7 @@
                   "startLine": 18
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -7768,7 +6378,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)"
             }
           ],
           "properties": {
@@ -7791,7 +6401,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForDeserialize.TestMethod1221Ok(System.Xml.XmlTextReader)"
             }
           ],
           "properties": {
@@ -7814,7 +6424,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -7837,7 +6447,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
             }
           ],
           "properties": {
@@ -7860,7 +6470,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -7884,7 +6494,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -7907,7 +6517,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
             }
           ],
           "properties": {
@@ -7930,7 +6540,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod1(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -7954,7 +6564,7 @@
                   "startLine": 33
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -7978,7 +6588,7 @@
                   "startLine": 33
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
             }
           ],
           "properties": {
@@ -8001,7 +6611,7 @@
                   "startLine": 29
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
             }
           ],
           "properties": {
@@ -8024,7 +6634,7 @@
                   "startLine": 30
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod2(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -8048,7 +6658,7 @@
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8072,7 +6682,7 @@
                   "startLine": 41
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
             }
           ],
           "properties": {
@@ -8095,7 +6705,7 @@
                   "startLine": 37
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
             }
           ],
           "properties": {
@@ -8118,7 +6728,7 @@
                   "startLine": 38
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForLoad.TestMethod3(System.String)"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -8142,7 +6752,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8166,7 +6776,7 @@
                   "startLine": 15
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
             }
           ],
           "properties": {
@@ -8189,7 +6799,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
             }
           ],
           "toolFingerprint": "schema",
@@ -8213,7 +6823,7 @@
                   "startLine": 19
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod18(System.String)"
             }
           ],
           "properties": {
@@ -8236,7 +6846,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
             }
           ],
           "properties": {
@@ -8259,7 +6869,7 @@
                   "startLine": 23
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
             }
           ],
           "properties": {
@@ -8282,7 +6892,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForSchemaRead.TestMethod19(System.Xml.XmlTextReader)"
             }
           ],
           "toolFingerprint": "schema",
@@ -8306,7 +6916,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -8329,7 +6939,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
             }
           ],
           "toolFingerprint": "vr",
@@ -8353,7 +6963,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213(System.IO.Stream)"
             }
           ],
           "properties": {
@@ -8376,7 +6986,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8400,7 +7010,7 @@
                   "startLine": 20
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -8423,7 +7033,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForValidatingReader.TestMethod1213Ok(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "vr",
@@ -8447,7 +7057,7 @@
                   "startLine": 14
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
             }
           ],
           "properties": {
@@ -8470,7 +7080,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
             }
           ],
           "toolFingerprint": "doc",
@@ -8494,7 +7104,7 @@
                   "startLine": 16
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod16(System.String)"
             }
           ],
           "properties": {
@@ -8517,7 +7127,7 @@
                   "startLine": 20
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)"
             }
           ],
           "properties": {
@@ -8540,7 +7150,7 @@
                   "startLine": 22
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlReaderForXPathDocument.TestMethod17(System.Xml.XmlReader)"
             }
           ],
           "toolFingerprint": "doc",
@@ -8558,7 +7168,7 @@
               "analysisTarget": {
                 "uri": "file:///C:/MSECTools/SecDevMain/src/Shared/OneMicrosoftStaticAnalysisResults/Sarif.Test.Functional/SarifConverterTestData/FxCop/src/SecurityXmlRuleTests.dll"
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver"
             }
           ],
           "properties": {
@@ -8581,7 +7191,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()"
             }
           ],
           "properties": {
@@ -8604,7 +7214,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest1()"
             }
           ],
           "toolFingerprint": "XslCompiledTransformLoadWrongOverload",
@@ -8628,7 +7238,7 @@
                   "startLine": 25
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()"
             }
           ],
           "properties": {
@@ -8651,7 +7261,7 @@
                   "startLine": 28
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest2()"
             }
           ],
           "properties": {
@@ -8674,7 +7284,7 @@
                   "startLine": 36
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest3()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest3()"
             }
           ],
           "properties": {
@@ -8697,7 +7307,7 @@
                   "startLine": 46
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest4()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest4()"
             }
           ],
           "properties": {
@@ -8720,7 +7330,7 @@
                   "startLine": 57
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()"
             }
           ],
           "properties": {
@@ -8743,7 +7353,7 @@
                   "startLine": 64
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest5()"
             }
           ],
           "toolFingerprint": "XslCompiledTransformLoadInsecureXmlResolve",
@@ -8767,7 +7377,7 @@
                   "startLine": 68
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()"
             }
           ],
           "properties": {
@@ -8790,7 +7400,7 @@
                   "startLine": 71
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.LoadTest6()"
             }
           ],
           "properties": {
@@ -8813,7 +7423,7 @@
                   "startLine": 310
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest1()"
             }
           ],
           "properties": {
@@ -8836,7 +7446,7 @@
                   "startLine": 319
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest2(System.String)"
             }
           ],
           "properties": {
@@ -8859,7 +7469,7 @@
                   "startLine": 333
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8883,7 +7493,7 @@
                   "startLine": 333
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8907,7 +7517,7 @@
                   "startLine": 333
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
             }
           ],
           "properties": {
@@ -8930,7 +7540,7 @@
                   "startLine": 328
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.SuppresionTest3(System.String)"
             }
           ],
           "properties": {
@@ -8953,7 +7563,7 @@
                   "startLine": 87
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -8977,7 +7587,7 @@
                   "startLine": 87
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9001,7 +7611,7 @@
                   "startLine": 87
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
             }
           ],
           "properties": {
@@ -9024,7 +7634,7 @@
                   "startLine": 83
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest1(System.String)"
             }
           ],
           "properties": {
@@ -9047,7 +7657,7 @@
                   "startLine": 95
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9071,7 +7681,7 @@
                   "startLine": 95
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9095,7 +7705,7 @@
                   "startLine": 95
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
             }
           ],
           "properties": {
@@ -9118,7 +7728,7 @@
                   "startLine": 91
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
             }
           ],
           "properties": {
@@ -9141,7 +7751,7 @@
                   "startLine": 95
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest2(System.String)"
             }
           ],
           "toolFingerprint": "XslCompiledTransformTransformInsecureXmlResolver",
@@ -9165,7 +7775,7 @@
                   "startLine": 104
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9189,7 +7799,7 @@
                   "startLine": 104
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9213,7 +7823,7 @@
                   "startLine": 104
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
             }
           ],
           "properties": {
@@ -9236,7 +7846,7 @@
                   "startLine": 100
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest3(System.String)"
             }
           ],
           "properties": {
@@ -9259,7 +7869,7 @@
                   "startLine": 108
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)"
             }
           ],
           "properties": {
@@ -9282,7 +7892,7 @@
                   "startLine": 112
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest4(System.String)"
             }
           ],
           "toolFingerprint": "XslCompiledTransformTransformWrongOverload",
@@ -9306,7 +7916,7 @@
                   "startLine": 120
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9330,7 +7940,7 @@
                   "startLine": 116
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
             }
           ],
           "properties": {
@@ -9353,7 +7963,7 @@
                   "startLine": 120
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.TransformTest5(System.String)"
             }
           ],
           "toolFingerprint": "XslCompiledTransformTransformWrongOverload",
@@ -9377,7 +7987,7 @@
                   "startLine": 226
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
             }
           ],
           "properties": {
@@ -9400,7 +8010,7 @@
                   "startLine": 228
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
             }
           ],
           "toolFingerprint": "doc",
@@ -9424,7 +8034,7 @@
                   "startLine": 228
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest1()"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -9448,7 +8058,7 @@
                   "startLine": 232
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest2()"
             }
           ],
           "properties": {
@@ -9471,7 +8081,7 @@
                   "startLine": 239
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()"
             }
           ],
           "properties": {
@@ -9494,7 +8104,7 @@
                   "startLine": 241
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest3()"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -9518,7 +8128,7 @@
                   "startLine": 246
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "properties": {
@@ -9541,7 +8151,7 @@
                   "startLine": 253
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest5()"
             }
           ],
           "properties": {
@@ -9564,7 +8174,7 @@
                   "startLine": 267
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()"
             }
           ],
           "properties": {
@@ -9587,7 +8197,7 @@
                   "startLine": 269
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest6()"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -9611,7 +8221,7 @@
                   "startLine": 278
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest7()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest7()"
             }
           ],
           "properties": {
@@ -9634,7 +8244,7 @@
                   "startLine": 289
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()"
             }
           ],
           "properties": {
@@ -9657,7 +8267,7 @@
                   "startLine": 292
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlDocumentTest8()"
             }
           ],
           "toolFingerprint": "XmlDocument",
@@ -9681,7 +8291,7 @@
                   "startLine": 130
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9705,7 +8315,7 @@
                   "startLine": 128
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
             }
           ],
           "properties": {
@@ -9728,7 +8338,7 @@
                   "startLine": 130
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
             }
           ],
           "toolFingerprint": "reader",
@@ -9752,7 +8362,7 @@
                   "startLine": 130
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest1()"
             }
           ],
           "toolFingerprint": "XmlReaderCreateWrongOverload",
@@ -9776,7 +8386,7 @@
                   "startLine": 212
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9800,7 +8410,7 @@
                   "startLine": 206
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
             }
           ],
           "properties": {
@@ -9823,7 +8433,7 @@
                   "startLine": 212
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest10()"
             }
           ],
           "toolFingerprint": "reader",
@@ -9847,7 +8457,7 @@
                   "startLine": 138
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9871,7 +8481,7 @@
                   "startLine": 134
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
             }
           ],
           "properties": {
@@ -9894,7 +8504,7 @@
                   "startLine": 138
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest2()"
             }
           ],
           "toolFingerprint": "reader",
@@ -9918,7 +8528,7 @@
                   "startLine": 146
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -9942,7 +8552,7 @@
                   "startLine": 142
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
             }
           ],
           "properties": {
@@ -9965,7 +8575,7 @@
                   "startLine": 146
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest3(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "reader",
@@ -9989,7 +8599,7 @@
                   "startLine": 154
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10013,7 +8623,7 @@
                   "startLine": 150
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "properties": {
@@ -10036,7 +8646,7 @@
                   "startLine": 154
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "reader",
@@ -10060,7 +8670,7 @@
                   "startLine": 150
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "resolver",
@@ -10084,7 +8694,7 @@
                   "startLine": 154
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest4(System.Xml.XmlSecureResolver)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateInsecureXmlResolver",
@@ -10108,7 +8718,7 @@
                   "startLine": 168
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10132,7 +8742,7 @@
                   "startLine": 158
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
             }
           ],
           "properties": {
@@ -10155,7 +8765,7 @@
                   "startLine": 168
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest5()"
             }
           ],
           "toolFingerprint": "reader",
@@ -10179,7 +8789,7 @@
                   "startLine": 177
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10203,7 +8813,7 @@
                   "startLine": 172
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
             }
           ],
           "properties": {
@@ -10226,7 +8836,7 @@
                   "startLine": 177
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest6()"
             }
           ],
           "toolFingerprint": "reader",
@@ -10250,7 +8860,7 @@
                   "startLine": 186
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10274,7 +8884,7 @@
                   "startLine": 181
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
             }
           ],
           "properties": {
@@ -10297,7 +8907,7 @@
                   "startLine": 186
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
             }
           ],
           "toolFingerprint": "reader",
@@ -10321,7 +8931,7 @@
                   "startLine": 186
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest7()"
             }
           ],
           "toolFingerprint": "XmlReaderCreateInsecureXmlResolver",
@@ -10345,7 +8955,7 @@
                   "startLine": 196
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10369,7 +8979,7 @@
                   "startLine": 190
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
             }
           ],
           "properties": {
@@ -10392,7 +9002,7 @@
                   "startLine": 196
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
             }
           ],
           "toolFingerprint": "reader",
@@ -10416,7 +9026,7 @@
                   "startLine": 196
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest8()"
             }
           ],
           "toolFingerprint": "XmlReaderCreateInsecureXmlResolver",
@@ -10440,7 +9050,7 @@
                   "startLine": 202
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
             }
           ],
           "toolFingerprint": "NonExceptionEdge",
@@ -10464,7 +9074,7 @@
                   "startLine": 200
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
             }
           ],
           "properties": {
@@ -10487,7 +9097,7 @@
                   "startLine": 202
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
             }
           ],
           "toolFingerprint": "reader",
@@ -10511,7 +9121,7 @@
                   "startLine": 202
                 }
               },
-              "fullyQualifiedLogicalName": "FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!FxCopUnsafeXml.UseXmlSecureResolver.XmlReaderTest9(System.Xml.XmlReaderSettings)"
             }
           ],
           "toolFingerprint": "XmlReaderCreateInsecureXmlResolver",
@@ -10535,7 +9145,7 @@
                   "startLine": 17
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)"
             }
           ],
           "properties": {
@@ -10558,7 +9168,7 @@
                   "startLine": 13
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.String,System.String)"
             }
           ],
           "properties": {
@@ -10581,7 +9191,7 @@
                   "startLine": 21
                 }
               },
-              "fullyQualifiedLogicalName": "SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.Xml.Schema.XmlSchema)"
+              "fullyQualifiedLogicalName": "securityxmlruletests.dll!SecurityXmlRuleTests.DoNotAddStringsToXmlSchema.TestMethod(System.Xml.Schema.XmlSchema)"
             }
           ],
           "properties": {

--- a/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/AndroidStudioConverterTests.cs
@@ -232,29 +232,27 @@ Possible resolution: delete", result.Message);
                 FullyQualifiedLogicalName = "my_fancy_binary\\my_method",
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "my_fancy_binary",
-                    Kind = LogicalLocationKind.Module
+                    "my_fancy_binary", new LogicalLocation { ParentKey = null, Name = "my_fancy_binary", Kind = LogicalLocationKind.Module }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "my_method",
-                    Kind = LogicalLocationKind.Member
-                }
-            };
+                    @"my_fancy_binary\my_method",
+                    new LogicalLocation { ParentKey = "my_fancy_binary", Name = "my_method", Kind = LogicalLocationKind.Member }
+                },
+           };
 
-            LocationInfo locationInfo = GetLocationInfoForBuilder(builder);
+            var converter = new AndroidStudioConverter();
+            Result result = converter.ConvertProblemToSarifResult(new AndroidStudioProblem(builder));
 
-            locationInfo.Location.ValueEquals(expectedLocation).Should().BeTrue();
+            result.Locations[0].ValueEquals(expectedLocation).Should().BeTrue();
 
-            locationInfo.LogicalLocationComponents
-                .SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -272,24 +270,23 @@ Possible resolution: delete", result.Message);
                 FullyQualifiedLogicalName = "my_method"
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "my_method",
-                    Kind = LogicalLocationKind.Member
-                }
-            };
+                    "my_method", new LogicalLocation { ParentKey = null, Name = "my_method", Kind = LogicalLocationKind.Member }
+                },
+           };
 
-            LocationInfo locationInfo = GetLocationInfoForBuilder(builder);
+            var converter = new AndroidStudioConverter();
+            Result result = converter.ConvertProblemToSarifResult(new AndroidStudioProblem(builder));
 
-            locationInfo.Location.ValueEquals(expectedLocation).Should().BeTrue();
+            result.Locations[0].ValueEquals(expectedLocation).Should().BeTrue();
 
-            locationInfo.LogicalLocationComponents
-                .SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -306,30 +303,27 @@ Possible resolution: delete", result.Message);
             {
                 FullyQualifiedLogicalName = "FancyPackageName\\my_method"
             };
-
-            var expectedLogicalLocationComponents = new[]
+            
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "FancyPackageName",
-                    Kind = LogicalLocationKind.Package
+                    "FancyPackageName", new LogicalLocation { ParentKey = null, Name = "FancyPackageName", Kind = LogicalLocationKind.Package }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "my_method",
-                    Kind = LogicalLocationKind.Member
-                }
-            };
+                    @"FancyPackageName\my_method", new LogicalLocation { ParentKey = "FancyPackageName", Name = "my_method", Kind = LogicalLocationKind.Member }
+                },
+           };
 
-            LocationInfo locationInfo = GetLocationInfoForBuilder(builder);
+            var converter = new AndroidStudioConverter();
+            Result result = converter.ConvertProblemToSarifResult(new AndroidStudioProblem(builder));
 
-            locationInfo.Location.ValueEquals(expectedLocation).Should().BeTrue();
+            result.Locations[0].ValueEquals(expectedLocation).Should().BeTrue();
 
-            locationInfo.LogicalLocationComponents
-                .SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -346,24 +340,23 @@ Possible resolution: delete", result.Message);
                 FullyQualifiedLogicalName = "FancyPackageName"
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "FancyPackageName",
-                    Kind = LogicalLocationKind.Package
+                    "FancyPackageName", new LogicalLocation { ParentKey = null, Name = "FancyPackageName", Kind = LogicalLocationKind.Package }
                 }
-            };
+           };
 
-            LocationInfo locationInfo = GetLocationInfoForBuilder(builder);
+            var converter = new AndroidStudioConverter();
+            Result result = converter.ConvertProblemToSarifResult(new AndroidStudioProblem(builder));
 
-            locationInfo.Location.ValueEquals(expectedLocation).Should().BeTrue();
+            result.Locations[0].ValueEquals(expectedLocation).Should().BeTrue();
 
-            locationInfo.LogicalLocationComponents
-                .SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -384,24 +377,23 @@ Possible resolution: delete", result.Message);
                 FullyQualifiedLogicalName = "LastResortModule"
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "LastResortModule",
-                    Kind = LogicalLocationKind.Module
+                    "LastResortModule", new LogicalLocation { ParentKey = null, Name = "LastResortModule", Kind = LogicalLocationKind.Module }
                 }
-            };
+           };
 
-            LocationInfo locationInfo = GetLocationInfoForBuilder(builder);
+            var converter = new AndroidStudioConverter();
+            Result result = converter.ConvertProblemToSarifResult(new AndroidStudioProblem(builder));
 
-            locationInfo.Location.ValueEquals(expectedLocation).Should().BeTrue();
+            result.Locations[0].ValueEquals(expectedLocation).Should().BeTrue();
 
-            locationInfo.LogicalLocationComponents
-                .SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -425,7 +417,7 @@ Possible resolution: delete", result.Message);
         private struct LocationInfo
         {
             public Location Location;
-            public IList<LogicalLocationComponent> LogicalLocationComponents;
+            public LogicalLocation LogicalLocation;
         }
 
         private static LocationInfo GetLocationInfoForBuilder(AndroidStudioProblem.Builder builder)
@@ -436,14 +428,14 @@ Possible resolution: delete", result.Message);
             Location location = result.Locations.First();
 
             string logicalLocationKey = converter.LogicalLocationsDictionary.Keys.SingleOrDefault();
-            IList<LogicalLocationComponent> logicalLocationComponents = logicalLocationKey != null
+            LogicalLocation logicalLocation = logicalLocationKey != null
                 ? converter.LogicalLocationsDictionary[logicalLocationKey]
-                : new List<LogicalLocationComponent>(0);
+                : null;
 
             return new LocationInfo
             {
                 Location = location,
-                LogicalLocationComponents = logicalLocationComponents
+                LogicalLocation = logicalLocation
             };
         }
     }

--- a/src/Sarif.UnitTests/Converters/FxCopConverterTests.cs
+++ b/src/Sarif.UnitTests/Converters/FxCopConverterTests.cs
@@ -401,41 +401,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             expectedResult.SetProperty("Category", "FakeCategory");
             expectedResult.SetProperty("FixCategory", "Breaking");
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "mybinary.dll",
-                    Kind = LogicalLocationKind.Module
+                    "mybinary.dll", new LogicalLocation { ParentKey = null, Name = "mybinary.dll", Kind = LogicalLocationKind.Module }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "mynamespace",
-                    Kind = LogicalLocationKind.Namespace
+                    "mybinary.dll!mynamespace",
+                    new LogicalLocation { ParentKey = "mybinary.dll", Name = "mynamespace", Kind = LogicalLocationKind.Namespace }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "mytype",
-                    Kind = LogicalLocationKind.Type
+                    "mybinary.dll!mynamespace.mytype",
+                    new LogicalLocation { ParentKey = "mybinary.dll!mynamespace", Name = "mytype", Kind = LogicalLocationKind.Type }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "mymember(string)",
-                    Kind = LogicalLocationKind.Member
-                }
-            };
+                    "mybinary.dll!mynamespace.mytype.mymember(string)",
+                    new LogicalLocation { ParentKey = "mybinary.dll!mynamespace.mytype", Name = "mymember(string)", Kind = LogicalLocationKind.Member }
+                }            };
 
             var converter = new FxCopConverter();
             Result result = converter.CreateResult(context);
 
-            result.ValueEquals(expectedResult).Should().BeTrue();
-
-            converter.LogicalLocationsDictionary.Keys.Should().ContainSingle(expectedLogicalLocation);
-            var actualLogicalLocationComponents = converter.LogicalLocationsDictionary[expectedLogicalLocation];
-            actualLogicalLocationComponents.SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -465,36 +456,30 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "mynamespace",
-                    Kind = LogicalLocationKind.Namespace
+                    "mynamespace",
+                    new LogicalLocation { ParentKey = null, Name = "mynamespace", Kind = LogicalLocationKind.Namespace }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "mytype",
-                    Kind = LogicalLocationKind.Type
+                    "mynamespace.mytype",
+                    new LogicalLocation { ParentKey = "mynamespace", Name = "mytype", Kind = LogicalLocationKind.Type }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "mymember(string)",
-                    Kind = LogicalLocationKind.Member
+                    "mynamespace.mytype.mymember(string)",
+                    new LogicalLocation { ParentKey = "mynamespace.mytype", Name = "mymember(string)", Kind = LogicalLocationKind.Member }
                 }
             };
 
             var converter = new FxCopConverter();
             Result result = converter.CreateResult(context);
 
-            result.Locations.SequenceEqual(expectedLocations, Location.ValueComparer).Should().BeTrue();
-
-            converter.LogicalLocationsDictionary.Keys.Should().ContainSingle(expectedLogicalLocation);
-            var actualLogicalLocationComponents = converter.LogicalLocationsDictionary[expectedLogicalLocation];
-            actualLogicalLocationComponents.SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]
@@ -527,31 +512,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             };
 
-            var expectedLogicalLocationComponents = new[]
+            var expectedLogicalLocations = new Dictionary<string, LogicalLocation>
             {
-                new LogicalLocationComponent
                 {
-                    Name = "mybinary.dll",
-                    Kind = LogicalLocationKind.Module
+                    "mybinary.dll",
+                    new LogicalLocation { ParentKey = null, Name = "mybinary.dll", Kind = LogicalLocationKind.Module }
                 },
-                new LogicalLocationComponent
                 {
-                    Name = "myresource.resx",
-                    Kind = LogicalLocationKind.Resource
-                }
+                    "mybinary.dll!myresource.resx",
+                    new LogicalLocation { ParentKey = "mybinary.dll", Name = "myresource.resx",Kind = LogicalLocationKind.Resource }
+                },
             };
 
             var converter = new FxCopConverter();
             Result result = converter.CreateResult(context);
 
-            result.Locations.SequenceEqual(expectedLocations, Location.ValueComparer).Should().BeTrue();
-
-            converter.LogicalLocationsDictionary.Keys.Should().ContainSingle(expectedLogicalLocation);
-            var actualLogicalLocationComponents = converter.LogicalLocationsDictionary[expectedLogicalLocation];
-            actualLogicalLocationComponents.SequenceEqual(
-                    expectedLogicalLocationComponents,
-                    LogicalLocationComponent.ValueComparer)
-                .Should().BeTrue();
+            foreach (string key in expectedLogicalLocations.Keys)
+            {
+                expectedLogicalLocations[key].ValueEquals(converter.LogicalLocationsDictionary[key]).Should().BeTrue();
+            }
+            converter.LogicalLocationsDictionary.Count.Should().Be(expectedLogicalLocations.Count);
         }
 
         [TestMethod]

--- a/src/Sarif.UnitTests/Converters/ToolFileConverterBaseTests.cs
+++ b/src/Sarif.UnitTests/Converters/ToolFileConverterBaseTests.cs
@@ -37,24 +37,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 FullyQualifiedLogicalName = "a"
             };
 
-            LogicalLocationComponent[] logicalLocationComponents = new[]
+            var logicalLocation = new LogicalLocation
             {
-                new LogicalLocationComponent
-                {
-                    Name = "a",
-                    Kind = LogicalLocationKind.Namespace
-                },
+                Name = "a",
+                Kind = LogicalLocationKind.Namespace
             };
 
             var converter = new LogicalLocationTestConverter();
 
-            converter.AddLogicalLocation(location, logicalLocationComponents);
+            string logicalLocationKey = converter.AddLogicalLocation(logicalLocation);
 
-            location.LogicalLocationKey.Should().BeNull();
+            location.FullyQualifiedLogicalName.Should().Be(logicalLocationKey);
 
             converter.LogicalLocationsDictionary.Keys.Count.Should().Be(1);
             converter.LogicalLocationsDictionary.Keys.Should().Contain("a");
-            converter.LogicalLocationsDictionary["a"].SequenceEqual(logicalLocationComponents).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a"].ValueEquals(logicalLocation).Should().BeTrue();
         }
 
         [TestMethod]
@@ -70,26 +67,30 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 FullyQualifiedLogicalName = "a"
             };
 
-            LogicalLocationComponent[] logicalLocationComponents = new[]
+            var logicalLocation1 = new LogicalLocation
             {
-                new LogicalLocationComponent
-                {
-                    Name = "a",
-                    Kind = LogicalLocationKind.Namespace
-                }
+                Name = "a",
+                Kind = LogicalLocationKind.Namespace
+            };
+
+            var logicalLocation2 = new LogicalLocation
+            {
+                Name = "a",
+                Kind = LogicalLocationKind.Namespace
             };
 
             var converter = new LogicalLocationTestConverter();
 
-            converter.AddLogicalLocation(location1, logicalLocationComponents);
-            converter.AddLogicalLocation(location2, logicalLocationComponents);
+            string logicalLocationKey = converter.AddLogicalLocation(logicalLocation1);
+            logicalLocationKey.Should().Be(location1.FullyQualifiedLogicalName);
 
-            location1.LogicalLocationKey.Should().BeNull();
-            location2.LogicalLocationKey.Should().BeNull();
+            logicalLocationKey = converter.AddLogicalLocation(logicalLocation2);
+            logicalLocationKey.Should().Be(location2.FullyQualifiedLogicalName);
 
             converter.LogicalLocationsDictionary.Keys.Count.Should().Be(1);
             converter.LogicalLocationsDictionary.Keys.Should().Contain("a");
-            converter.LogicalLocationsDictionary["a"].SequenceEqual(logicalLocationComponents).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a"].ValueEquals(logicalLocation1).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a"].ValueEquals(logicalLocation2).Should().BeTrue();
         }
 
         [TestMethod]
@@ -100,13 +101,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 FullyQualifiedLogicalName = "a"
             };
 
-            LogicalLocationComponent[] logicalLocationComponents1 = new[]
+            var logicalLocation1 = new LogicalLocation
             {
-                new LogicalLocationComponent
-                {
-                    Name = "a",
-                    Kind = LogicalLocationKind.Namespace
-                }
+                Name = "a",
+                Kind = LogicalLocationKind.Namespace
             };
 
             Location location2 = new Location
@@ -114,13 +112,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 FullyQualifiedLogicalName = "a"
             };
 
-            LogicalLocationComponent[] logicalLocationComponents2 = new[]
+            var logicalLocation2 = new LogicalLocation
             {
-                new LogicalLocationComponent
-                {
-                    Name = "a",
-                    Kind = LogicalLocationKind.Package
-                }
+                Name = "a",
+                Kind = LogicalLocationKind.Package
             };
 
             Location location3 = new Location
@@ -128,31 +123,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 FullyQualifiedLogicalName = "a"
             };
 
-            LogicalLocationComponent[] logicalLocationComponents3 = new[]
+            var logicalLocation3 = new LogicalLocation
             {
-                new LogicalLocationComponent
-                {
-                    Name = "a",
-                    Kind = LogicalLocationKind.Module
-                }
+                Name = "a",
+                Kind = LogicalLocationKind.Member
             };
 
             var converter = new LogicalLocationTestConverter();
 
-            converter.AddLogicalLocation(location1, logicalLocationComponents1);
-            converter.AddLogicalLocation(location2, logicalLocationComponents2);
-            converter.AddLogicalLocation(location3, logicalLocationComponents3);
+            string logicalLocationKey = converter.AddLogicalLocation(logicalLocation1);
+            logicalLocationKey.Should().Be("a");
 
-            location1.LogicalLocationKey.Should().BeNull();
-            location2.LogicalLocationKey.Should().Be("a-0");
-            location3.LogicalLocationKey.Should().Be("a-1");
+            logicalLocationKey = converter.AddLogicalLocation(logicalLocation2);
+            logicalLocationKey.Should().Be("a-0");
+
+            logicalLocationKey = converter.AddLogicalLocation(logicalLocation3);
+            logicalLocationKey.Should().Be("a-1");
 
             converter.LogicalLocationsDictionary.Keys.Count.Should().Be(3);
-            converter.LogicalLocationsDictionary["a"].SequenceEqual(logicalLocationComponents1).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a"].ValueEquals(logicalLocation1).Should().BeTrue();
             converter.LogicalLocationsDictionary.Keys.Should().Contain("a-0");
-            converter.LogicalLocationsDictionary["a-0"].SequenceEqual(logicalLocationComponents2).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a-0"].ValueEquals(logicalLocation2).Should().BeTrue();
             converter.LogicalLocationsDictionary.Keys.Should().Contain("a-1");
-            converter.LogicalLocationsDictionary["a-1"].SequenceEqual(logicalLocationComponents3).Should().BeTrue();
+            converter.LogicalLocationsDictionary["a-1"].ValueEquals(logicalLocation3).Should().BeTrue();
         }
     }
 }

--- a/src/Sarif.UnitTests/ResultLogObjectWriter.cs
+++ b/src/Sarif.UnitTests/ResultLogObjectWriter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         /// A dictionary whose keys are strings specifying a logical location and
         /// whose values provide information about each component of the logical location.
         /// </param>
-        public void WriteLogicalLocations(IDictionary<string, IList<LogicalLocationComponent>> logicalLocationDictionary)
+        public void WriteLogicalLocations(IDictionary<string, LogicalLocation> logicalLocationDictionary)
         {
             throw new NotImplementedException();
         }

--- a/src/Sarif/Autogenerated/LogicalLocation.cs
+++ b/src/Sarif/Autogenerated/LogicalLocation.cs
@@ -9,15 +9,15 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// A component of a logical location.
+    /// A logical location of a construct that produced a result.
     /// </summary>
     [DataContract]
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.33.0.0")]
-    public partial class LogicalLocationComponent : ISarifNode
+    public partial class LogicalLocation : ISarifNode
     {
-        public static IEqualityComparer<LogicalLocationComponent> ValueComparer => LogicalLocationComponentEqualityComparer.Instance;
+        public static IEqualityComparer<LogicalLocation> ValueComparer => LogicalLocationEqualityComparer.Instance;
 
-        public bool ValueEquals(LogicalLocationComponent other) => ValueComparer.Equals(this, other);
+        public bool ValueEquals(LogicalLocation other) => ValueComparer.Equals(this, other);
         public int ValueGetHashCode() => ValueComparer.GetHashCode(this);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                return SarifNodeKind.LogicalLocationComponent;
+                return SarifNodeKind.LogicalLocation;
             }
         }
 
@@ -38,34 +38,43 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string Name { get; set; }
 
         /// <summary>
-        /// The type of construct this logicalLocationComponent refers to. Should be one of 'declaration', 'function', 'member', 'module', 'namespace', 'package', 'resource', or 'type', if any of those accurately describe the construct.
+        /// Identifies the key of the immediate parent of the construct in which the result occurred. For example, this property might point to a logical location that represents the namespace that holds a type.
+        /// </summary>
+        [DataMember(Name = "parentKey", IsRequired = false, EmitDefaultValue = false)]
+        public string ParentKey { get; set; }
+
+        /// <summary>
+        /// The type of construct this logicalLocationComponent refers to. Should be one of 'function', 'member', 'module', 'namespace', 'package', 'resource', or 'type', if any of those accurately describe the construct.
         /// </summary>
         [DataMember(Name = "kind", IsRequired = false, EmitDefaultValue = false)]
         public string Kind { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicalLocationComponent" /> class.
+        /// Initializes a new instance of the <see cref="LogicalLocation" /> class.
         /// </summary>
-        public LogicalLocationComponent()
+        public LogicalLocation()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicalLocationComponent" /> class from the supplied values.
+        /// Initializes a new instance of the <see cref="LogicalLocation" /> class from the supplied values.
         /// </summary>
         /// <param name="name">
         /// An initialization value for the <see cref="P: Name" /> property.
         /// </param>
+        /// <param name="parentKey">
+        /// An initialization value for the <see cref="P: ParentKey" /> property.
+        /// </param>
         /// <param name="kind">
         /// An initialization value for the <see cref="P: Kind" /> property.
         /// </param>
-        public LogicalLocationComponent(string name, string kind)
+        public LogicalLocation(string name, string parentKey, string kind)
         {
-            Init(name, kind);
+            Init(name, parentKey, kind);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicalLocationComponent" /> class from the specified instance.
+        /// Initializes a new instance of the <see cref="LogicalLocation" /> class from the specified instance.
         /// </summary>
         /// <param name="other">
         /// The instance from which the new instance is to be initialized.
@@ -73,14 +82,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="other" /> is null.
         /// </exception>
-        public LogicalLocationComponent(LogicalLocationComponent other)
+        public LogicalLocation(LogicalLocation other)
         {
             if (other == null)
             {
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Name, other.Kind);
+            Init(other.Name, other.ParentKey, other.Kind);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -91,19 +100,20 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public LogicalLocationComponent DeepClone()
+        public LogicalLocation DeepClone()
         {
-            return (LogicalLocationComponent)DeepCloneCore();
+            return (LogicalLocation)DeepCloneCore();
         }
 
         private ISarifNode DeepCloneCore()
         {
-            return new LogicalLocationComponent(this);
+            return new LogicalLocation(this);
         }
 
-        private void Init(string name, string kind)
+        private void Init(string name, string parentKey, string kind)
         {
             Name = name;
+            ParentKey = parentKey;
             Kind = kind;
         }
     }

--- a/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
@@ -8,14 +8,14 @@ using System.Collections.Generic;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// Defines methods to support the comparison of objects of type LogicalLocationComponent for equality.
+    /// Defines methods to support the comparison of objects of type LogicalLocation for equality.
     /// </summary>
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.33.0.0")]
-    internal sealed class LogicalLocationComponentEqualityComparer : IEqualityComparer<LogicalLocationComponent>
+    internal sealed class LogicalLocationEqualityComparer : IEqualityComparer<LogicalLocation>
     {
-        internal static readonly LogicalLocationComponentEqualityComparer Instance = new LogicalLocationComponentEqualityComparer();
+        internal static readonly LogicalLocationEqualityComparer Instance = new LogicalLocationEqualityComparer();
 
-        public bool Equals(LogicalLocationComponent left, LogicalLocationComponent right)
+        public bool Equals(LogicalLocation left, LogicalLocation right)
         {
             if (ReferenceEquals(left, right))
             {
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.ParentKey != right.ParentKey)
+            {
+                return false;
+            }
+
             if (left.Kind != right.Kind)
             {
                 return false;
@@ -40,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return true;
         }
 
-        public int GetHashCode(LogicalLocationComponent obj)
+        public int GetHashCode(LogicalLocation obj)
         {
             if (ReferenceEquals(obj, null))
             {
@@ -53,6 +58,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Name != null)
                 {
                     result = (result * 31) + obj.Name.GetHashCode();
+                }
+
+                if (obj.ParentKey != null)
+                {
+                    result = (result * 31) + obj.ParentKey.GetHashCode();
                 }
 
                 if (obj.Kind != null)

--- a/src/Sarif/Autogenerated/Run.cs
+++ b/src/Sarif/Autogenerated/Run.cs
@@ -56,10 +56,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         public IDictionary<string, IList<FileData>> Files { get; set; }
 
         /// <summary>
-        /// A dictionary, each of whose keys specifies a fully qualified logical location such as a type nested within a namespace, and each of whose values is an array of logicalLocationComponent objects.
+        /// A dictionary, each of whose keys specifies a logical location such as a namespace, type or function.
         /// </summary>
         [DataMember(Name = "logicalLocations", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, IList<LogicalLocationComponent>> LogicalLocations { get; set; }
+        public IDictionary<string, LogicalLocation> LogicalLocations { get; set; }
 
         /// <summary>
         /// The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) in the event that a log file represents an actual scan.
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="correlationId">
         /// An initialization value for the <see cref="P: CorrelationId" /> property.
         /// </param>
-        public Run(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
+        public Run(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, LogicalLocation> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
         {
             Init(tool, invocation, analysisTarget, files, logicalLocations, results, toolNotifications, configurationNotifications, rules, id, correlationId);
         }
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Run(this);
         }
 
-        private void Init(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, IList<LogicalLocationComponent>> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
+        private void Init(Tool tool, Invocation invocation, PhysicalLocation analysisTarget, IDictionary<string, IList<FileData>> files, IDictionary<string, LogicalLocation> logicalLocations, IEnumerable<Result> results, IEnumerable<Notification> toolNotifications, IEnumerable<Notification> configurationNotifications, IDictionary<string, Rule> rules, string id, string correlationId)
         {
             if (tool != null)
             {
@@ -223,30 +223,35 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (logicalLocations != null)
             {
-                LogicalLocations = new Dictionary<string, IList<LogicalLocationComponent>>();
+                LogicalLocations = new Dictionary<string, LogicalLocation>();
                 foreach (var value_2 in logicalLocations)
                 {
-                    var destination_1 = new List<LogicalLocationComponent>();
-                    foreach (var value_3 in value_2.Value)
-                    {
-                        if (value_3 == null)
-                        {
-                            destination_1.Add(null);
-                        }
-                        else
-                        {
-                            destination_1.Add(new LogicalLocationComponent(value_3));
-                        }
-                    }
-
-                    LogicalLocations.Add(value_2.Key, destination_1);
+                    LogicalLocations.Add(value_2.Key, new LogicalLocation(value_2.Value));
                 }
             }
 
             if (results != null)
             {
-                var destination_2 = new List<Result>();
-                foreach (var value_4 in results)
+                var destination_1 = new List<Result>();
+                foreach (var value_3 in results)
+                {
+                    if (value_3 == null)
+                    {
+                        destination_1.Add(null);
+                    }
+                    else
+                    {
+                        destination_1.Add(new Result(value_3));
+                    }
+                }
+
+                Results = destination_1;
+            }
+
+            if (toolNotifications != null)
+            {
+                var destination_2 = new List<Notification>();
+                foreach (var value_4 in toolNotifications)
                 {
                     if (value_4 == null)
                     {
@@ -254,17 +259,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                     }
                     else
                     {
-                        destination_2.Add(new Result(value_4));
+                        destination_2.Add(new Notification(value_4));
                     }
                 }
 
-                Results = destination_2;
+                ToolNotifications = destination_2;
             }
 
-            if (toolNotifications != null)
+            if (configurationNotifications != null)
             {
                 var destination_3 = new List<Notification>();
-                foreach (var value_5 in toolNotifications)
+                foreach (var value_5 in configurationNotifications)
                 {
                     if (value_5 == null)
                     {
@@ -276,33 +281,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     }
                 }
 
-                ToolNotifications = destination_3;
-            }
-
-            if (configurationNotifications != null)
-            {
-                var destination_4 = new List<Notification>();
-                foreach (var value_6 in configurationNotifications)
-                {
-                    if (value_6 == null)
-                    {
-                        destination_4.Add(null);
-                    }
-                    else
-                    {
-                        destination_4.Add(new Notification(value_6));
-                    }
-                }
-
-                ConfigurationNotifications = destination_4;
+                ConfigurationNotifications = destination_3;
             }
 
             if (rules != null)
             {
                 Rules = new Dictionary<string, Rule>();
-                foreach (var value_7 in rules)
+                foreach (var value_6 in rules)
                 {
-                    Rules.Add(value_7.Key, new Rule(value_7.Value));
+                    Rules.Add(value_6.Key, new Rule(value_6.Value));
                 }
             }
 

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -89,31 +89,15 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 foreach (var value_2 in left.LogicalLocations)
                 {
-                    IList<LogicalLocationComponent> value_3;
+                    LogicalLocation value_3;
                     if (!right.LogicalLocations.TryGetValue(value_2.Key, out value_3))
                     {
                         return false;
                     }
 
-                    if (!object.ReferenceEquals(value_2.Value, value_3))
+                    if (!LogicalLocation.ValueComparer.Equals(value_2.Value, value_3))
                     {
-                        if (value_2.Value == null || value_3 == null)
-                        {
-                            return false;
-                        }
-
-                        if (value_2.Value.Count != value_3.Count)
-                        {
-                            return false;
-                        }
-
-                        for (int index_1 = 0; index_1 < value_2.Value.Count; ++index_1)
-                        {
-                            if (!LogicalLocationComponent.ValueComparer.Equals(value_2.Value[index_1], value_3[index_1]))
-                            {
-                                return false;
-                            }
-                        }
+                        return false;
                     }
                 }
             }
@@ -130,9 +114,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                for (int index_2 = 0; index_2 < left.Results.Count; ++index_2)
+                for (int index_1 = 0; index_1 < left.Results.Count; ++index_1)
                 {
-                    if (!Result.ValueComparer.Equals(left.Results[index_2], right.Results[index_2]))
+                    if (!Result.ValueComparer.Equals(left.Results[index_1], right.Results[index_1]))
                     {
                         return false;
                     }
@@ -151,9 +135,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                for (int index_3 = 0; index_3 < left.ToolNotifications.Count; ++index_3)
+                for (int index_2 = 0; index_2 < left.ToolNotifications.Count; ++index_2)
                 {
-                    if (!Notification.ValueComparer.Equals(left.ToolNotifications[index_3], right.ToolNotifications[index_3]))
+                    if (!Notification.ValueComparer.Equals(left.ToolNotifications[index_2], right.ToolNotifications[index_2]))
                     {
                         return false;
                     }
@@ -172,9 +156,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                for (int index_4 = 0; index_4 < left.ConfigurationNotifications.Count; ++index_4)
+                for (int index_3 = 0; index_3 < left.ConfigurationNotifications.Count; ++index_3)
                 {
-                    if (!Notification.ValueComparer.Equals(left.ConfigurationNotifications[index_4], right.ConfigurationNotifications[index_4]))
+                    if (!Notification.ValueComparer.Equals(left.ConfigurationNotifications[index_3], right.ConfigurationNotifications[index_3]))
                     {
                         return false;
                     }

--- a/src/Sarif/Autogenerated/SarifNodeKind.cs
+++ b/src/Sarif/Autogenerated/SarifNodeKind.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         Location,
         /// <summary>
-        /// A value indicating that the <see cref="ISarifNode" /> object is of type <see cref="LogicalLocationComponent" />.
+        /// A value indicating that the <see cref="ISarifNode" /> object is of type <see cref="LogicalLocation" />.
         /// </summary>
-        LogicalLocationComponent,
+        LogicalLocation,
         /// <summary>
         /// A value indicating that the <see cref="ISarifNode" /> object is of type <see cref="Notification" />.
         /// </summary>

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -66,8 +66,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return VisitInvocation((Invocation)node);
                 case SarifNodeKind.Location:
                     return VisitLocation((Location)node);
-                case SarifNodeKind.LogicalLocationComponent:
-                    return VisitLogicalLocationComponent((LogicalLocationComponent)node);
+                case SarifNodeKind.LogicalLocation:
+                    return VisitLogicalLocation((LogicalLocation)node);
                 case SarifNodeKind.Notification:
                     return VisitNotification((Notification)node);
                 case SarifNodeKind.PhysicalLocation:
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return node;
         }
 
-        public virtual LogicalLocationComponent VisitLogicalLocationComponent(LogicalLocationComponent node)
+        public virtual LogicalLocation VisitLogicalLocation(LogicalLocation node)
         {
             if (node != null)
             {
@@ -371,10 +371,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         var value = node.LogicalLocations[key];
                         if (value != null)
                         {
-                            for (int index_0 = 0; index_0 < node.LogicalLocations[key].Count; ++index_0)
-                            {
-                                node.LogicalLocations[key][index_0] = VisitNullChecked(node.LogicalLocations[key][index_0]);
-                            }
+                            node.LogicalLocations[key] = VisitNullChecked(value);
                         }
                     }
                 }

--- a/src/Sarif/IResultLogWriter.cs
+++ b/src/Sarif/IResultLogWriter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A dictionary whose keys are strings specifying a logical location and
         /// whose values provide information about each component of the logical location.
         /// </param>
-        void WriteLogicalLocations(IDictionary<string, IList<LogicalLocationComponent>> logicalLocationDictionary);
+        void WriteLogicalLocations(IDictionary<string, LogicalLocation> logicalLocationsDictionary);
 
         /// <summary>
         /// Write information about rules to the log. This information may appear

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -442,8 +442,8 @@
           "type": "string"
         },
 
-        "parent": {
-          "description": "Identifies the immediate parent of the construct in which the result occurred. For example, this property might contain the name of a namespace that holds a type.",
+        "parentKey": {
+          "description": "Identifies the key of the immediate parent of the construct in which the result occurred. For example, this property might point to a logical location that represents the namespace that holds a type.",
           "type": "string"
         },
 

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -431,14 +431,19 @@
         }
       }
     },
-    "logicalLocationComponent": {
-      "description": "A component of a logical location.",
+    "logicalLocation": {
+      "description": "A logical location of a construct that produced a result.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
 
         "name": {
           "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+
+        "parent": {
+          "description": "Identifies the immediate parent of the construct in which the result occurred. For example, this property might contain the name of a namespace that holds a type.",
           "type": "string"
         },
 
@@ -843,14 +848,8 @@
         },
 
         "logicalLocations": {
-          "description": "A dictionary, each of whose keys specifies a fully qualified logical location such as a type nested within a namespace, and each of whose values is an array of logicalLocationComponent objects.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/logicalLocationComponent"
-            }
-          }
+          "description": "A dictionary, each of whose keys specifies a logical location such as a namespace, type or function.",
+          "$ref": "#/definitions/logicalLocation"
         },
 
         "results": {

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -448,7 +448,7 @@
         },
 
         "kind": {
-          "description": "The type of construct this logicalLocationComponent refers to. Should be one of 'declaration', 'function', 'member', 'module', 'namespace', 'package', 'resource', or 'type', if any of those accurately describe the construct.",
+          "description": "The type of construct this logicalLocationComponent refers to. Should be one of 'function', 'member', 'module', 'namespace', 'package', 'resource', or 'type', if any of those accurately describe the construct.",
           "type": "string"
         }
       }
@@ -849,7 +849,10 @@
 
         "logicalLocations": {
           "description": "A dictionary, each of whose keys specifies a logical location such as a namespace, type or function.",
+          "type": "object",
+          "additionalProperties": {
           "$ref": "#/definitions/logicalLocation"
+          }
         },
 
         "results": {

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -144,11 +144,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         /// A dictionary whose keys are strings specifying a logical location and
         /// whose values provide information about each component of the logical location.
         /// </param>
-        public void WriteLogicalLocations(IDictionary<string, IList<LogicalLocationComponent>> logicalLocationDictionary)
+        public void WriteLogicalLocations(IDictionary<string, LogicalLocation> logicalLocationsDictionary)
         {
-            if (logicalLocationDictionary == null)
+            if (logicalLocationsDictionary == null)
             {
-                throw new ArgumentNullException(nameof(logicalLocationDictionary));
+                throw new ArgumentNullException(nameof(logicalLocationsDictionary));
             }
 
             EnsureInitialized();
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             EnsureStateNotAlreadySet(Conditions.Disposed | Conditions.LogicalLocationsWritten);
 
             _jsonWriter.WritePropertyName("logicalLocations");
-            _serializer.Serialize(_jsonWriter, logicalLocationDictionary, typeof(Dictionary<string, IList<LogicalLocationComponent>>));
+            _serializer.Serialize(_jsonWriter, logicalLocationsDictionary, typeof(Dictionary<string, LogicalLocation>));
 
             _writeConditions |= Conditions.LogicalLocationsWritten;
         }


### PR DESCRIPTION
@lgolding @nguerrera @rtaket 
Convert logicalLocations dictionary to a holder of logcalLocations (each of which identifies a leaf item and its parent).This change looks good as deployed for FxCop and Android Studio. We could consider populating each logical location with the specific delimiter that separates it from its parent. This would both structure the data and allow viewers to reconstruct a fully-qualified path as intended by the producer. It's not strictly necessary thought (particularly as the list of logical location kinds is, by design, very general).