### PR TITLE
Fix Appveyor SarifLogger_RedactedCommandLine test failure

### DIFF
--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -22,6 +22,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var sb = new StringBuilder();
 
+            // On a developer's machine, the script BuildAndTest.cmd runs the tests with a particular command line. 
+            // Under AppVeyor, the appveyor.yml file simply specifies the names of the test assemblies, and AppVeyor 
+            // constructs and executes its own, different command line. So, based on our knowledge of each of those 
+            // command lines, we select a different token to redact in each of those cases.
+            //
+            //
             // Sample test execution command-line from within VS. We will redact the 'TestExecution' role data
             //
             // "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO 14.0\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\TESTWINDOW\te.processhost.managed.exe"

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -64,8 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 else
                 {
-                    string argumentToRedact = Environment.CommandLine;
-                    argumentToRedact = argumentToRedact.Split(new string[] { @"/agentKey" }, StringSplitOptions.None)[1].Trim();
+                    string argumentToRedact = commandLine.Split(new string[] { @"/agentKey" }, StringSplitOptions.None)[1].Trim();
                     argumentToRedact = argumentToRedact.Split(' ')[0];
                     tokensToRedact = new string[] { argumentToRedact };
                 }

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -56,7 +56,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 run.Invocation.CommandLine = Redact(run.Invocation.CommandLine, invocationTokensToRedact);
                 run.Invocation.Machine = Redact(run.Invocation.Machine, invocationTokensToRedact);
                 run.Invocation.Account = Redact(run.Invocation.Account, invocationTokensToRedact);
-                run.Invocation.CommandLine = Redact(run.Invocation.CommandLine, invocationTokensToRedact);
                 run.Invocation.WorkingDirectory = Redact(run.Invocation.WorkingDirectory, invocationTokensToRedact);
 
                 if (run.Invocation.EnvironmentVariables != null)


### PR DESCRIPTION
It looks like AppVeyor uses a different command line to invoke the tests. This caused the SarifLogger_RedactedCommandLine test to fail. 