### PR TITLE
Validate dependencies

### DIFF
--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
-    <Reference Include="Microsoft.Json.Schema, Version=0.42.0.0, Culture=neutral, PublicKeyToken=7aebd41ac4801eb9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Json.Schema.0.42.0\lib\net451\Microsoft.Json.Schema.dll</HintPath>
+    <Reference Include="Microsoft.Json.Schema, Version=0.43.0.0, Culture=neutral, PublicKeyToken=7aebd41ac4801eb9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Json.Schema.0.43.0\lib\net451\Microsoft.Json.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Sarif.ValidationTests/packages.config
+++ b/src/Sarif.ValidationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.2.1" targetFramework="net451" />
-  <package id="Microsoft.Json.Schema" version="0.42.0" targetFramework="net451" />
+  <package id="Microsoft.Json.Schema" version="0.43.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Sarif.Sdk" version="1.5.24-beta" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -194,7 +194,11 @@
           }
         }
       },
-      "required": [ "uri", "replacements" ]
+
+      "required": [ "uri", "replacements" ],
+      "dependencies": {
+        "uriBaseId": [ "uri" ]
+      }
     },
     "file": {
       "description": "A single file. In some cases, this file might be nested within another file.",
@@ -261,6 +265,10 @@
             }
           }
         }
+      },
+
+      "dependencies": {
+        "uriBaseId": [ "uri" ]
       }
     },
     "fix": {
@@ -553,7 +561,7 @@
           "type": "string",
           "format": "uri"
         },
-        
+
         "uriBaseId": {
           "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
           "type": "string"
@@ -564,7 +572,11 @@
           "$ref": "#/definitions/region"
         }
       },
-      "required": [ "uri" ]
+
+      "required": [ "uri" ],
+      "dependencies": {
+        "uriBaseId": [ "uri" ]
+      }
     },
     "region": {
       "description": "A region within a file where a result was detected.",
@@ -1050,7 +1062,12 @@
         }
       },
 
-      "required": ["fullyQualifiedLogicalName"]
+      "required": [ "fullyQualifiedLogicalName" ],
+      "dependencies": {
+        "uriBaseId": [ "uri" ],
+        "line": [ "uri" ],
+        "column": [ "line" ]
+      }
     },
     "tool": {
       "description": "The analysis tool that was run.",


### PR DESCRIPTION
Upgrade to JSchema 0.43.0, which validates the JSON Schema "dependencies" property. Add appropriate property dependencies to the schema to take advantage of it.

@michaelcfanning 