### PR TITLE
Fix #378: Don't offer ".sarif.json" as an extension

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommand.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Sarif.Viewer
             if (logFile == null)
             {
                 string title = "Open Static Analysis Results Interchange Format (SARIF) file";
-                string filter = "SARIF files (*.sarif;*.sarif.json)|*.sarif;*.sarif.json";
+                string filter = "SARIF files (*.sarif)|*.sarif";
 
                 switch (menuCommand.CommandID.ID)
                 {

--- a/src/Sarif.Viewer.VisualStudio/SarifFileAndContentDefinitions.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifFileAndContentDefinitions.cs
@@ -17,11 +17,5 @@ namespace Microsoft.Sarif.Viewer
         [FileExtension(".sarif")]
         [BaseDefinition("sarif")]
         internal static FileExtensionToContentTypeDefinition sarifFileExtensionToContentTypeDefinition = new FileExtensionToContentTypeDefinition();
-
-        [Export]
-        [FileExtension(".sarif.json")]
-        [BaseDefinition("sarif")]
-        internal static FileExtensionToContentTypeDefinition sarifJsonFileExtensionToContentTypeDefinition = new FileExtensionToContentTypeDefinition();
-
     }
 }


### PR DESCRIPTION
The official recommended extension for SARIF files is ".sarif", not ".sarif.json", for reasons discussed in #378. So remove mentions of ".sarif.json" from the VS SARIF VSIX.

@bobschumaker FYI