### PR TITLE
Update WebSkim files to reflect changes to nested files. Enable webskim tests.

### DIFF
--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -4,8 +4,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.5.22";       
+        public const string Prerelease = "-developer";                       
+        public const string AssemblyVersion = "1.5.23";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/LocalizedBundleDoubleNesting.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/LocalizedBundleDoubleNesting.sarif
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "4ce4fd0d-570e-453f-a079-e1a6e0cddf73",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "M1001",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "privateNetworkClientServer"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle#/FoodAndDrink_4.0.35.0_x86.appx/AppxManifest.xml",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle": {
+          "mimeType": "application/octet-stream"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle#/FoodAndDrink_4.0.35.0_x86.appx": {
+          "uri": "/FoodAndDrink_4.0.35.0_x86.appx",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle",
+          "mimeType": "application/vns.ms-appx"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle#/FoodAndDrink_4.0.35.0_x86.appx/AppxManifest.xml": {
+          "uri": "/AppxManifest.xml",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/FoodAndDrink_4.0.35.0_x86.appxbundle#/FoodAndDrink_4.0.35.0_x86.appx",
+          "mimeType": "text/xml"
+        }
+      },
+      "rules": {
+        "M1001": {
+          "id": "M1001",
+          "name": "AvoidDangerousCapabilities",
+          "shortDescription": "Avoid use of dangerous application capabilities.",
+          "messageFormats": {
+            "Error": "Avoid use of dangerous application capabilities. Capability: {0}"
+          },
+          "properties": {
+            "tags": ["appx","sdl"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /appx d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\Mod50.Test.Unit\\ModernCopTestData\\Mod50\\CompiledPackages\\FoodAndDrink_4.0.35.0_x86.appxbundle /out .\\LocalizedBundleDoubleNesting.sarif",
+        "startTime": "2016-05-23T19:05:26.975Z",
+        "endTime": "2016-05-23T19:05:33.338Z",
+        "processId": 16000,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromAppX.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromAppX.sarif
@@ -1,0 +1,3402 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "a9538c71-6bfe-4bc8-a713-e66b28e43ef7",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "M1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 4
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 32
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 56
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 68
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 80
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 92
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 104
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 116
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 128
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 140
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 152
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 164
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 176
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 188
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 200
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 212
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 224
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 236
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 248
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 260
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 272
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 284
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 296
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 308
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 320
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 332
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 344
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 356
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 368
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 380
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 392
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 404
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 416
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 428
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 440
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 452
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 464
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 476
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 488
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 500
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 512
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 524
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 536
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 548
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 560
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 572
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 584
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 596
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 608
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 620
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 632
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 644
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 656
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 668
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 680
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 692
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 704
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 712
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 716
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2027",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "microsoft",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "fwlink",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 19
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2045",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "args.setPromise()."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js",
+                "region": {
+                  "startLine": 35,
+                  "startColumn": 326
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx": {
+          "mimeType": "application/vns.ms-appx"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/minified.js": {
+          "uri": "/js/minified.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx#/js/default.js": {
+          "uri": "/js/default.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp.appx",
+          "mimeType": "text/javascript"
+        }
+      },
+      "rules": {
+        "M1003": {
+          "id": "M1003",
+          "name": "DoNotShipObfuscatedCode",
+          "shortDescription": "Do not ship obfuscated or minified code.",
+          "messageFormats": {
+            "Error": "Do not ship obfuscated or minified code."
+          },
+          "properties": {
+            "tags": ["appx","sdl"]
+          }
+        },
+        "JS2021": {
+          "id": "JS2021",
+          "name": "SeparateBinaryOperatorArgumentsWithSpaces",
+          "shortDescription": "Binary and ternary operators should be separated from operands with spaces.",
+          "messageFormats": {
+            "Warning": "All binary and ternary operators (with the exception of the '.' operator) should be separated from operands with spaces."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS3085": {
+          "id": "JS3085",
+          "name": "VariableDeclaredMultipleTimes",
+          "shortDescription": "Do not declare multiple variables with an identical name in the same scope.",
+          "messageFormats": {
+            "Error": "Variable '{0}' was previously defined in this scope. {1}"
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS1003": {
+          "id": "JS1003",
+          "name": "SemanticAnalysisHalted",
+          "shortDescription": "Semantic analysis halted unexpectedly due to errors processing target or reference files.",
+          "messageFormats": {
+            "Error": "Semantic analysis halted unexpectedly due to errors processing target or reference files."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS2027": {
+          "id": "JS2027",
+          "name": "PunctuateCommentsCorrectly",
+          "shortDescription": "Provide punctuation at the ends of sentences for multiline comments.",
+          "messageFormats": {
+            "Warning": "Provide punctuation at the ends of sentences for multiline comments.  If this block is commented code, use '////' to open the comment line."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2073": {
+          "id": "JS2073",
+          "name": "CommentIsMisspelled",
+          "shortDescription": "Review text for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' found in comment text is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment. If this is a reference to a DOM or other api which can’t be recased, wrap the term in apostrophes to resolve the warning, e.g., 'onmouseover'."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2074": {
+          "id": "JS2074",
+          "name": "IdentifierNameIsMisspelled",
+          "shortDescription": "Review identifier name for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' in {1} name '{2}' is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2045": {
+          "id": "JS2045",
+          "name": "ReviewEmptyBlocks",
+          "shortDescription": "Review empty blocks for correctness issues.",
+          "messageFormats": {
+            "Warning": "Review empty blocks for correctness issues."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /appx d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\WebRules.Test.Unit\\ModernCopTestData\\WebRules_PackageRules\\MinificationRuleApp.appx /out .\\NestedLocationsFromAppX.sarif",
+        "startTime": "2016-05-23T19:05:19.100Z",
+        "endTime": "2016-05-23T19:05:20.772Z",
+        "processId": 34508,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryNoTrailingSlash.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryNoTrailingSlash.sarif
@@ -1,0 +1,3402 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "2c5e090a-95b4-47b0-b90f-d842bc3b92a6",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "M1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 4
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 32
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 56
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 68
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 80
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 92
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 104
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 116
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 128
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 140
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 152
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 164
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 176
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 188
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 200
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 212
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 224
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 236
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 248
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 260
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 272
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 284
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 296
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 308
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 320
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 332
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 344
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 356
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 368
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 380
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 392
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 404
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 416
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 428
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 440
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 452
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 464
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 476
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 488
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 500
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 512
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 524
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 536
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 548
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 560
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 572
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 584
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 596
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 608
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 620
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 632
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 644
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 656
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 668
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 680
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 692
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 704
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 712
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 716
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2027",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "microsoft",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "fwlink",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 19
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2045",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "args.setPromise()."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 35,
+                  "startColumn": 326
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/": {
+          "mimeType": "application/x-directory"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js": {
+          "uri": "js/minified.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js": {
+          "uri": "js/default.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/",
+          "mimeType": "text/javascript"
+        }
+      },
+      "rules": {
+        "M1003": {
+          "id": "M1003",
+          "name": "DoNotShipObfuscatedCode",
+          "shortDescription": "Do not ship obfuscated or minified code.",
+          "messageFormats": {
+            "Error": "Do not ship obfuscated or minified code."
+          },
+          "properties": {
+            "tags": ["appx","sdl"]
+          }
+        },
+        "JS2021": {
+          "id": "JS2021",
+          "name": "SeparateBinaryOperatorArgumentsWithSpaces",
+          "shortDescription": "Binary and ternary operators should be separated from operands with spaces.",
+          "messageFormats": {
+            "Warning": "All binary and ternary operators (with the exception of the '.' operator) should be separated from operands with spaces."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS3085": {
+          "id": "JS3085",
+          "name": "VariableDeclaredMultipleTimes",
+          "shortDescription": "Do not declare multiple variables with an identical name in the same scope.",
+          "messageFormats": {
+            "Error": "Variable '{0}' was previously defined in this scope. {1}"
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS1003": {
+          "id": "JS1003",
+          "name": "SemanticAnalysisHalted",
+          "shortDescription": "Semantic analysis halted unexpectedly due to errors processing target or reference files.",
+          "messageFormats": {
+            "Error": "Semantic analysis halted unexpectedly due to errors processing target or reference files."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS2027": {
+          "id": "JS2027",
+          "name": "PunctuateCommentsCorrectly",
+          "shortDescription": "Provide punctuation at the ends of sentences for multiline comments.",
+          "messageFormats": {
+            "Warning": "Provide punctuation at the ends of sentences for multiline comments.  If this block is commented code, use '////' to open the comment line."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2073": {
+          "id": "JS2073",
+          "name": "CommentIsMisspelled",
+          "shortDescription": "Review text for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' found in comment text is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment. If this is a reference to a DOM or other api which can’t be recased, wrap the term in apostrophes to resolve the warning, e.g., 'onmouseover'."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2074": {
+          "id": "JS2074",
+          "name": "IdentifierNameIsMisspelled",
+          "shortDescription": "Review identifier name for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' in {1} name '{2}' is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2045": {
+          "id": "JS2045",
+          "name": "ReviewEmptyBlocks",
+          "shortDescription": "Review empty blocks for correctness issues.",
+          "messageFormats": {
+            "Warning": "Review empty blocks for correctness issues."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /appx d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\WebRules.Test.Unit\\ModernCopTestData\\WebRules_PackageRules\\MinificationRuleApp /out .\\NestedLocationsFromDirectoryNoTrailingSlash.sarif",
+        "startTime": "2016-05-23T19:05:21.099Z",
+        "endTime": "2016-05-23T19:05:22.682Z",
+        "processId": 16780,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryTrailingSlash.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/NestedLocationsFromDirectoryTrailingSlash.sarif
@@ -1,0 +1,3402 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "8aaa47b4-1a62-4fdb-b975-ca3d7f3fe5cb",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "M1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 4
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 20
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 16
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 32
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 28
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 40
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 56
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 52
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 68
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 64
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 80
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 76
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 92
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 88
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 104
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 100
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 116
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 112
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 128
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 124
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 140
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 136
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 152
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 148
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 164
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 160
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 176
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 172
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 188
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 184
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 200
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 196
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 212
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 208
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 224
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 220
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 236
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 232
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 248
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 244
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 260
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 256
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 272
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 268
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 284
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 280
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 296
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 292
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 308
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 304
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 320
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 316
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 332
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 328
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 344
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 340
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 356
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 352
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 368
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 364
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 380
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 376
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 392
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 388
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 404
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 400
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 416
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 412
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 428
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 424
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 440
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 436
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 452
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 448
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 464
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 460
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 476
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 472
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 488
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 484
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 500
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 496
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 512
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 508
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 524
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 520
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 536
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 532
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 548
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 544
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 560
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 556
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 572
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 568
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 584
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 580
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 596
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 592
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 608
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 604
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 620
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 616
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 632
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 628
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 644
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 640
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 656
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 652
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 668
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 664
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 680
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 676
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 692
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 688
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 704
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "apple",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 712
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 700
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2021",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 716
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2027",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "microsoft",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 5
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "fwlink",
+              "http://go.microsoft.com/fwlink/?LinkId=232509"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 19
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2045",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "args.setPromise()."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js",
+                "region": {
+                  "startLine": 35,
+                  "startColumn": 326
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/": {
+          "mimeType": "application/x-directory"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/minified.js": {
+          "uri": "js/minified.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/#js/default.js": {
+          "uri": "js/default.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_PackageRules/MinificationRuleApp/",
+          "mimeType": "text/javascript"
+        }
+      },
+      "rules": {
+        "M1003": {
+          "id": "M1003",
+          "name": "DoNotShipObfuscatedCode",
+          "shortDescription": "Do not ship obfuscated or minified code.",
+          "messageFormats": {
+            "Error": "Do not ship obfuscated or minified code."
+          },
+          "properties": {
+            "tags": ["appx","sdl"]
+          }
+        },
+        "JS2021": {
+          "id": "JS2021",
+          "name": "SeparateBinaryOperatorArgumentsWithSpaces",
+          "shortDescription": "Binary and ternary operators should be separated from operands with spaces.",
+          "messageFormats": {
+            "Warning": "All binary and ternary operators (with the exception of the '.' operator) should be separated from operands with spaces."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS3085": {
+          "id": "JS3085",
+          "name": "VariableDeclaredMultipleTimes",
+          "shortDescription": "Do not declare multiple variables with an identical name in the same scope.",
+          "messageFormats": {
+            "Error": "Variable '{0}' was previously defined in this scope. {1}"
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS1003": {
+          "id": "JS1003",
+          "name": "SemanticAnalysisHalted",
+          "shortDescription": "Semantic analysis halted unexpectedly due to errors processing target or reference files.",
+          "messageFormats": {
+            "Error": "Semantic analysis halted unexpectedly due to errors processing target or reference files."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS2027": {
+          "id": "JS2027",
+          "name": "PunctuateCommentsCorrectly",
+          "shortDescription": "Provide punctuation at the ends of sentences for multiline comments.",
+          "messageFormats": {
+            "Warning": "Provide punctuation at the ends of sentences for multiline comments.  If this block is commented code, use '////' to open the comment line."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2073": {
+          "id": "JS2073",
+          "name": "CommentIsMisspelled",
+          "shortDescription": "Review text for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' found in comment text is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment. If this is a reference to a DOM or other api which can’t be recased, wrap the term in apostrophes to resolve the warning, e.g., 'onmouseover'."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2074": {
+          "id": "JS2074",
+          "name": "IdentifierNameIsMisspelled",
+          "shortDescription": "Review identifier name for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' in {1} name '{2}' is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS2045": {
+          "id": "JS2045",
+          "name": "ReviewEmptyBlocks",
+          "shortDescription": "Review empty blocks for correctness issues.",
+          "messageFormats": {
+            "Warning": "Review empty blocks for correctness issues."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /appx d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\WebRules.Test.Unit\\ModernCopTestData\\WebRules_PackageRules\\MinificationRuleApp /out .\\NestedLocationsFromDirectoryTrailingSlash.sarif",
+        "startTime": "2016-05-23T19:05:23.017Z",
+        "endTime": "2016-05-23T19:05:24.536Z",
+        "processId": 17828,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/RelatedLocations.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/RelatedLocations.sarif
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "82d9ee25-84c0-4758-99e6-084352d50fe7",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "JS2085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Strict mode was not set for at least one function in this file. Consider resolving using this violation by using the JavaScript module pattern to wrap all code contained in the file within a function expression. Enable strict mode as the first statement of the containing function. To disable enforcement of the module pattern and permit setting strict mode at global file level, pass /setting:JS2085.EnableStrictMode.EnforceModulePattern=false on the command-line."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_JavaScriptRules/Semantic/VariableDeclaredMultipleTimes.js",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3085",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "repeated",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_JavaScriptRules/Semantic/VariableDeclaredMultipleTimes.js",
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 9
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_JavaScriptRules/Semantic/VariableDeclaredMultipleTimes.js",
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 9
+                }
+              },
+              "message": "The previous declaration was here."
+            }
+          ]
+        },
+        {
+          "ruleId": "JS1003",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_JavaScriptRules/Semantic/VariableDeclaredMultipleTimes.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/WebRules.Test.Unit/ModernCopTestData/WebRules_JavaScriptRules/Semantic/VariableDeclaredMultipleTimes.js": {
+          "mimeType": "text/javascript"
+        }
+      },
+      "rules": {
+        "JS2085": {
+          "id": "JS2085",
+          "name": "EnableStrictMode",
+          "shortDescription": "Always enable strict mode when possible.",
+          "messageFormats": {
+            "Error": "Code should run in strict mode wherever possible. {0}"
+          },
+          "properties": {
+            "tags": ["js","sdl"]
+          }
+        },
+        "JS3085": {
+          "id": "JS3085",
+          "name": "VariableDeclaredMultipleTimes",
+          "shortDescription": "Do not declare multiple variables with an identical name in the same scope.",
+          "messageFormats": {
+            "Error": "Variable '{0}' was previously defined in this scope. {1}"
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS1003": {
+          "id": "JS1003",
+          "name": "SemanticAnalysisHalted",
+          "shortDescription": "Semantic analysis halted unexpectedly due to errors processing target or reference files.",
+          "messageFormats": {
+            "Error": "Semantic analysis halted unexpectedly due to errors processing target or reference files."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /file d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\WebRules.Test.Unit\\ModernCopTestData\\WebRules_PackageRules\\..\\WebRules_JavaScriptRules\\Semantic\\VariableDeclaredMultipleTimes.js /out .\\RelatedLocations.sarif",
+        "startTime": "2016-05-23T19:05:17.450Z",
+        "endTime": "2016-05-23T19:05:18.797Z",
+        "processId": 26844,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/SimpleBundleDoubleNesting.sarif
+++ b/src/Sarif.FunctionalTests/DirectProducerTestData/WebSkim/SimpleBundleDoubleNesting.sarif
@@ -1,0 +1,2079 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "id": "6cdc2173-c8e6-464c-bbae-260aef3eeb24",
+      "tool": {
+        "name": "ModernCop",
+        "fullName": "mod50 7.0.7000.0",
+        "version": "7.0.7000.0",
+        "semanticVersion": "7.0.7000",
+        "fileVersion": "7.0.20811.0",
+        "language": "en-US",
+        "properties": {
+          "CompanyName": "Microsoft Corporation"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "M1001",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "enterpriseAuthentication"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/AppxManifest.xml",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "M1001",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "privateNetworkClientServer"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/AppxManifest.xml",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "M1001",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "sharedUserCertificates"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/AppxManifest.xml",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1080",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "img",
+              "data-win-bind",
+              "id, class, followed by all other attributes in sorted order."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.html",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 861
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1080",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "img",
+              "data-win-bind",
+              "id, class, followed by all other attributes in sorted order."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.html",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1156
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1088",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/default.html",
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1080",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "img",
+              "height",
+              "id, class, followed by all other attributes in sorted order."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.html",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1411
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1080",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "div",
+              "data-win-options",
+              "id, class, followed by all other attributes in sorted order."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.html",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 3383
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "WEB1080",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "img",
+              "data-win-bind",
+              "id, class, followed by all other attributes in sorted order."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.html",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 3609
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Object.prototype",
+              "createGrouped"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js",
+                "region": {
+                  "startLine": 18,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Object.prototype",
+              "dispose"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js",
+                "region": {
+                  "startLine": 36,
+                  "startColumn": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js",
+                "region": {
+                  "startLine": 46,
+                  "startColumn": 21
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Object.prototype",
+              "getAt"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js",
+                "region": {
+                  "startLine": 47,
+                  "startColumn": 36
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3057",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "string",
+              "Object"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js",
+                "region": {
+                  "startLine": 48,
+                  "startColumn": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "nav",
+              "variable",
+              "nav"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Application",
+              "sessionState"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "util",
+              "variable",
+              "util"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3058",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Data"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 21,
+                  "startColumn": 33
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3047",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 24,
+                  "startColumn": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 36,
+                  "startColumn": 63
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3057",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "string",
+              "Object"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 37,
+                  "startColumn": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 40,
+                  "startColumn": 61
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3057",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "string",
+              "Object"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js",
+                "region": {
+                  "startLine": 42,
+                  "startColumn": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2027",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "microsoft",
+              "http://go.microsoft.com/fwlink/?LinkID=286574"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "fwlink",
+              "http://go.microsoft.com/fwlink/?LinkID=286574"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 6,
+                  "startColumn": 17
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "nav",
+              "variable",
+              "nav"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "sched",
+              "variable",
+              "sched"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Utilities",
+              "Scheduler"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 9,
+                  "startColumn": 33
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Application.addEventListener",
+              "2"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 12,
+                  "startColumn": 8
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 12,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2045",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 11
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Application",
+              "sessionState"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 22,
+                  "startColumn": 31
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Object.prototype",
+              "current"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.UI.processAll",
+              "0"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 27,
+                  "startColumn": 23
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Promise",
+              "then"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 27,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3047",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 39,
+                  "startColumn": 3
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Application",
+              "insecureFunction"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 39,
+                  "startColumn": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3058",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "input"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 39,
+                  "startColumn": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2001",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "window.eval",
+              ""
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 41,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 44,
+                  "startColumn": 22
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Application",
+              "sessionState"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 49,
+                  "startColumn": 13
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2073",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "suspended, call args.setPromise()."
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js",
+                "region": {
+                  "startLine": 54,
+                  "startColumn": 121
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "nav",
+              "variable",
+              "nav"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Class.define",
+              "2"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 42
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "<anonymous object>",
+              "_createPageElement"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 11,
+                  "startColumn": 48
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Navigation.removeEventListener",
+              "2"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 21,
+                  "startColumn": 26
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2023",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 25,
+                  "startColumn": 46
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that",
+              "_navigating"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 25,
+                  "startColumn": 66
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2023",
+          "level": "warning",
+          "formattedRuleMessage": {
+            "formatId": "Warning"
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 26,
+                  "startColumn": 46
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that",
+              "_navigated"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 26,
+                  "startColumn": 65
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that",
+              "_resized"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 28,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3058",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Application"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 30,
+                  "startColumn": 17
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Promise",
+              "as"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 35,
+                  "startColumn": 55
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Viewstate",
+              "member",
+              "_lastViewstate"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 36,
+                  "startColumn": 15
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageControl",
+              "pageElement"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 40,
+                  "startColumn": 52
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageControl",
+              "pageElement"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 40,
+                  "startColumn": 72
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageElement",
+              "_element"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 45,
+                  "startColumn": 52
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "<anonymous object>",
+              "_disposed"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 50,
+                  "startColumn": 30
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Utilities",
+              "disposeSubTree"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 55,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "<anonymous object>",
+              "_eventHandlerRemover"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 56,
+                  "startColumn": 46
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "window",
+              "getComputedStyle"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 65,
+                  "startColumn": 55
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3057",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageControl",
+              "boolean"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 76,
+                  "startColumn": 42
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageControl",
+              "getAnimationElements"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 76,
+                  "startColumn": 62
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageControl",
+              "getAnimationElements"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 77,
+                  "startColumn": 49
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "pageElement",
+              "style"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 83,
+                  "startColumn": 38
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.UI.Animation.enterPage",
+              "1"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 84,
+                  "startColumn": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Promise",
+              "done"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 84,
+                  "startColumn": 80
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 88,
+                  "startColumn": 28
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "Object.prototype",
+              "appendChild"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 90,
+                  "startColumn": 35
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.Promise",
+              "as"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 95,
+                  "startColumn": 65
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3053",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "WinJS.UI.Pages.render",
+              "3"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 96,
+                  "startColumn": 46
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageElement",
+              "winControl"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 100,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageElement",
+              "winControl"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 101,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageElement",
+              "winControl"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 102,
+                  "startColumn": 44
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageElement",
+              "winControl"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 104,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageElement",
+              "parentNode"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 106,
+                  "startColumn": 36
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS2074",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "args",
+              "parameter",
+              "args"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 115,
+                  "startColumn": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3057",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageControl",
+              "boolean"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 116,
+                  "startColumn": 42
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageControl",
+              "updateLayout"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 116,
+                  "startColumn": 62
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3092",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": [
+              "that.pageControl",
+              "updateLayout"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js",
+                "region": {
+                  "startLine": 117,
+                  "startColumn": 42
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "JS3054",
+          "level": "error",
+          "formattedRuleMessage": {
+            "formatId": "Error",
+            "arguments": []
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/data.js",
+                "region": {
+                  "startLine": 44,
+                  "startColumn": 5
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "files": {
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle": {
+          "mimeType": "application/octet-stream"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx": {
+          "uri": "/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle",
+          "mimeType": "application/vns.ms-appx"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/AppxManifest.xml": {
+          "uri": "/AppxManifest.xml",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/xml"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.html": {
+          "uri": "/pages/section/section.html",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/html"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/default.html": {
+          "uri": "/default.html",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/html"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.html": {
+          "uri": "/pages/hub/hub.html",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/html"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/section/section.js": {
+          "uri": "/pages/section/section.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/pages/hub/hub.js": {
+          "uri": "/pages/hub/hub.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/default.js": {
+          "uri": "/js/default.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/navigator.js": {
+          "uri": "/js/navigator.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/javascript"
+        },
+        "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx/js/data.js": {
+          "uri": "/js/data.js",
+          "parentKey": "file:///d:/src/SecDevTools/Main/src/ModernCop/Source/Mod50.Test.Unit/ModernCopTestData/Mod50/CompiledPackages/SimpleJSApp.appxbundle#/SimpleJSApp_1.0.0.1_AnyCPU.appx",
+          "mimeType": "text/javascript"
+        }
+      },
+      "rules": {
+        "M1001": {
+          "id": "M1001",
+          "name": "AvoidDangerousCapabilities",
+          "shortDescription": "Avoid use of dangerous application capabilities.",
+          "messageFormats": {
+            "Error": "Avoid use of dangerous application capabilities. Capability: {0}"
+          },
+          "properties": {
+            "tags": ["appx","sdl"]
+          }
+        },
+        "WEB1080": {
+          "id": "WEB1080",
+          "name": "AttributesAreNotOrderedCorrectly",
+          "shortDescription": "The tag attribute values are not ordered correctly.",
+          "messageFormats": {
+            "Error": "The <{0}> tag attributes are not ordered as specified on the analysis command-line. This violation was prompted by the '{1}' attribute. As currently configured, attributes should appear in the following order: {2}"
+          },
+          "properties": {
+            "tags": ["html"]
+          }
+        },
+        "WEB1088": {
+          "id": "WEB1088",
+          "name": "IframeHasInvalidSandboxAttribute",
+          "shortDescription": "The <Iframe> tag has a missing or invalid sandbox attribute value.",
+          "messageFormats": {
+            "Error": "The <iframe>  tag should have a 'sandbox' attribute set with at least one valid option ('allow-forms', 'allow-same-origin', 'allow-scripts', or 'allow-top-navigation'). Setting both 'allow-scripts' and 'allow-same-origin' for a single <iframe> tag is not advised."
+          },
+          "properties": {
+            "tags": ["html","sdl"]
+          }
+        },
+        "JS3092": {
+          "id": "JS3092",
+          "name": "DeclarePropertiesBeforeUse",
+          "shortDescription": "Declare properties before accessing them.",
+          "messageFormats": {
+            "Error": "'{0}' does not contain a definition for '{1}'. Declare this property explicitly before using it."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS2074": {
+          "id": "JS2074",
+          "name": "IdentifierNameIsMisspelled",
+          "shortDescription": "Review identifier name for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' in {1} name '{2}' is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS3057": {
+          "id": "JS3057",
+          "name": "AvoidImplicitTypeCoercion",
+          "shortDescription": "Avoid calls that result in implicit type coercion.",
+          "messageFormats": {
+            "Error": "Call results in an implicit conversion of type '{0}' to '{1}'."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS3058": {
+          "id": "JS3058",
+          "name": "DeclareVariablesBeforeUse",
+          "shortDescription": "Declare variables explicitly before use.",
+          "messageFormats": {
+            "Error": "Variable '{0}' undeclared. This error must be resolved before further semantic analysis can be done."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS3047": {
+          "id": "JS3047",
+          "name": "ProvideExplicitSemicolons",
+          "shortDescription": "Provide explicit semicolons.",
+          "messageFormats": {
+            "Error": "Provide an explicit semicolon."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2027": {
+          "id": "JS2027",
+          "name": "PunctuateCommentsCorrectly",
+          "shortDescription": "Provide punctuation at the ends of sentences for multiline comments.",
+          "messageFormats": {
+            "Warning": "Provide punctuation at the ends of sentences for multiline comments.  If this block is commented code, use '////' to open the comment line."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2073": {
+          "id": "JS2073",
+          "name": "CommentIsMisspelled",
+          "shortDescription": "Review text for possible misspelling.",
+          "messageFormats": {
+            "Error": "The term '{0}' found in comment text is not recognized. Correct the misspelling, if it is one, provide an alternate term, or add the term to the custom dictionary or as an in-source comment. If this is a reference to a DOM or other api which can’t be recased, wrap the term in apostrophes to resolve the warning, e.g., 'onmouseover'."
+          },
+          "properties": {
+            "tags": ["spelling","js"]
+          }
+        },
+        "JS3053": {
+          "id": "JS3053",
+          "name": "IncorrectNumberOfArguments",
+          "shortDescription": "Incorrect number of arguments in function call.",
+          "messageFormats": {
+            "Error": "Function '{0}' does not take {1} arguments."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        },
+        "JS2045": {
+          "id": "JS2045",
+          "name": "ReviewEmptyBlocks",
+          "shortDescription": "Review empty blocks for correctness issues.",
+          "messageFormats": {
+            "Warning": "Review empty blocks for correctness issues."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS2001": {
+          "id": "JS2001",
+          "name": "DoNotUseEval",
+          "shortDescription": "Do not use the 'eval' function or its functional equivalents.",
+          "messageFormats": {
+            "Error": "Do not use the 'eval' function or its functional equivalents, which obscure code function, complicate tooling, and are a source of non-performant and insecure code patterns. This violation occurred due to use of '{0}' detected in source. {1}"
+          },
+          "properties": {
+            "tags": ["js","sdl"]
+          }
+        },
+        "JS2023": {
+          "id": "JS2023",
+          "name": "UseDoubleQuotesForStringLiterals",
+          "shortDescription": "Use double quotes where possible to declare string literals.",
+          "messageFormats": {
+            "Warning": "Use double quotes where possible to declare string literals. For string literals that represent HTML snippets, encapsulate embedded attribute names using single quotes."
+          },
+          "properties": {
+            "tags": ["js"]
+          }
+        },
+        "JS3054": {
+          "id": "JS3054",
+          "name": "NotAllCodePathsReturnValue",
+          "shortDescription": "Not all code paths return a value.",
+          "messageFormats": {
+            "Error": "Not all code paths return a value."
+          },
+          "properties": {
+            "tags": ["js","semantic"]
+          }
+        }
+      },
+      "invocation": {
+        "commandLine": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe  analyze /appx d:\\src\\SecDevTools\\Main\\src\\ModernCop\\Source\\Mod50.Test.Unit\\ModernCopTestData\\Mod50\\CompiledPackages\\SimpleJSApp.appxbundle /out .\\SimpleBundleDoubleNesting.sarif",
+        "startTime": "2016-05-23T19:05:24.839Z",
+        "endTime": "2016-05-23T19:05:26.636Z",
+        "processId": 25964,
+        "fileName": "D:\\src\\SecDevTools\\Main\\bin\\x64\\Debug\\ModernCop\\mod50.exe",
+        "workingDirectory": "d:\\src\\sarif-sdk\\src\\Sarif.FunctionalTests\\DirectProducerTestData\\WebSkim"
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -1520,4 +1520,5 @@
   <Target Name="CopySchema" AfterTargets="Build">
     <Copy SourceFiles="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json" DestinationFolder="$(OutDir)" />
   </Target>
+  <ProjectExtensions />
 </Project>

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -4,9 +4,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "-beta";                       
-        public const string AssemblyVersion = "1.5.22";       
-        public const string FileVersion = "1.5.22" + ".0";    
+        public const string Prerelease = "-developer";                       
+        public const string AssemblyVersion = "1.5.23";       
+        public const string FileVersion = "1.5.23" + ".0";    
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          
  }                                                                             


### PR DESCRIPTION
@lgolding 

webskim updated with all SDK changes. Look at WebSkim population of nested files, the deepest tool usage we have for this concept. WebSkim in one case is analyzing an appx bundle, that includes an appx, that includes many analysis targets.