### PR TITLE
Ignore failing test SarifLogger_RedactedCommandLine

### DIFF
--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     public class SarifLoggerTests : JsonTests
     {
         [TestMethod]
+        [Ignore] // https://github.com/Microsoft/sarif-sdk/issues/389
         public void SarifLogger_RedactedCommandLine()
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
This test fails on AppVeyor because it hard-codes path information.

@michaelcfanning @rtaket FYI