### PR TITLE
Support invocation.responseFiles

### DIFF
--- a/src/Sarif/Autogenerated/Invocation.cs
+++ b/src/Sarif/Autogenerated/Invocation.cs
@@ -39,6 +39,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string CommandLine { get; set; }
 
         /// <summary>
+        /// The contents of any response files specified on the tool's command line.
+        /// </summary>
+        [DataMember(Name = "responseFiles", IsRequired = false, EmitDefaultValue = false)]
+        public IDictionary<string, string> ResponseFiles { get; set; }
+
+        /// <summary>
         /// The date and time at which the run started. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "startTime", IsRequired = false, EmitDefaultValue = false)]
@@ -105,6 +111,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="commandLine">
         /// An initialization value for the <see cref="P: CommandLine" /> property.
         /// </param>
+        /// <param name="responseFiles">
+        /// An initialization value for the <see cref="P: ResponseFiles" /> property.
+        /// </param>
         /// <param name="startTime">
         /// An initialization value for the <see cref="P: StartTime" /> property.
         /// </param>
@@ -132,9 +141,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P: Properties" /> property.
         /// </param>
-        public Invocation(string commandLine, DateTime startTime, DateTime endTime, string machine, string account, int processId, string fileName, string workingDirectory, IDictionary<string, string> environmentVariables, IDictionary<string, SerializedPropertyInfo> properties)
+        public Invocation(string commandLine, IDictionary<string, string> responseFiles, DateTime startTime, DateTime endTime, string machine, string account, int processId, string fileName, string workingDirectory, IDictionary<string, string> environmentVariables, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(commandLine, startTime, endTime, machine, account, processId, fileName, workingDirectory, environmentVariables, properties);
+            Init(commandLine, responseFiles, startTime, endTime, machine, account, processId, fileName, workingDirectory, environmentVariables, properties);
         }
 
         /// <summary>
@@ -153,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.CommandLine, other.StartTime, other.EndTime, other.Machine, other.Account, other.ProcessId, other.FileName, other.WorkingDirectory, other.EnvironmentVariables, other.Properties);
+            Init(other.CommandLine, other.ResponseFiles, other.StartTime, other.EndTime, other.Machine, other.Account, other.ProcessId, other.FileName, other.WorkingDirectory, other.EnvironmentVariables, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -174,9 +183,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Invocation(this);
         }
 
-        private void Init(string commandLine, DateTime startTime, DateTime endTime, string machine, string account, int processId, string fileName, string workingDirectory, IDictionary<string, string> environmentVariables, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(string commandLine, IDictionary<string, string> responseFiles, DateTime startTime, DateTime endTime, string machine, string account, int processId, string fileName, string workingDirectory, IDictionary<string, string> environmentVariables, IDictionary<string, SerializedPropertyInfo> properties)
         {
             CommandLine = commandLine;
+            if (responseFiles != null)
+            {
+                ResponseFiles = new Dictionary<string, string>(responseFiles);
+            }
+
             StartTime = startTime;
             EndTime = endTime;
             Machine = machine;

--- a/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
@@ -33,6 +33,28 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (!object.ReferenceEquals(left.ResponseFiles, right.ResponseFiles))
+            {
+                if (left.ResponseFiles == null || right.ResponseFiles == null || left.ResponseFiles.Count != right.ResponseFiles.Count)
+                {
+                    return false;
+                }
+
+                foreach (var value_0 in left.ResponseFiles)
+                {
+                    string value_1;
+                    if (!right.ResponseFiles.TryGetValue(value_0.Key, out value_1))
+                    {
+                        return false;
+                    }
+
+                    if (value_0.Value != value_1)
+                    {
+                        return false;
+                    }
+                }
+            }
+
             if (left.StartTime != right.StartTime)
             {
                 return false;
@@ -75,15 +97,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                foreach (var value_0 in left.EnvironmentVariables)
+                foreach (var value_2 in left.EnvironmentVariables)
                 {
-                    string value_1;
-                    if (!right.EnvironmentVariables.TryGetValue(value_0.Key, out value_1))
+                    string value_3;
+                    if (!right.EnvironmentVariables.TryGetValue(value_2.Key, out value_3))
                     {
                         return false;
                     }
 
-                    if (value_0.Value != value_1)
+                    if (value_2.Value != value_3)
                     {
                         return false;
                     }
@@ -97,15 +119,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                foreach (var value_2 in left.Properties)
+                foreach (var value_4 in left.Properties)
                 {
-                    SerializedPropertyInfo value_3;
-                    if (!right.Properties.TryGetValue(value_2.Key, out value_3))
+                    SerializedPropertyInfo value_5;
+                    if (!right.Properties.TryGetValue(value_4.Key, out value_5))
                     {
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!object.Equals(value_4.Value, value_5))
                     {
                         return false;
                     }
@@ -128,6 +150,22 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.CommandLine != null)
                 {
                     result = (result * 31) + obj.CommandLine.GetHashCode();
+                }
+
+                if (obj.ResponseFiles != null)
+                {
+                    // Use xor for dictionaries to be order-independent.
+                    int xor_0 = 0;
+                    foreach (var value_6 in obj.ResponseFiles)
+                    {
+                        xor_0 ^= value_6.Key.GetHashCode();
+                        if (value_6.Value != null)
+                        {
+                            xor_0 ^= value_6.Value.GetHashCode();
+                        }
+                    }
+
+                    result = (result * 31) + xor_0;
                 }
 
                 result = (result * 31) + obj.StartTime.GetHashCode();
@@ -156,33 +194,33 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.EnvironmentVariables != null)
                 {
                     // Use xor for dictionaries to be order-independent.
-                    int xor_0 = 0;
-                    foreach (var value_4 in obj.EnvironmentVariables)
+                    int xor_1 = 0;
+                    foreach (var value_7 in obj.EnvironmentVariables)
                     {
-                        xor_0 ^= value_4.Key.GetHashCode();
-                        if (value_4.Value != null)
+                        xor_1 ^= value_7.Key.GetHashCode();
+                        if (value_7.Value != null)
                         {
-                            xor_0 ^= value_4.Value.GetHashCode();
+                            xor_1 ^= value_7.Value.GetHashCode();
                         }
                     }
 
-                    result = (result * 31) + xor_0;
+                    result = (result * 31) + xor_1;
                 }
 
                 if (obj.Properties != null)
                 {
                     // Use xor for dictionaries to be order-independent.
-                    int xor_1 = 0;
-                    foreach (var value_5 in obj.Properties)
+                    int xor_2 = 0;
+                    foreach (var value_8 in obj.Properties)
                     {
-                        xor_1 ^= value_5.Key.GetHashCode();
-                        if (value_5.Value != null)
+                        xor_2 ^= value_8.Key.GetHashCode();
+                        if (value_8.Value != null)
                         {
-                            xor_1 ^= value_5.Value.GetHashCode();
+                            xor_2 ^= value_8.Value.GetHashCode();
                         }
                     }
 
-                    result = (result * 31) + xor_1;
+                    result = (result * 31) + xor_2;
                 }
             }
 

--- a/src/Sarif/Autogenerated/Result.cs
+++ b/src/Sarif/Autogenerated/Result.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string RuleKey { get; set; }
 
         /// <summary>
-        /// The kind of observation this result represents. If this property is not present, its implied value is 'warning'.
+        /// A value specifying the severity level of the result. If this property is not present, its implied value is 'warning'.
         /// </summary>
         [DataMember(Name = "level", IsRequired = false, EmitDefaultValue = false)]
         public ResultLevel Level { get; set; }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -54,7 +54,7 @@
       "kind": "EnumHint",
       "arguments": {
         "typeName": "AnnotatedCodeLocationImportance",
-        "description":  "Values specifying the importance of an \"annotatedCodeLocation\" within the \"codeFlow\" in which it occurs"
+        "description": "Values specifying the importance of an \"annotatedCodeLocation\" within the \"codeFlow\" in which it occurs"
       }
     }
   ],
@@ -83,7 +83,7 @@
       }
     }
   ],
-  "*.Properties" : [
+  "*.Properties": [
     {
       "kind": "DictionaryHint",
       "arguments": {
@@ -197,6 +197,11 @@
     }
   ],
   "Invocation.EnvironmentVariables": [
+    {
+      "kind": "DictionaryHint"
+    }
+  ],
+  "Invocation.ResponseFiles": [
     {
       "kind": "DictionaryHint"
     }

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -683,7 +683,7 @@
         },
 
         "level": {
-          "description": "The kind of observation this result represents. If this property is not present, its implied value is 'warning'.",
+          "description": "A value specifying the severity level of the result. If this property is not present, its implied value is 'warning'.",
           "default": "warning",
           "enum": [ "notApplicable", "pass", "note", "warning", "error" ]
         },

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -357,6 +357,12 @@
           "type": "string"
         },
 
+        "responseFiles": {
+          "description": "The contents of any response files specified on the tool's command line.",
+          "type": "object",
+          "additionalProperties": true
+        },
+
         "startTime": {
           "description": "The date and time at which the run started. See \"Date/time properties\" in the SARIF spec for the required format.",
           "type": "string",
@@ -386,19 +392,18 @@
 
         "fileName": {
           "description": "The fully qualified path to the analysis tool.",
-          "type": "string",
-          "default": { }
+          "type": "string"
         },
 
         "workingDirectory": {
           "description": "The working directory for the analysis rool run.",
-          "type": "string",
-          "default": { }
+          "type": "string"
         },
 
         "environmentVariables": {
           "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
           "type": "object",
+          "additionalProperties": true,
           "default": { }
         },
 
@@ -887,7 +892,7 @@
           "description": "A dictionary, each of whose keys specifies a logical location such as a namespace, type or function.",
           "type": "object",
           "additionalProperties": {
-          "$ref": "#/definitions/logicalLocation"
+            "$ref": "#/definitions/logicalLocation"
           }
         },
 


### PR DESCRIPTION
Also:
* Address sarif-standard/sarif-specification#173 by making the schema descriptions of the `result.level` and `notification.level` properties consistent.
* Remove a couple of invalid `"default"` properties which specified that
  the default value for a string-valued property was an empty object.
* Added `"additionalProperties": true` to `invocation.environmentVariables`,
  just for explicitness.
 