### PR TITLE
CA2227: Suppressed readonly warnings.

### DIFF
--- a/src/Sarif/IAnalysisContext.cs
+++ b/src/Sarif/IAnalysisContext.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         IRule Rule { get; set; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         PropertyBagDictionary Policy { get; set; }
         
         IAnalysisLogger Logger { get; set; }

--- a/src/Sarif/Readers/ResultDiffingVisitor.cs
+++ b/src/Sarif/Readers/ResultDiffingVisitor.cs
@@ -16,8 +16,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             VisitSarifLog(sarifLog);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public HashSet<Result> NewResults { get; set; }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public HashSet<Result> AbsentResults { get; set; }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public HashSet<Result> SharedResults { get; set; }
 
         public override Result VisitResult(Result node)

--- a/src/Sarif/TypedPropertyBag.cs
+++ b/src/Sarif/TypedPropertyBag.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         protected Dictionary<string, string> SettingNameToDescriptionsMap { get; set; }
 
         public virtual T GetProperty(PerLanguageOption<T> setting)


### PR DESCRIPTION
@lgolding @michaelcfanning @jinujoseph @jericahuang @Rolstenhouse 
This rule wants me to make certain things read-only by removing their setters. However, these things need to be set as different values later in the program, so they cannot be read-only. For now, I have suppressed this rule. However, I realize that the documentation recommends never suppressing this rule since it is a serious security concern, so I am open to any better solutions to this issue you recommend.