### PR TITLE
Validated if "result" parameter was null.

### DIFF
--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -70,6 +70,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void Log(IRule rule, Result result)
         {
+            if (result == null)
+            {
+                throw new ArgumentNullException("result");
+            }
+
             string message = result.GetMessageText(rule, concise: false);
 
             // TODO we need better retrieval for locations than these defaults

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (result == null)
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
             string message = result.GetMessageText(rule, concise: false);


### PR DESCRIPTION
@jericahuang @lgolding 