### PR TITLE
FortifyConverter: Don't emit aCL.importance

### DIFF
--- a/src/Sarif.Converters/FortifyConverter.cs
+++ b/src/Sarif.Converters/FortifyConverter.cs
@@ -149,14 +149,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                         {
                             new AnnotatedCodeLocation
                             {
-                                PhysicalLocation = source,
-                                Importance = AnnotatedCodeLocationImportance.Essential
+                                PhysicalLocation = source
                             },
 
                             new AnnotatedCodeLocation
                             {
-                                PhysicalLocation = primaryOrSink,
-                                Importance = AnnotatedCodeLocationImportance.Essential
+                                PhysicalLocation = primaryOrSink
                             }
                         }
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
@@ -266,8 +266,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -275,8 +274,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -311,8 +309,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -320,8 +317,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -356,8 +352,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -365,8 +360,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -401,8 +395,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -410,8 +403,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -446,8 +438,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -455,8 +446,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -491,8 +481,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -500,8 +489,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -536,8 +524,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -545,8 +532,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -581,8 +567,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -590,8 +575,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -626,8 +610,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -635,8 +618,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -671,8 +653,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -680,8 +661,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -716,8 +696,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -725,8 +704,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -761,8 +739,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -770,8 +747,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -806,8 +782,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -815,8 +790,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -851,8 +825,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -860,8 +833,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -896,8 +868,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -905,8 +876,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -941,8 +911,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -950,8 +919,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -986,8 +954,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -995,8 +962,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1031,8 +997,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1040,8 +1005,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1076,8 +1040,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1085,8 +1048,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1121,8 +1083,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1130,8 +1091,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1166,8 +1126,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1175,8 +1134,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1211,8 +1169,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1220,8 +1177,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1256,8 +1212,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1265,8 +1220,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1301,8 +1255,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1310,8 +1263,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1346,8 +1298,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1355,8 +1306,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1391,8 +1341,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1400,8 +1349,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1436,8 +1384,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1445,8 +1392,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1481,8 +1427,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1490,8 +1435,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1526,8 +1470,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1535,8 +1478,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1571,8 +1513,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1580,8 +1521,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1616,8 +1556,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1625,8 +1564,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1661,8 +1599,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1670,8 +1607,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1706,8 +1642,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1715,8 +1650,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1751,8 +1685,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1760,8 +1693,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1796,8 +1728,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1805,8 +1736,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1841,8 +1771,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1850,8 +1779,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1886,8 +1814,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1895,8 +1822,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1931,8 +1857,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1940,8 +1865,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1976,8 +1900,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1985,8 +1908,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2021,8 +1943,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2030,8 +1951,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2066,8 +1986,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2075,8 +1994,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2111,8 +2029,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2120,8 +2037,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2156,8 +2072,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2165,8 +2080,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2201,8 +2115,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2210,8 +2123,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2246,8 +2158,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2255,8 +2166,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2291,8 +2201,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2300,8 +2209,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2336,8 +2244,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2345,8 +2252,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2381,8 +2287,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2390,8 +2295,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2426,8 +2330,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2435,8 +2338,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2471,8 +2373,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2480,8 +2381,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2516,8 +2416,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2525,8 +2424,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2561,8 +2459,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2570,8 +2467,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2606,8 +2502,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2615,8 +2510,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2651,8 +2545,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2660,8 +2553,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2696,8 +2588,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2705,8 +2596,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2741,8 +2631,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2750,8 +2639,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2786,8 +2674,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2795,8 +2682,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2831,8 +2717,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2840,8 +2725,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2876,8 +2760,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2885,8 +2768,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2921,8 +2803,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2930,8 +2811,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2966,8 +2846,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2975,8 +2854,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3011,8 +2889,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3020,8 +2897,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3056,8 +2932,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3065,8 +2940,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3101,8 +2975,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3110,8 +2983,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3146,8 +3018,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3155,8 +3026,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3191,8 +3061,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3200,8 +3069,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3236,8 +3104,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3245,8 +3112,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3281,8 +3147,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3290,8 +3155,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3326,8 +3190,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3335,8 +3198,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3371,8 +3233,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3380,8 +3241,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3416,8 +3276,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3425,8 +3284,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3461,8 +3319,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3470,8 +3327,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3506,8 +3362,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3515,8 +3370,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3551,8 +3405,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3560,8 +3413,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3596,8 +3448,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3605,8 +3456,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3641,8 +3491,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3650,8 +3499,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3686,8 +3534,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3695,8 +3542,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3731,8 +3577,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3740,8 +3585,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3776,8 +3620,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3785,8 +3628,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3821,8 +3663,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3830,8 +3671,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3866,8 +3706,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3875,8 +3714,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3911,8 +3749,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3920,8 +3757,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3956,8 +3792,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3965,8 +3800,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4001,8 +3835,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4010,8 +3843,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4046,8 +3878,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4055,8 +3886,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4091,8 +3921,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4100,8 +3929,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4136,8 +3964,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4145,8 +3972,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4181,8 +4007,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4190,8 +4015,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4226,8 +4050,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4235,8 +4058,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4313,8 +4135,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4322,8 +4143,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4358,8 +4178,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4367,8 +4186,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4403,8 +4221,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4412,8 +4229,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4448,8 +4264,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4457,8 +4272,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4493,8 +4307,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4502,8 +4315,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4538,8 +4350,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4547,8 +4358,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4583,8 +4393,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4592,8 +4401,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4628,8 +4436,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4637,8 +4444,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4673,8 +4479,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4682,8 +4487,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4718,8 +4522,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4727,8 +4530,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4763,8 +4565,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4772,8 +4573,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4808,8 +4608,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4817,8 +4616,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }

--- a/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
@@ -266,8 +266,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -275,8 +274,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -311,8 +309,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -320,8 +317,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -356,8 +352,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -365,8 +360,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -401,8 +395,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -410,8 +403,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -446,8 +438,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -455,8 +446,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -491,8 +481,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -500,8 +489,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -536,8 +524,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -545,8 +532,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -581,8 +567,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -590,8 +575,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -626,8 +610,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -635,8 +618,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -671,8 +653,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -680,8 +661,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -716,8 +696,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -725,8 +704,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -761,8 +739,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -770,8 +747,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -806,8 +782,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -815,8 +790,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -851,8 +825,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -860,8 +833,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -896,8 +868,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -905,8 +876,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -941,8 +911,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -950,8 +919,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -986,8 +954,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -995,8 +962,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1031,8 +997,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1040,8 +1005,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1076,8 +1040,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1085,8 +1048,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1121,8 +1083,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1130,8 +1091,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1166,8 +1126,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1175,8 +1134,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1211,8 +1169,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1220,8 +1177,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1256,8 +1212,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1265,8 +1220,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1301,8 +1255,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1310,8 +1263,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1346,8 +1298,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1355,8 +1306,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1391,8 +1341,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1400,8 +1349,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1436,8 +1384,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1445,8 +1392,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1481,8 +1427,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1490,8 +1435,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1526,8 +1470,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1535,8 +1478,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1571,8 +1513,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1580,8 +1521,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1616,8 +1556,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1625,8 +1564,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1661,8 +1599,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1670,8 +1607,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1706,8 +1642,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1715,8 +1650,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1751,8 +1685,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1760,8 +1693,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1796,8 +1728,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1805,8 +1736,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1841,8 +1771,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1850,8 +1779,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1886,8 +1814,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1895,8 +1822,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1931,8 +1857,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1940,8 +1865,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -1976,8 +1900,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -1985,8 +1908,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2021,8 +1943,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2030,8 +1951,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2066,8 +1986,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2075,8 +1994,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2111,8 +2029,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2120,8 +2037,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2156,8 +2072,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2165,8 +2080,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2201,8 +2115,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2210,8 +2123,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2246,8 +2158,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2255,8 +2166,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2291,8 +2201,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2300,8 +2209,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2336,8 +2244,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2345,8 +2252,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2381,8 +2287,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2390,8 +2295,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2426,8 +2330,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2435,8 +2338,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2471,8 +2373,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2480,8 +2381,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2516,8 +2416,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2525,8 +2424,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2561,8 +2459,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2570,8 +2467,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2606,8 +2502,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2615,8 +2510,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2651,8 +2545,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2660,8 +2553,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2696,8 +2588,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2705,8 +2596,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2741,8 +2631,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2750,8 +2639,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2786,8 +2674,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2795,8 +2682,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2831,8 +2717,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2840,8 +2725,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2876,8 +2760,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2885,8 +2768,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2921,8 +2803,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2930,8 +2811,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -2966,8 +2846,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -2975,8 +2854,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3011,8 +2889,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3020,8 +2897,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3056,8 +2932,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3065,8 +2940,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3101,8 +2975,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3110,8 +2983,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3146,8 +3018,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3155,8 +3026,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3191,8 +3061,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3200,8 +3069,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3236,8 +3104,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3245,8 +3112,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3281,8 +3147,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3290,8 +3155,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3326,8 +3190,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3335,8 +3198,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3371,8 +3233,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3380,8 +3241,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3416,8 +3276,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3425,8 +3284,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3461,8 +3319,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3470,8 +3327,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3506,8 +3362,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3515,8 +3370,7 @@
                     "region": {
                       "startLine": 204
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3551,8 +3405,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3560,8 +3413,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3596,8 +3448,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3605,8 +3456,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3641,8 +3491,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3650,8 +3499,7 @@
                     "region": {
                       "startLine": 259
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3686,8 +3534,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3695,8 +3542,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3731,8 +3577,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3740,8 +3585,7 @@
                     "region": {
                       "startLine": 257
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3776,8 +3620,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3785,8 +3628,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3821,8 +3663,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3830,8 +3671,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3866,8 +3706,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3875,8 +3714,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3911,8 +3749,7 @@
                     "region": {
                       "startLine": 243
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3920,8 +3757,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -3956,8 +3792,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -3965,8 +3800,7 @@
                     "region": {
                       "startLine": 199
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4001,8 +3835,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4010,8 +3843,7 @@
                     "region": {
                       "startLine": 225
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4046,8 +3878,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4055,8 +3886,7 @@
                     "region": {
                       "startLine": 255
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4091,8 +3921,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4100,8 +3929,7 @@
                     "region": {
                       "startLine": 205
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4136,8 +3964,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4145,8 +3972,7 @@
                     "region": {
                       "startLine": 200
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4181,8 +4007,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4190,8 +4015,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4226,8 +4050,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4235,8 +4058,7 @@
                     "region": {
                       "startLine": 223
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4313,8 +4135,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4322,8 +4143,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4358,8 +4178,7 @@
                     "region": {
                       "startLine": 236
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4367,8 +4186,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4403,8 +4221,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4412,8 +4229,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4448,8 +4264,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4457,8 +4272,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4493,8 +4307,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4502,8 +4315,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4538,8 +4350,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4547,8 +4358,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4583,8 +4393,7 @@
                     "region": {
                       "startLine": 142
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4592,8 +4401,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4628,8 +4436,7 @@
                     "region": {
                       "startLine": 237
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4637,8 +4444,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4673,8 +4479,7 @@
                     "region": {
                       "startLine": 239
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4682,8 +4487,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4718,8 +4522,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4727,8 +4530,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4763,8 +4565,7 @@
                     "region": {
                       "startLine": 238
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4772,8 +4573,7 @@
                     "region": {
                       "startLine": 279
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }
@@ -4808,8 +4608,7 @@
                     "region": {
                       "startLine": 134
                     }
-                  },
-                  "importance": "essential"
+                  }
                 },
                 {
                   "physicalLocation": {
@@ -4817,8 +4616,7 @@
                     "region": {
                       "startLine": 87
                     }
-                  },
-                  "importance": "essential"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
This converter always emitted Importance=Essential (previously, Essential=true), even though the native tool output doesn't have any equivalent.