### PR TITLE
Display real call tree in viewer

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFlowToTreeConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFlowToTreeConverterTests.cs
@@ -66,6 +66,18 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes.Count.Should().Be(2);
             topLevelNodes[0].Children.Count.Should().Be(4);
             topLevelNodes[0].Children[2].Children.Count.Should().Be(1);
+
+            // Check that we have the right nodes at the right places in the tree.
+            topLevelNodes[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[0].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[0].Children[0].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
+            topLevelNodes[0].Children[1].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[0].Children[1].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
+            topLevelNodes[0].Children[2].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[0].Children[2].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
+            topLevelNodes[0].Children[3].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
+            topLevelNodes[1].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[1].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
         }
 
         public void CanConvertCodeFlowToTreeNonCallOrReturn()
@@ -118,6 +130,13 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes.Count.Should().Be(2);
             topLevelNodes[0].Children.Count.Should().Be(4);
             topLevelNodes[1].Children.Count.Should().Be(3);
+
+            // Spot-check that we have the right nodes at the right places in the tree.
+            topLevelNodes[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[0].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Declaration);
+            topLevelNodes[0].Children[3].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
+            topLevelNodes[1].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Call);
+            topLevelNodes[1].Children[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.CallReturn);
         }
 
         public void CanConvertCodeFlowToTreeOnlyDeclarations()
@@ -147,6 +166,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             topLevelNodes[0].Children.Should().BeEmpty();
             topLevelNodes[1].Children.Should().BeEmpty();
             topLevelNodes[2].Children.Should().BeEmpty();
+
+            topLevelNodes[0].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Declaration);
+            topLevelNodes[1].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Declaration);
+            topLevelNodes[2].Location.Kind.Should().Be(AnnotatedCodeLocationKind.Declaration);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFlowToTreeConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeFlowToTreeConverterTests.cs
@@ -61,11 +61,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            CallTreeNode root = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
 
-            root.Children.Count.Should().Be(2);
-            root.Children[0].Children.Count.Should().Be(4);
-            root.Children[0].Children[2].Children.Count.Should().Be(1);
+            topLevelNodes.Count.Should().Be(2);
+            topLevelNodes[0].Children.Count.Should().Be(4);
+            topLevelNodes[0].Children[2].Children.Count.Should().Be(1);
         }
 
         public void CanConvertCodeFlowToTreeNonCallOrReturn()
@@ -113,11 +113,11 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            CallTreeNode root = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
 
-            root.Children.Count.Should().Be(2);
-            root.Children[0].Children.Count.Should().Be(4);
-            root.Children[1].Children.Count.Should().Be(3);
+            topLevelNodes.Count.Should().Be(2);
+            topLevelNodes[0].Children.Count.Should().Be(4);
+            topLevelNodes[1].Children.Count.Should().Be(3);
         }
 
         public void CanConvertCodeFlowToTreeOnlyDeclarations()
@@ -141,10 +141,12 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 }
             };
 
-            CallTreeNode root = CodeFlowToTreeConverter.Convert(codeFlow);
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
 
-            root.Children.Count.Should().Be(3);
-            root.Children[0].Children.Count.Should().Be(0);
+            topLevelNodes.Count.Should().Be(3);
+            topLevelNodes[0].Children.Should().BeEmpty();
+            topLevelNodes[1].Children.Should().BeEmpty();
+            topLevelNodes[2].Children.Should().BeEmpty();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeFlowToTreeConverter.cs
@@ -1,26 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Sarif.Viewer.VisualStudio
 {
     internal static class CodeFlowToTreeConverter
     {
-        internal static CallTreeNode Convert(CodeFlow codeFlow)
+        internal static List<CallTreeNode> Convert(CodeFlow codeFlow)
         {
            int currentCodeFlowIndex = -1;
 
-            CallTreeNode root = new CallTreeNode
-            {
-                Children = GetChildren(codeFlow, ref currentCodeFlowIndex)
-            };
-
-            return root;
+            return GetChildren(codeFlow, ref currentCodeFlowIndex);
         }
 
         private static List<CallTreeNode> GetChildren(CodeFlow codeFlow, ref int currentCodeFlowIndex)
@@ -36,6 +29,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
                     case AnnotatedCodeLocationKind.Call:
                         children.Add(new CallTreeNode
                         {
+                            Location = codeFlow.Locations[currentCodeFlowIndex],
                             Children = GetChildren(codeFlow, ref currentCodeFlowIndex)
                         });
                         break;
@@ -43,6 +37,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
                     case AnnotatedCodeLocationKind.CallReturn:
                         children.Add(new CallTreeNode
                         {
+                            Location = codeFlow.Locations[currentCodeFlowIndex],
                             Children = new List<CallTreeNode>()
                         });
                         foundCallReturn = true;
@@ -51,6 +46,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio
                     default:
                         children.Add(new CallTreeNode
                         {
+                            Location = codeFlow.Locations[currentCodeFlowIndex],
                             Children = new List<CallTreeNode>()
                         });
                         currentCodeFlowIndex++;

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Sarif.Viewer.Models
+{
+    public class CallTree
+    {
+        public CallTree(IList<CallTreeNode> topLevelNodes)
+        {
+            TopLevelNodes = new ObservableCollection<CallTreeNode>(topLevelNodes);
+        }
+
+        public ObservableCollection<CallTreeNode> TopLevelNodes { get; }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Sarif;
 
@@ -9,6 +8,7 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     public class CallTreeNode
     {
+        public AnnotatedCodeLocation Location { get; set; }
         public List<CallTreeNode> Children { get; set; }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Sarif.Viewer
         private AnnotatedCodeLocationCollection _locations;
         private AnnotatedCodeLocationCollection _relatedLocations;
         private ObservableCollection<AnnotatedCodeLocationCollection> _codeFlows;
+        private ObservableCollection<CallTree> _callTrees;
         private ObservableCollection<StackCollection> _stacks;
         private ObservableCollection<FixModel> _fixes;
         private DelegateCommand _openLogFileCommand;
@@ -31,6 +32,7 @@ namespace Microsoft.Sarif.Viewer
             this._locations = new AnnotatedCodeLocationCollection(String.Empty);
             this._relatedLocations = new AnnotatedCodeLocationCollection(String.Empty);
             this._codeFlows = new ObservableCollection<AnnotatedCodeLocationCollection>();
+            this._callTrees = new ObservableCollection<CallTree>();
             this._stacks = new ObservableCollection<StackCollection>();
             this._fixes = new ObservableCollection<FixModel>();
         }
@@ -79,6 +81,7 @@ namespace Microsoft.Sarif.Viewer
                 foreach (CodeFlow codeFlow in result.CodeFlows)
                 {
                     this.CodeFlows.Add(codeFlow.ToAnnotatedCodeLocationCollection());
+                    this.CallTrees.Add(codeFlow.ToCallTree());
                 }
             }
 
@@ -216,6 +219,14 @@ namespace Microsoft.Sarif.Viewer
             get
             {
                 return this._codeFlows;
+            }
+        }
+
+        public ObservableCollection<CallTree> CallTrees
+        {
+            get
+            {
+                return this._callTrees;
             }
         }
 

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Converters\ObjectToVisibilityConverter.cs" />
     <Compile Include="DelegateCommand.cs" />
     <Compile Include="DelegateCommandBase.cs" />
+    <Compile Include="Models\CallTree.cs" />
     <Compile Include="Models\CallTreeNode.cs" />
     <Compile Include="Models\InvocationModel.cs" />
     <Compile Include="Models\ReplacementModel.cs" />
@@ -303,6 +304,10 @@
     <Page Include="Controls\InternetHyperlink.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Themes\CallTrees.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Themes\CodeFlows.xaml">
       <SubType>Designer</SubType>

--- a/src/Sarif.Viewer.VisualStudio/Sarif/CodeFlow.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/CodeFlow.extensions.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Sarif.Viewer.VisualStudio;
 
 namespace Microsoft.Sarif.Viewer.Sarif
 {
@@ -37,6 +33,18 @@ namespace Microsoft.Sarif.Viewer.Sarif
             }
 
             return model;
+        }
+
+        public static CallTree ToCallTree(this CodeFlow codeFlow)
+        {
+            if (codeFlow == null || codeFlow.Locations.Count == 0)
+            {
+                return null;
+            }
+
+            List<CallTreeNode> topLevelNodes = CodeFlowToTreeConverter.Convert(codeFlow);
+
+            return new CallTree(topLevelNodes);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
@@ -1,0 +1,26 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Microsoft.Sarif.Viewer.Themes"
+                    xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/DefaultStyles.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <DataTemplate x:Key="CallTreeTemplate">
+        <ListView ItemsSource="{Binding}">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TreeView ItemsSource="{Binding TopLevelNodes}">
+                        <TreeView.ItemTemplate>
+                            <HierarchicalDataTemplate DataType="x:Type local:CallTreeNode" ItemsSource="{Binding Children}">
+                                <TextBlock Text="{Binding Location.Kind}" />
+                            </HierarchicalDataTemplate>
+                        </TreeView.ItemTemplate>
+                    </TreeView>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </DataTemplate>
+
+</ResourceDictionary>

--- a/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
@@ -25,6 +25,7 @@
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Locations.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Stacks.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/CodeFlows.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/CallTrees.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Fixes.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Information.xaml" />
                 <ResourceDictionary>
@@ -152,6 +153,23 @@
 
                 <ContentControl ContentTemplate="{StaticResource AnnotatedCodeLocationCollectionDataGridTemplate}"
                                 Content="{Binding CodeFlows}" />
+            </TabItem>
+            <TabItem Visibility="{Binding CallTrees, Converter={StaticResource collectionToVisibility0Converter}}">
+                <TabItem.Header>
+                    <DockPanel Margin="5 0 5 0">
+                        <TextBlock DockPanel.Dock="Left"
+                                   Text="Call Trees" />
+                        <TextBlock DockPanel.Dock="Left"
+                                   Visibility="{Binding CallTrees, Converter={StaticResource collectionToVisibility1Converter}}">
+                            <Run Text=" (" />
+                            <Run Text="{Binding CallTrees, Mode=OneWay, Converter={StaticResource collectionToCountConverter}}" />
+                            <Run Text=")" />
+                        </TextBlock>
+                    </DockPanel>
+                </TabItem.Header>
+
+                <ContentControl ContentTemplate="{StaticResource CallTreeTemplate}"
+                                Content="{Binding CallTrees}" />
             </TabItem>
             <TabItem Visibility="{Binding Stacks, Converter={StaticResource collectionToVisibility0Converter}}">
                 <TabItem.Header>


### PR DESCRIPTION
Add a list of `CallTree` objects to the view model. Populate them by converting each code flow to a nested call tree using @jericahuang and @kschecht's `CodeFlowToTreeConverter` class. Display them in a new tab in the "code locations" window. 

As we've discussed, I was wrong to suggest that the `CodeFlowToTreeConverter` produce a single, dummy node containing all the top-level code flow locations. Instead, it now produces a list of the top-level nodes. I adjusted the converter and the tests accordingly.

This is _just enough_ code to demonstrate that we get real code flow data in a real tree view. There's no styling, no data templating, no scroll bars -- I'm just displaying the `AnnotatedCodeLocation.Kind` to show that it's real. The fun part comes next.

![image](https://cloud.githubusercontent.com/assets/11762653/16858626/197b323e-49dd-11e6-8d05-f061834e2a8a.png)
