### PR TITLE
Add 'callee' and 'calleeKey' to annotatedCodeLocation object.

### DIFF
--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -63,6 +63,16 @@
           "type": "string"
         },
 
+        "callee": {
+          "description": "For annotated code locations of kind 'call', the fully qualified logical name of the function being called.",
+          "type": "string"
+        },
+
+        "calleeKey": {
+          "description": "A key used to retrieve the callee logicalLocation from the logicalLocations dictionary.",
+          "type": "string"
+        },
+
         "module": {
           "description": "The name of the module that contains the code that is executing.",
           "type": "string"


### PR DESCRIPTION
@lgolding @rtaket 

ryley, if you can merge this change and regenerate the telemetry build, I'd appreciate it. i'm temporarily taking a build with 'callee' (but not the telemetry work) in order to make progress against SDV direct production.