### PR TITLE
Fix #409 Space between "File" and "Name"

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
@@ -49,7 +49,7 @@
                 <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Rule.Version, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Version : "
+                           Text="Version: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="2"
                            Grid.Column="1"
@@ -58,7 +58,7 @@
                 <TextBlock Grid.Row="3"
                            Grid.Column="0"
                            Visibility="{Binding Rule.Category, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Category : "
+                           Text="Category: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="3"
                            Grid.Column="1"
@@ -66,7 +66,7 @@
                            Text="{Binding Rule.Category}" />
                 <TextBlock Grid.Row="4"
                            Grid.Column="0"
-                           Text="Default Severity : "
+                           Text="Default level: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="4"
                            Grid.Column="1"
@@ -74,7 +74,7 @@
                 <TextBlock Grid.Row="5"
                            Grid.Column="0"
                            Visibility="{Binding Rule.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner : "
+                           Text="Owner: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="5"
                            Grid.Column="1"
@@ -83,7 +83,7 @@
                 <TextBlock Grid.Row="6"
                            Grid.Column="0"
                            Visibility="{Binding Rule.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback : "
+                           Text="Feedback: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="6"
                            Grid.Column="1"
@@ -149,7 +149,7 @@
                 <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Tool.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner : "
+                           Text="Owner: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="2"
                            Grid.Column="1"
@@ -158,7 +158,7 @@
                 <TextBlock Grid.Row="3"
                            Grid.Column="0"
                            Visibility="{Binding Tool.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback : "
+                           Text="Feedback: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="3"
                            Grid.Column="1"
@@ -176,7 +176,7 @@
                 <TextBlock Grid.Row="7"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Command Line : "
+                           Text="Command line: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBox Grid.Row="7"
                          Grid.Column="1"
@@ -190,7 +190,7 @@
                 <TextBlock Grid.Row="8"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.StartTime, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Start Time : "
+                           Text="Start time: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="8"
                            Grid.Column="1"
@@ -199,7 +199,7 @@
                 <TextBlock Grid.Row="9"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EndTime, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="End Time : "
+                           Text="End time: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="9"
                            Grid.Column="1"
@@ -208,7 +208,7 @@
                 <TextBlock Grid.Row="10"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Machine, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Machine : "
+                           Text="Machine: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="10"
                            Grid.Column="1"
@@ -217,7 +217,7 @@
                 <TextBlock Grid.Row="11"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Account, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Account : "
+                           Text="Account: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="11"
                            Grid.Column="1"
@@ -226,7 +226,7 @@
                 <TextBlock Grid.Row="12"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.ProcessId, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Process Id : "
+                           Text="Process id: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="12"
                            Grid.Column="1"
@@ -235,7 +235,7 @@
                 <TextBlock Grid.Row="13"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.FileName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="FileName : "
+                           Text="File name: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="13"
                            Grid.Column="1"
@@ -245,7 +245,7 @@
                 <TextBlock Grid.Row="14"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.WorkingDirectory, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Working Directory : "
+                           Text="Working directory: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="14"
                            Grid.Column="1"
@@ -254,7 +254,7 @@
                 <TextBlock Grid.Row="15"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EnvironmentVariables, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Environment Variables : "
+                           Text="Environment variables: "
                            Style="{StaticResource PropertyKey}" />
                 <TextBlock Grid.Row="15"
                            Grid.Column="1"

--- a/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
+++ b/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.CodeAnalysis.Sarif;
 
 namespace Microsoft.Sarif.Viewer.ViewModels
 {
@@ -145,6 +146,37 @@ namespace Microsoft.Sarif.Viewer.ViewModels
                 Region = new CodeAnalysis.Sarif.Region(13, 1, 13, 2, 0, 0),
             });
             viewModel.CodeFlows.Add(codeFlows2);
+
+            viewModel.CallTrees.Add(new CallTree(
+                new List<CallTreeNode>
+                {
+                    new CallTreeNode
+                    {
+                        Location = new AnnotatedCodeLocation
+                        {
+                            Kind = AnnotatedCodeLocationKind.Assignment
+                        }
+                    },
+
+                    new CallTreeNode
+                    {
+                        Location = new AnnotatedCodeLocation
+                        {
+                            Kind = AnnotatedCodeLocationKind.Call,
+                            Callee = "my_func"
+                        },
+                        Children = new List<CallTreeNode>
+                        {
+                            new CallTreeNode
+                            {
+                                Location = new AnnotatedCodeLocation
+                                {
+                                    Kind = AnnotatedCodeLocationKind.CallReturn
+                                }
+                            }
+                        }
+                    }
+                }));
 
             StackCollection stack1 = new StackCollection("Stack A1");
             stack1.Add(new StackFrameModel()


### PR DESCRIPTION
Also:

* Use sentence casing on data item labels.
* Use "level" instead of "severity".
* Don't put spaces before colons.
* Add some dummy data to display in the call tree tab at design time.