### PR TITLE
Use new version of JSchema validator that produces SARIF

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -96,6 +96,12 @@ if "%ERRORLEVEL%" NEQ "0" (
 goto ExitFailed
 )
 
+src\packages\xunit.runner.console.2.1.0\tools\xunit.console.x86.exe bld\bin\Sarif.ValidationTests\AnyCPU_Release\Sarif.ValidationTests.dll
+
+if "%ERRORLEVEL%" NEQ "0" (
+goto ExitFailed
+)
+
 goto Exit
 
 :ExitFailed

--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -29,10 +29,6 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Json.Schema, Version=0.37.0.0, Culture=neutral, PublicKeyToken=7aebd41ac4801eb9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Json.Schema.0.37.0\lib\net45\Microsoft.Json.Schema.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
@@ -71,7 +67,6 @@
   <ItemGroup>
     <Compile Include="SarifConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SarifValidatorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ConverterTestData\FxCop\FxCopProjectAllMessageStates.fxcop">

--- a/src/Sarif.FunctionalTests/packages.config
+++ b/src/Sarif.FunctionalTests/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.2.1" targetFramework="net452" />
-  <package id="Microsoft.Json.Schema" version="0.37.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />

--- a/src/Sarif.Sdk.sln
+++ b/src/Sarif.Sdk.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{AFC8AFD8
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PREfastXmlSarifConverter", "PREfastXmlSarifConverter\PREfastXmlSarifConverter.vcxproj", "{F6727C72-C40C-4A6E-BAE0-23B4B5FE7DB1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarif.ValidationTests", "Sarif.ValidationTests\Sarif.ValidationTests.csproj", "{A35E38C4-8189-43C0-BA09-8D05B8EF0791}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,18 @@ Global
 		{F6727C72-C40C-4A6E-BAE0-23B4B5FE7DB1}.Release|x64.Build.0 = Release|x64
 		{F6727C72-C40C-4A6E-BAE0-23B4B5FE7DB1}.Release|x86.ActiveCfg = Release|Win32
 		{F6727C72-C40C-4A6E-BAE0-23B4B5FE7DB1}.Release|x86.Build.0 = Release|Win32
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|x64.Build.0 = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Debug|x86.Build.0 = Debug|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|x64.ActiveCfg = Release|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|x64.Build.0 = Release|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|x86.ActiveCfg = Release|Any CPU
+		{A35E38C4-8189-43C0-BA09-8D05B8EF0791}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Sarif.ValidationTests/Properties/AssemblyInfo.cs
+++ b/src/Sarif.ValidationTests/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using System.Reflection;
 
-[assembly: AssemblyTitle("Static Analysis Results Interchange Format Library Functional Tests")]
+[assembly: AssemblyTitle("Static Analysis Results Interchange Format Library Validation Tests")]

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{A35E38C4-8189-43C0-BA09-8D05B8EF0791}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.CodeAnalysis.Sarif.ValidationTests</RootNamespace>
+    <AssemblyName>Sarif.ValidationTests</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\TestKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
+  <ItemGroup>
+    <Reference Include="Microsoft.Json.Schema, Version=0.38.0.0, Culture=neutral, PublicKeyToken=7aebd41ac4801eb9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Json.Schema.0.38.0\lib\net451\Microsoft.Json.Schema.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sarif, Version=1.5.24.0, Culture=neutral, PublicKeyToken=06c70c7db0c6cd6b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sarif.Sdk.1.5.24-beta\lib\net45\Sarif.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SarifValidatorTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="CopyTestData" AfterTargets="Build">
+    <ItemGroup>
+      <ConverterTestData Include="$(SolutionDir)\Sarif.FunctionalTests\ConverterTestData\**\*.sarif" />
+      <DirectProducerTestData Include="$(SolutionDir)\Sarif.FunctionalTests\DirectProducerTestData\**\*.sarif" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ConverterTestData)" DestinationFolder="$(OutDir)ConverterTestData\%(RecursiveDir)" />
+    <Copy SourceFiles="@(DirectProducerTestData)" DestinationFolder="$(OutDir)DirectProducerTestData\%(RecursiveDir)" />
+    <Copy SourceFiles="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json" DestinationFolder="$(OutDir)" />
+  </Target>
+</Project>

--- a/src/Sarif.ValidationTests/SarifValidatorTests.cs
+++ b/src/Sarif.ValidationTests/SarifValidatorTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using FluentAssertions;
 
 using Microsoft.Json.Schema;
+using Microsoft.Json.Schema.Sarif;
 using Microsoft.Json.Schema.Validation;
 
 using Xunit;
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             _jsonSchemaFilePath = Path.Combine(Environment.CurrentDirectory, JsonSchemaFile);
             string schemaText = File.ReadAllText(JsonSchemaFile);
-            _schema = SchemaReader.ReadSchema(schemaText);
+            _schema = SchemaReader.ReadSchema(schemaText, JsonSchemaFile);
         }
 
         [Theory]
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string instanceText = File.ReadAllText(inputFile);
             var validator = new Validator(_schema);
 
-            string[] errors = validator.Validate(instanceText);
+            Result[] errors = validator.Validate(instanceText, inputFile);
 
             // Test errors.Count(), rather than errors.Should().BeEmpty, because the latter
             // produces a less clear error message: it calls ToString on each member of
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string instanceText = File.ReadAllText(inputFile);
             var validator = new Validator(_schema);
 
-            string[] errors = validator.Validate(instanceText);
+            Result[] errors = validator.Validate(instanceText, inputFile);
 
             // Test errors.Count(), rather than errors.Should().BeEmpty, because the latter
             // produces a less clear error message: it calls ToString on each member of
@@ -110,13 +111,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
         }
 
-        private string FailureReason(string[] errors)
+        private string FailureReason(Result[] errors)
         {
             var sb = new StringBuilder("file should be valid, but the following errors were found:\n");
 
             foreach (var error in errors)
             {
-                sb.AppendLine(error);
+                sb.AppendLine(error.FormatForVisualStudio(RuleFactory.GetRuleFromRuleId(error.RuleId)));
             }
 
             return sb.ToString();

--- a/src/Sarif.ValidationTests/packages.config
+++ b/src/Sarif.ValidationTests/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net451" />
+  <package id="Microsoft.Json.Schema" version="0.38.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Sarif.Sdk" version="1.5.24-beta" targetFramework="net451" />
+  <package id="xunit" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
Upgrade to Json.Schema 0.38.0, in which the validator returns an array of SARIF `Result` objects rather than an array of formatted messages.

This induces a circular dependency in the FunctionalTests project (which, until now, has included the validation tests). FunctionalTests has a project reference to the version of Sarif.dll being built (say, 1.5.25). But FunctionalTests also has a NuGet reference to Json.Schema, which in turn was built by taking a NuGet reference to the *published* version of Sarif.Sdk (say 1.5.24). The two versions of Sarif.dll can't coexist in the same project.

To break this dependency, we move the validation tests into their own project. This project does *not* have a project dependency on Sarif.dll. Instead it has NuGet references both to Json.Schema, and to the matching version of Sarif.Sdk. (We need the explicit NuGet reference to Sarif.Sdk, even though Json.Schema's NuGet package declares a dependency on it, because the validation tests directly use SARIF types such as `Result`.)

It is ok to have the validator tests depend on an older version of Sarif.Sdk because these tests are not (directly) testing the behavior of the SARIF APIs. Rather, they are verifying that the files in the TestData directory conform to the most recent version of the SARIF schema. They happen to do so by creating SARIF `Result` objects. The tests don't care if the `Result` objects don't have the newest "shape"; they just care that the right number of them are produced.

And the reason for doing all of this is so that the SARIF validator command line tool (which is built around the validator object from Json.Schema) can create SARIF output by serializing the `Result` objects to a file.

@michaelcfanning 