### PR TITLE
Tweak "tool" property descriptions

### DIFF
--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -1121,12 +1121,12 @@
         },
 
         "version": {
-          "description": "The tool version.",
+          "description": "The tool version, in whatever format the tool natively provides.",
           "type": "string"
         },
 
         "semanticVersion": {
-          "description": "The tool version rendered as Semantic Versioning 2.0.",
+          "description": "The tool version in the format specified by Semantic Versioning 2.0.",
           "type": "string"
         },
 
@@ -1137,7 +1137,7 @@
         },
 
         "sarifLoggerVersion": {
-          "description": "A version that uniuquely identifies the logging component that generated this file, if it is versioned separately from the tool.",
+          "description": "A version that uniquely identifies the SARIF logging component that generated this file, if it is versioned separately from the tool.",
           "type": "string"
         },
 


### PR DESCRIPTION
... for consistency with the spec. This addresses sarif-standard/sarif-spec#176, "Review SDK tool definition to ensure consistency with spec" (that work item really should've been in the sdk repo, but no matter).