### PR TITLE
Fix #435: Remove non-existent Tool and Rule properties

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Sarif.Viewer.Models
         private string _id;
         private string _name;
         private string _category;
-        private string _severity;
+        private string _defaultLevel;
         private string _description;
         private string _helpUri;
 
@@ -80,13 +80,13 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._severity;
+                return this._defaultLevel;
             }
             set
             {
-                if (value != this._severity)
+                if (value != this._defaultLevel)
                 {
-                    this._severity = value;
+                    this._defaultLevel = value;
                     NotifyPropertyChanged("Severity");
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._id;
+                return _id;
             }
             set
             {
-                if (value != this._id)
+                if (value != _id)
                 {
-                    this._id = value;
-                    NotifyPropertyChanged("Id");
+                    _id = value;
+                    NotifyPropertyChanged(nameof(Id));
                 }
             }
         }
@@ -32,14 +32,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._name;
+                return _name;
             }
             set
             {
-                if (value != this._name)
+                if (value != _name)
                 {
-                    this._name = value;
-                    NotifyPropertyChanged("Name");
+                    _name = value;
+                    NotifyPropertyChanged(nameof(Name));
                 }
             }
         }
@@ -48,14 +48,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._description;
+                return _description;
             }
             set
             {
-                if (value != this._description)
+                if (value != _description)
                 {
-                    this._description = value;
-                    NotifyPropertyChanged("Description");
+                    _description = value;
+                    NotifyPropertyChanged(nameof(Description));
                 }
             }
         }
@@ -64,14 +64,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._category;
+                return _category;
             }
             set
             {
-                if (value != this._category)
+                if (value != _category)
                 {
-                    this._category = value;
-                    NotifyPropertyChanged("Category");
+                    _category = value;
+                    NotifyPropertyChanged(nameof(Category));
                 }
             }
         }
@@ -80,14 +80,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._defaultLevel;
+                return _defaultLevel;
             }
             set
             {
-                if (value != this._defaultLevel)
+                if (value != _defaultLevel)
                 {
-                    this._defaultLevel = value;
-                    NotifyPropertyChanged("Severity");
+                    _defaultLevel = value;
+                    NotifyPropertyChanged(nameof(DefaultLevel));
                 }
             }
         }
@@ -96,14 +96,14 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._helpUri;
+                return _helpUri;
             }
             set
             {
-                if (value != this._helpUri)
+                if (value != _helpUri)
                 {
-                    this._helpUri = value;
-                    NotifyPropertyChanged("HelpUri");
+                    _helpUri = value;
+                    NotifyPropertyChanged(nameof(HelpUri));
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/RuleModel.cs
@@ -1,27 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using Microsoft.CodeAnalysis.Sarif;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Sarif.Viewer.Models
 {
     public class RuleModel : NotifyPropertyChangedObject
     {
         private string _id;
         private string _name;
-        private string _version;
         private string _category;
         private string _severity;
         private string _description;
-        private string _ownerName;
-        private string _ownerUri;
-        private string _feedbackUri;
         private string _helpUri;
 
         public string Id
@@ -52,54 +40,6 @@ namespace Microsoft.Sarif.Viewer.Models
                 {
                     this._name = value;
                     NotifyPropertyChanged("Name");
-                }
-            }
-        }
-
-        public string OwnerName
-        {
-            get
-            {
-                return this._ownerName;
-            }
-            set
-            {
-                if (value != this._ownerName)
-                {
-                    this._ownerName = value;
-                    NotifyPropertyChanged("OwnerName");
-                }
-            }
-        }
-
-        public string OwnerUri
-        {
-            get
-            {
-                return this._ownerUri;
-            }
-            set
-            {
-                if (value != this._ownerUri)
-                {
-                    this._ownerUri = value;
-                    NotifyPropertyChanged("OwnerUri");
-                }
-            }
-        }
-
-        public string FeedbackUri
-        {
-            get
-            {
-                return this._feedbackUri;
-            }
-            set
-            {
-                if (value != this._feedbackUri)
-                {
-                    this._feedbackUri = value;
-                    NotifyPropertyChanged("FeedbackUri");
                 }
             }
         }
@@ -136,7 +76,7 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        public string Severity
+        public string DefaultLevel
         {
             get
             {
@@ -164,22 +104,6 @@ namespace Microsoft.Sarif.Viewer.Models
                 {
                     this._helpUri = value;
                     NotifyPropertyChanged("HelpUri");
-                }
-            }
-        }
-
-        public string Version
-        {
-            get
-            {
-                return this._version;
-            }
-            set
-            {
-                if (value != this._version)
-                {
-                    this._version = value;
-                    NotifyPropertyChanged("Version");
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
@@ -1,14 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using Microsoft.CodeAnalysis.Sarif;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Sarif.Viewer.Models
 {
     public class ToolModel : NotifyPropertyChangedObject
@@ -17,24 +9,19 @@ namespace Microsoft.Sarif.Viewer.Models
         private string _fullName;
         private string _version;
         private string _semanticVersion;
-        private string _description;
-        private string _ownerName;
-        private string _ownerUri;
-        private string _feedbackUri;
-        private string _helpUri;
 
         public string Name
         {
             get
             {
-                return this._name;
+                return _name;
             }
             set
             {
-                if (value != this._name)
+                if (value != _name)
                 {
-                    this._name = value;
-                    NotifyPropertyChanged("Name");
+                    _name = value;
+                    NotifyPropertyChanged(nameof(Name));
                 }
             }
         }
@@ -55,98 +42,18 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        public string OwnerName
-        {
-            get
-            {
-                return this._ownerName;
-            }
-            set
-            {
-                if (value != this._ownerName)
-                {
-                    this._ownerName = value;
-                    NotifyPropertyChanged("OwnerName");
-                }
-            }
-        }
-
-        public string OwnerUri
-        {
-            get
-            {
-                return this._ownerUri;
-            }
-            set
-            {
-                if (value != this._ownerUri)
-                {
-                    this._ownerUri = value;
-                    NotifyPropertyChanged("OwnerUri");
-                }
-            }
-        }
-
-        public string FeedbackUri
-        {
-            get
-            {
-                return this._feedbackUri;
-            }
-            set
-            {
-                if (value != this._feedbackUri)
-                {
-                    this._feedbackUri = value;
-                    NotifyPropertyChanged("FeedbackUri");
-                }
-            }
-        }
-
-        public string Description
-        {
-            get
-            {
-                return this._description;
-            }
-            set
-            {
-                if (value != this._description)
-                {
-                    this._description = value;
-                    NotifyPropertyChanged("Description");
-                }
-            }
-        }
-
-        public string HelpUri
-        {
-            get
-            {
-                return this._helpUri;
-            }
-            set
-            {
-                if (value != this._helpUri)
-                {
-                    this._helpUri = value;
-                    NotifyPropertyChanged("HelpUri");
-                }
-            }
-        }
-
         public string Version
         {
             get
             {
-                return this._version;
+                return _version;
             }
             set
             {
-                if (value != this._version)
+                if (value != _version)
                 {
-                    this._version = value;
-                    NotifyPropertyChanged("Version");
+                    _version = value;
+                    NotifyPropertyChanged(nameof(Version));
                 }
             }
         }
@@ -155,13 +62,13 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._semanticVersion;
+                return _semanticVersion;
             }
             set
             {
-                if (value != this._semanticVersion)
+                if (value != _semanticVersion)
                 {
-                    this._semanticVersion = value;
+                    _semanticVersion = value;
                     NotifyPropertyChanged(nameof(SemanticVersion));
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/ToolModel.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Sarif.Viewer.Models
         {
             get
             {
-                return this._fullName;
+                return _fullName;
             }
             set
             {
-                if (value != this._fullName)
+                if (value != _fullName)
                 {
-                    this._fullName = value;
+                    _fullName = value;
                     NotifyPropertyChanged(nameof(FullName));
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Rule.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Rule.extensions.cs
@@ -3,14 +3,6 @@
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Sarif.Viewer.Sarif
 {
@@ -34,15 +26,9 @@ namespace Microsoft.Sarif.Viewer.Sarif
                     Id = rule.Id,
                     Name = rule.Name,
                     Category = rule.GetCategory(),
-                    Severity = rule.DefaultLevel.ToString(),
+                    DefaultLevel = rule.DefaultLevel.ToString(),
                     Description = rule.FullDescription,
-                    HelpUri = rule.HelpUri?.AbsoluteUri,
-
-                    // TODO: Replace with real values
-                    //Version = "0.0.0",
-                    //OwnerName = "John Doe",
-                    //OwnerUri = "mailto:johndoe@sarif.microsoft.com",
-                    //FeedbackUri = "mailto:toolfeedback@sarif.microsoft.com",
+                    HelpUri = rule.HelpUri?.AbsoluteUri
                 };
             }
 

--- a/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Information.xaml
@@ -21,9 +21,6 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -31,7 +28,8 @@
                 </Grid.ColumnDefinitions>
                 <DockPanel Grid.Row="0"
                       Grid.Column="0"
-                      Grid.ColumnSpan="2">
+                      Grid.ColumnSpan="2"
+                      Margin="0,0,0,10">
                     <TextBlock DockPanel.Dock="Left"
                                Text="{Binding Rule.Id}"
                                FontWeight="Bold"
@@ -41,62 +39,42 @@
                                Visibility="{Binding Rule.Name, Converter={StaticResource stringToVisibilityConverter}}"
                                FontWeight="Bold" />
                 </DockPanel>
-                <controls:InternetHyperlink Grid.Row="1"
-                                            Text="Help"
-                                            Margin="0 0 0 5"
-                                            Visibility="{Binding Rule.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
-                                            NavigateUri="{Binding Rule.HelpUri}" />
-                <TextBlock Grid.Row="2"
+
+                <TextBlock Grid.Row="1"
                            Grid.Column="0"
-                           Visibility="{Binding Rule.Version, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Version: "
+                           Text="Default level: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="2"
+                <TextBlock Grid.Row="1"
                            Grid.Column="1"
-                           Visibility="{Binding Rule.Version, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Rule.Version}" />
-                <TextBlock Grid.Row="3"
+                           Text="{Binding Rule.DefaultLevel}" />
+                <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Rule.Category, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Category: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="3"
+                <TextBlock Grid.Row="2"
                            Grid.Column="1"
                            Visibility="{Binding Rule.Category, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.Category}" />
+                <TextBlock Grid.Row="3"
+                           Grid.Column="0"
+                           Visibility="{Binding Rule.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
+                           Text="Help: "
+                           Style="{StaticResource PropertyKey}" />
+                <controls:InternetHyperlink Grid.Row="3"
+                                            Grid.Column="1"
+                                            Text="{Binding Rule.HelpUri}"
+                                            Margin="0 0 0 5"
+                                            Visibility="{Binding Rule.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
+                                            NavigateUri="{Binding Rule.HelpUri}" />
                 <TextBlock Grid.Row="4"
-                           Grid.Column="0"
-                           Text="Default level: "
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="4"
-                           Grid.Column="1"
-                           Text="{Binding Rule.Severity}" />
-                <TextBlock Grid.Row="5"
-                           Grid.Column="0"
-                           Visibility="{Binding Rule.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner: "
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="5"
-                           Grid.Column="1"
-                           Visibility="{Binding Rule.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Rule.OwnerName}" />
-                <TextBlock Grid.Row="6"
-                           Grid.Column="0"
-                           Visibility="{Binding Rule.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback: "
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="6"
-                           Grid.Column="1"
-                           Visibility="{Binding Rule.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Rule.FeedbackUri}" />
-                <TextBlock Grid.Row="7"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
                            Visibility="{Binding Rule.Description, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Rule.Description}"
                            TextWrapping="Wrap"
                            Style="{StaticResource PropertyKey}" />
-                <Separator Grid.Row="8"
+                <Separator Grid.Row="5"
                            Grid.Column="0"
                            Grid.ColumnSpan="2"
                            Margin="0 15 0 3" />
@@ -116,12 +94,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
+
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -130,7 +103,8 @@
 
                 <DockPanel Grid.Row="0"
                       Grid.Column="0"
-                      Grid.ColumnSpan="2">
+                      Grid.ColumnSpan="2"
+                      Margin="0, 0, 0, 10">
                     <TextBlock DockPanel.Dock="Left"
                                Text="{Binding Tool.Name}"
                                FontWeight="Bold"
@@ -140,45 +114,14 @@
                                FontWeight="Bold"
                                Visibility="{Binding Tool.Version, Converter={StaticResource stringToVisibilityConverter}}" />
                 </DockPanel>
-                <controls:InternetHyperlink Grid.Row="1"
-                                            Grid.Column="0"
-                                            Text="Help"
-                                            Margin="0 0 0 5"
-                                            Visibility="{Binding Tool.HelpUri, Converter={StaticResource stringToVisibilityConverter}}"
-                                            NavigateUri="{Binding Tool.HelpUri}" />
-                <TextBlock Grid.Row="2"
-                           Grid.Column="0"
-                           Visibility="{Binding Tool.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Owner: "
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="2"
-                           Grid.Column="1"
-                           Visibility="{Binding Tool.OwnerName, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Tool.OwnerName}" />
-                <TextBlock Grid.Row="3"
-                           Grid.Column="0"
-                           Visibility="{Binding Tool.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="Feedback: "
-                           Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="3"
-                           Grid.Column="1"
-                           Visibility="{Binding Tool.FeedbackUri, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Tool.FeedbackUri}" />
-                <TextBlock Grid.Row="4"
-                           Grid.Column="0"
-                           Grid.ColumnSpan="2"
-                           Visibility="{Binding Tool.Description, Converter={StaticResource stringToVisibilityConverter}}"
-                           Text="{Binding Tool.Description}"
-                           TextWrapping="Wrap"
-                           Style="{StaticResource PropertyKey}" />
 
                 <!-- Invocation metadata -->
-                <TextBlock Grid.Row="7"
+                <TextBlock Grid.Row="1"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Command line: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBox Grid.Row="7"
+                <TextBox Grid.Row="1"
                          Grid.Column="1"
                          Visibility="{Binding Invocation.CommandLine, Converter={StaticResource stringToVisibilityConverter}}"
                          Background="Transparent"
@@ -187,76 +130,76 @@
                          IsReadOnly="True"
                          TextWrapping="Wrap"
                          IsTabStop="False" />
-                <TextBlock Grid.Row="8"
+                <TextBlock Grid.Row="2"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.StartTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Start time: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="8"
+                <TextBlock Grid.Row="2"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.StartTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.StartTime}" />
-                <TextBlock Grid.Row="9"
+                <TextBlock Grid.Row="3"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EndTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="End time: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="9"
+                <TextBlock Grid.Row="3"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.EndTime, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.EndTime}" />
-                <TextBlock Grid.Row="10"
+                <TextBlock Grid.Row="4"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Machine, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Machine: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="10"
+                <TextBlock Grid.Row="4"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.Machine, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.Machine}" />
-                <TextBlock Grid.Row="11"
+                <TextBlock Grid.Row="5"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.Account, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Account: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="11"
+                <TextBlock Grid.Row="5"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.Account, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.Account}" />
-                <TextBlock Grid.Row="12"
+                <TextBlock Grid.Row="6"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.ProcessId, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Process id: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="12"
+                <TextBlock Grid.Row="6"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.ProcessId, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.ProcessId}" />
-                <TextBlock Grid.Row="13"
+                <TextBlock Grid.Row="7"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.FileName, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="File name: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="13"
+                <TextBlock Grid.Row="7"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.FileName, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.FileName}"
                            TextWrapping="Wrap" />
-                <TextBlock Grid.Row="14"
+                <TextBlock Grid.Row="8"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.WorkingDirectory, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Working directory: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="14"
+                <TextBlock Grid.Row="8"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.WorkingDirectory, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.WorkingDirectory}" />
-                <TextBlock Grid.Row="15"
+                <TextBlock Grid.Row="9"
                            Grid.Column="0"
                            Visibility="{Binding Invocation.EnvironmentVariables, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="Environment variables: "
                            Style="{StaticResource PropertyKey}" />
-                <TextBlock Grid.Row="15"
+                <TextBlock Grid.Row="9"
                            Grid.Column="1"
                            Visibility="{Binding Invocation.EnvironmentVariables, Converter={StaticResource stringToVisibilityConverter}}"
                            Text="{Binding Invocation.EnvironmentVariables}" />

--- a/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
+++ b/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
@@ -50,8 +50,6 @@ namespace Microsoft.Sarif.Viewer.ViewModels
             {
                 Name = "FxCop",
                 Version = "1.0.0.0",
-                Description = "FxCop Tool",
-                HelpUri = "http://aka.ms/analysis/ca1824"
             };
 
             viewModel.Rule = new RuleModel()
@@ -59,7 +57,7 @@ namespace Microsoft.Sarif.Viewer.ViewModels
                 Id = "CA1823",
                 Name = "Avoid unused private fields",
                 HelpUri = "http://aka.ms/analysis/ca1823",
-                Severity = "Unknown"
+                DefaultLevel = "Unknown"
             };
 
             viewModel.Invocation = new InvocationModel()


### PR DESCRIPTION
These properties aren't defined in SARIF:
* Rule.Version
* Rule.OwnerName
* Rule.FeedbackUri (but HelpUri does exist, so show that)
* Tool.HelpUri
* Tool.OwnerName
* Tool.FeedbackUri
* Tool.Description (although it's not a bad idea)

Also:

* Add some design-time dummy data to the Call Trees tab.
* Add a little margin below the tool name/version in the Info tab
* Display the actual HelpUri instead of the text "Help" for the hyperlink.

Here's what it looks like now, with dummy data inserted for Category and HelpUri:

![image](https://cloud.githubusercontent.com/assets/11762653/16890434/72a178de-4aa3-11e6-8d30-1a63a7a01f75.png)
