### PR TITLE
VSIX: Layout formatting fixes

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Converters/ObjectToVisibilityConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/Converters/ObjectToVisibilityConverter.cs
@@ -11,20 +11,11 @@ using System.Windows.Data;
 
 namespace Microsoft.Sarif.Viewer.Converters
 {
-    public class StringWithUnknownToVisibilityConverter : IValueConverter
+    public class ObjectToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            string valueString = value as string;
-
-            if (string.IsNullOrWhiteSpace(valueString) || valueString == "Unknown")
-            {
-                return Visibility.Collapsed;
-            }
-            else
-            {
-                return Visibility.Visible;
-            }
+            return value == null ? Visibility.Collapsed : Visibility.Visible;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
@@ -183,23 +183,5 @@ namespace Microsoft.Sarif.Viewer.Models
                 }
             }
         }
-
-        public bool HasValues
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(OwnerName) && string.IsNullOrEmpty(OwnerUri) && 
-                    string.IsNullOrEmpty(FeedbackUri) && string.IsNullOrEmpty(Description) && 
-                    string.IsNullOrEmpty(Category) && string.IsNullOrEmpty(Version) && 
-                    (string.IsNullOrEmpty(Severity) || Severity == "Unknown"))
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
-            }
-        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Sarif.Viewer
             }
 
             this.Tool = run.Tool.ToToolModel();
-            this.Rule = rule.ToRuleModel(result.RuleId);
+            this.Rule = rule?.ToRuleModel(result.RuleId);
             this.Invocation = run.Invocation.ToInvocationModel();
 
             if (result.Locations != null)

--- a/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Sarif.Viewer.Models
     public class ToolModel : NotifyPropertyChangedObject
     {
         private string _name;
+        private string _fullName;
         private string _version;
+        private string _semanticVersion;
         private string _description;
         private string _ownerName;
         private string _ownerUri;
@@ -33,6 +35,22 @@ namespace Microsoft.Sarif.Viewer.Models
                 {
                     this._name = value;
                     NotifyPropertyChanged("Name");
+                }
+            }
+        }
+
+        public string FullName
+        {
+            get
+            {
+                return this._fullName;
+            }
+            set
+            {
+                if (value != this._fullName)
+                {
+                    this._fullName = value;
+                    NotifyPropertyChanged(nameof(FullName));
                 }
             }
         }
@@ -133,18 +151,18 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        public bool HasValues
+        public string SemanticVersion
         {
             get
             {
-                if (string.IsNullOrEmpty(Description) && string.IsNullOrEmpty(OwnerName) &&
-                    string.IsNullOrEmpty(OwnerUri) && string.IsNullOrEmpty(FeedbackUri))
+                return this._semanticVersion;
+            }
+            set
+            {
+                if (value != this._semanticVersion)
                 {
-                    return false;
-                }
-                else
-                {
-                    return true;
+                    this._semanticVersion = value;
+                    NotifyPropertyChanged(nameof(SemanticVersion));
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -48,8 +48,8 @@
     <Compile Include="Converters\BooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\Int32ToVisibilityConverter.cs" />
     <Compile Include="Converters\MultipleStringsToVisibilityConverter.cs" />
-    <Compile Include="Converters\StringWithUnknownToVisibilityConverter.cs" />
     <Compile Include="Converters\FileExistsToBooleanConverter.cs" />
+    <Compile Include="Converters\ObjectToVisibilityConverter.cs" />
     <Compile Include="DelegateCommand.cs" />
     <Compile Include="DelegateCommandBase.cs" />
     <Compile Include="Models\InvocationModel.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Tool.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Tool.extensions.cs
@@ -22,15 +22,10 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
             ToolModel model = new ToolModel()
             {
-                Name = !String.IsNullOrWhiteSpace(tool.FullName) ? tool.FullName : tool.Name,
-                Version = !String.IsNullOrWhiteSpace(tool.SemanticVersion) ? tool.SemanticVersion : tool.Version,
-
-                // TODO: Replace with real values
-                //OwnerName = "John Doe",
-                //OwnerUri = "mailto:johndoe@sarif.microsoft.com",
-                //FeedbackUri = "mailto:toolfeedback@sarif.microsoft.com",
-                //HelpUri = "https://microsoft.com/staticanalysis/tool",
-                //Description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                Name = tool.Name,
+                FullName = tool.FullName,
+                Version = tool.Version,
+                SemanticVersion = tool.SemanticVersion,
             };
 
             return model;

--- a/src/Sarif.Viewer.VisualStudio/Themes/DefaultStyles.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/DefaultStyles.xaml
@@ -7,13 +7,13 @@
     <!-- Converters -->
     <converters:DatabindingDebugConverter x:Key="databindingDebugConverter" />
     <converters:BooleanToVisibilityConverter x:Key="booleanToVisiblityConverter" />
+    <converters:ObjectToVisibilityConverter x:Key="objectToVisibilityConverter" />
     <converters:StringToVisibilityConverter x:Key="stringToVisibilityConverter" />
     <converters:Int32ToVisibilityConverter x:Key="int32ToVisibilityConverter" />
     <converters:CollectionToCountConverter x:Key="collectionToCountConverter" />
     <converters:CollectionToVisiblity0Converter x:Key="collectionToVisibility0Converter" />
     <converters:CollectionToVisiblity1Converter x:Key="collectionToVisibility1Converter" />
     <converters:MultipleStringsToVisibilityConverter x:Key="multipleStringsToVisibilityConverter" />
-    <converters:StringWithUnknownToVisibilityConverter x:Key="stringWithUnknownToVisibilityConverter" />
     <converters:BooleanToCollapsedVisibilityConverter x:Key="booleanToCollapsedVisibilityConverter" />
     <converters:FileExistsToBooleanConverter x:Key="fileExistsToBooleanConverter" />
 
@@ -35,6 +35,8 @@
            BasedOn="{StaticResource baseStyle}"></Style>
 
     <Style TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
         <Setter Property="FontSize"
                 Value="11.5" />
     </Style>

--- a/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
@@ -8,287 +8,266 @@
         <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/DefaultStyles.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <!-- Converters -->
-    <converters:StringToVisibilityConverter x:Key="stringToVisibilityConverter" />
-    <converters:StringWithUnknownToVisibilityConverter x:Key="stringWithUnknownToVisibilityConverter" />
-    <converters:BooleanToCollapsedVisibilityConverter x:Key="booleanToCollapsedVisibilityConverter" />
-
     <!-- Info Template - Displays info about the rule for the result and the tool which raised the result. -->
     <DataTemplate x:Key="InfoTemplate">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Grid.Row="0">
+        <DockPanel>
+            <!-- This is the Rule metadata grid. -->
+            <Grid DockPanel.Dock="Top"
+                  Visibility="{Binding Rule, Converter={StaticResource objectToVisibilityConverter}}">
                 <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0"
-                           Text="{Binding Rule.Id}"
-                           FontWeight="Bold" 
-                           Margin="0 5 0 0"
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Column="1"
-                           Text="{Binding Rule.Name, Mode=OneTime}"
-                           Visibility="{Binding Rule.Name, Converter={StaticResource stringToVisibilityConverter}}"
-                           FontWeight="Bold" />
-            </Grid>
-            <controls:InternetHyperlink Grid.Row="1"
-                           Text="Help"
-                           Margin="0 0 0 5"
-                           Visibility="{Binding Rule.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           NavigateUri="{Binding Rule.HelpUri}" />
-            <TextBlock Grid.Row="2"
+                <DockPanel Grid.Row="0"
+                      Grid.Column="0"
+                      Grid.ColumnSpan="2">
+                    <TextBlock DockPanel.Dock="Left"
+                               Text="{Binding Rule.Id}"
+                               FontWeight="Bold"
+                               Style="{StaticResource PropertyKey}" />
+                    <TextBlock DockPanel.Dock="Left"
+                               Text="{Binding Rule.Name, Mode=OneTime}"
+                               Visibility="{Binding Rule.Name, Converter={StaticResource stringToVisibilityConverter}}"
+                               FontWeight="Bold" />
+                </DockPanel>
+                <controls:InternetHyperlink Grid.Row="1"
+                                            Text="Help"
+                                            Margin="0 0 0 5"
+                                            Visibility="{Binding Rule.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
+                                            NavigateUri="{Binding Rule.HelpUri}" />
+                <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Rule.Version, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Version : " 
+                           Text="Version : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="2"
+                <TextBlock Grid.Row="2"
                            Grid.Column="1"
                            Visibility="{Binding Rule.Version, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.Version}" />
-            <TextBlock Grid.Row="3"
+                <TextBlock Grid.Row="3"
                            Grid.Column="0"
                            Visibility="{Binding Rule.Category, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Category : " 
+                           Text="Category : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="3"
+                <TextBlock Grid.Row="3"
                            Grid.Column="1"
                            Visibility="{Binding Rule.Category, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.Category}" />
-            <TextBlock Grid.Row="4"
+                <TextBlock Grid.Row="4"
                            Grid.Column="0"
-                           Visibility="{Binding Rule.Severity, Converter={StaticResource stringWithUnknownToVisibilityConverter}}"
-                           Text="Severity : " 
+                           Text="Default Severity : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="4"
+                <TextBlock Grid.Row="4"
                            Grid.Column="1"
-                           Visibility="{Binding Rule.Severity, Converter={StaticResource stringWithUnknownToVisibilityConverter}}"
                            Text="{Binding Rule.Severity}" />
-            <TextBlock Grid.Row="5"
+                <TextBlock Grid.Row="5"
                            Grid.Column="0"
                            Visibility="{Binding Rule.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner : " 
+                           Text="Owner : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="5"
+                <TextBlock Grid.Row="5"
                            Grid.Column="1"
                            Visibility="{Binding Rule.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.OwnerName}" />
-            <TextBlock Grid.Row="6"
+                <TextBlock Grid.Row="6"
                            Grid.Column="0"
                            Visibility="{Binding Rule.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback : " 
+                           Text="Feedback : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="6"
+                <TextBlock Grid.Row="6"
                            Grid.Column="1"
                            Visibility="{Binding Rule.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.FeedbackUri}" />
-            <TextBlock Grid.Row="7"
+                <TextBlock Grid.Row="7"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
                            Visibility="{Binding Rule.Description, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.Description}"
                            TextWrapping="Wrap"
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="8"
+                <Separator Grid.Row="8"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
-                           Visibility="{Binding Rule.HasValues, Converter={StaticResource booleanToCollapsedVisibilityConverter}}"
-                           HorizontalAlignment="Center"
-                           Margin="0 0 0 2"
-                           Text="No additional content"
-                           Foreground="Gray"
-                           Style="{StaticResource PropertyKey}" />
+                           Margin="0 15 0 3" />
+            </Grid>
 
-            <!-- Division between Tool and Rule. -->
-            <Separator Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 5 0 5" />
-
-            <Grid Grid.Row="10">
+            <!-- This is the Tool metadata grid. -->
+            <Grid DockPanel.Dock="Top"
+                  Visibility="{Binding Tool, Converter={StaticResource objectToVisibilityConverter}}">
                 <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0"
-                           Text="{Binding Tool.Name}" 
-                           FontWeight="Bold" 
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Column="1"
-                           Text="{Binding Tool.Version, Mode=OneTime}"
-                           FontWeight="Bold"
-                           Visibility="{Binding Tool.Version, Converter={StaticResource stringToVisibilityConverter}}" />
-            </Grid>
-            <controls:InternetHyperlink Grid.Row="11"
-                           Grid.Column="0"
-                           Text="Help"
-                           Margin="0 0 0 5"
-                           Visibility="{Binding Tool.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           NavigateUri="{Binding Tool.HelpUri}" />
-            <TextBlock Grid.Row="12"
+
+                <DockPanel Grid.Row="0"
+                      Grid.Column="0"
+                      Grid.ColumnSpan="2">
+                    <TextBlock DockPanel.Dock="Left"
+                               Text="{Binding Tool.Name}"
+                               FontWeight="Bold"
+                               Style="{StaticResource PropertyKey}" />
+                    <TextBlock DockPanel.Dock="Left"
+                               Text="{Binding Tool.Version, Mode=OneTime}"
+                               FontWeight="Bold"
+                               Visibility="{Binding Tool.Version, Converter={StaticResource stringToVisibilityConverter}}" />
+                </DockPanel>
+                <controls:InternetHyperlink Grid.Row="1"
+                                            Grid.Column="0"
+                                            Text="Help"
+                                            Margin="0 0 0 5"
+                                            Visibility="{Binding Tool.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
+                                            NavigateUri="{Binding Tool.HelpUri}" />
+                <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Tool.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner : " 
+                           Text="Owner : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="12"
+                <TextBlock Grid.Row="2"
                            Grid.Column="1"
                            Visibility="{Binding Tool.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Tool.OwnerName}" />
-            <TextBlock Grid.Row="13"
+                <TextBlock Grid.Row="3"
                            Grid.Column="0"
                            Visibility="{Binding Tool.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback : " 
+                           Text="Feedback : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="13"
+                <TextBlock Grid.Row="3"
                            Grid.Column="1"
                            Visibility="{Binding Tool.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Tool.FeedbackUri}" />
-            <TextBlock Grid.Row="14"
+                <TextBlock Grid.Row="4"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
                            Visibility="{Binding Tool.Description, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Tool.Description}"
                            TextWrapping="Wrap"
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="15"
-                           Grid.Column="0"
-                           Grid.ColumnSpan="2"
-                           Visibility="{Binding Tool.HasValues, Converter={StaticResource booleanToCollapsedVisibilityConverter}}"
-                           Text="No additional content"
-                           Margin="0 0 0 7"
-                           HorizontalAlignment="Center"
-                           Foreground="Gray"
-                           Style="{StaticResource PropertyKey}" />
 
-            <!-- Separating Tool from Invocation. -->
-            <TextBlock Grid.Row="16" />
-
-            <!-- Invocation will go here. -->
-            <TextBlock Grid.Row="17"
+                <!-- Invocation metadata -->
+                <TextBlock Grid.Row="7"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Command Line : " 
+                           Text="Command Line : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="17"
-                           Grid.Column="1"
-                           Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Invocation.CommandLine}" />
-            <TextBlock Grid.Row="18"
+                <TextBox Grid.Row="7"
+                         Grid.Column="1"
+                         Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         Text="{Binding Invocation.CommandLine, Mode=OneWay}"
+                         IsReadOnly="True"
+                         TextWrapping="Wrap"
+                         IsTabStop="False" />
+                <TextBlock Grid.Row="8"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.StartTime, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Start Time : " 
+                           Text="Start Time : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="18"
+                <TextBlock Grid.Row="8"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.StartTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.StartTime}" />
-            <TextBlock Grid.Row="19"
+                <TextBlock Grid.Row="9"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EndTime, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="End Time : " 
+                           Text="End Time : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="19"
+                <TextBlock Grid.Row="9"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.EndTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.EndTime}" />
-            <TextBlock Grid.Row="20"
+                <TextBlock Grid.Row="10"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Machine, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Machine : " 
+                           Text="Machine : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="21"
+                <TextBlock Grid.Row="10"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.Machine, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.Machine}" />
-            <TextBlock Grid.Row="22"
+                <TextBlock Grid.Row="11"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Account, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Account : " 
+                           Text="Account : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="22"
+                <TextBlock Grid.Row="11"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.Account, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.Account}" />
-            <TextBlock Grid.Row="23"
+                <TextBlock Grid.Row="12"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.ProcessId, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Process Id : " 
+                           Text="Process Id : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="23"
+                <TextBlock Grid.Row="12"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.ProcessId, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.ProcessId}" />
-            <TextBlock Grid.Row="24"
+                <TextBlock Grid.Row="13"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.FileName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="FileName : " 
+                           Text="FileName : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="24"
+                <TextBlock Grid.Row="13"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.FileName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Invocation.FileName}" />
-            <TextBlock Grid.Row="25"
+                           Text="{Binding Invocation.FileName}"
+                           TextWrapping="Wrap" />
+                <TextBlock Grid.Row="14"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.WorkingDirectory, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Working Directory : " 
+                           Text="Working Directory : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="25"
+                <TextBlock Grid.Row="14"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.WorkingDirectory, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.WorkingDirectory}" />
-            <TextBlock Grid.Row="26"
+                <TextBlock Grid.Row="15"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EnvironmentVariables, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Environment Variables : " 
+                           Text="Environment Variables : "
                            Style="{StaticResource PropertyKey}" />
-            <TextBlock Grid.Row="26"
+                <TextBlock Grid.Row="15"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.EnvironmentVariables, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.EnvironmentVariables}" />
+            </Grid>
 
-            <TextBlock Grid.Row="27"
-                       Grid.Column="0"
-                       Grid.ColumnSpan="2"
+            <TextBlock DockPanel.Dock="Top"
                        Margin="0 25 0 0">
                 <Hyperlink Command="{Binding OpenLogFileCommand}">Open Log File</Hyperlink>
             </TextBlock>
-        </Grid>
+
+        </DockPanel>
     </DataTemplate>
 
 </ResourceDictionary>

--- a/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
+++ b/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
@@ -59,7 +59,13 @@ namespace Microsoft.Sarif.Viewer.ViewModels
                 Name = "Avoid unused private fields",
                 HelpUri = "http://aka.ms/analysis/ca1823",
                 Severity = "Unknown"
-             };
+            };
+
+            viewModel.Invocation = new InvocationModel()
+            {
+                CommandLine = @"""C:\Temp\Foo.exe"" target.file /o out.sarif",
+                FileName = @"C:\Temp\Foo.exe",
+            };
 
             viewModel.Locations.Add(new Models.AnnotatedCodeLocationModel()
             {

--- a/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
@@ -61,7 +61,7 @@
                     <controls:InternetHyperlink DockPanel.Dock="Left"
                                                 Text="{Binding Rule.Id}"
                                                 NavigateUri="{Binding Rule.HelpUri}"
-                                                Margin="0 0 5 1"
+                                                Margin="0 0 5 0"
                                                 FontWeight="SemiBold"
                                                 FontSize="14.5"/>
                     <TextBlock DockPanel.Dock="Left"


### PR DESCRIPTION
- Fixed alignment of dialog header text
- Do not display the 'no additional content' string in the info tab.