### PR TITLE
Add spec sample files to validation tests

### DIFF
--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -917,6 +917,18 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <None Include="SpecExamples\Comprehensive.sarif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SpecExamples\Minimal.sarif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SpecExamples\Recommended.sarif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="SpecExamples\RuleMetadata.sarif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="UpdateBaselines.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
@@ -39,8 +39,17 @@
         }
       },
       "files": {
-        "file:///user/builder/work/src/collections/list.cpp": {
-          "mimeType": "text/x-c"
+        "collections/list.cpp": {
+          "uri": "collections/list.cpp",
+          "uriBaseId": "SRCROOT",
+          "mimeType": "text/x-c",
+          "length": 980,
+          "hashes": [
+            {
+              "algorithm": "sha256",
+              "value": "b13ce2678a8807ba0765ab94a0ecd394f869bc81"
+            }
+          ]
         }
       },
       "logicalLocations": {
@@ -62,16 +71,47 @@
       "results": [
         {
           "ruleId": "C2001",
-          "message": "Variable \"n\" was used without being initialized.",
+          "formattedRuleMessage": {
+            "formatId": "default",
+            "arguments": [
+              "n"
+            ]
+          },
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///user/builder/work/src/collections/list.cpp",
+                "uri": "collections/list.cpp",
                 "region": {
                   "startLine": 15
                 }
               },
               "fullyQualifiedLogicalName": "collections::list:add"
+            }
+          ],
+          "codeFlows": [
+            {
+              "message": "Code flow #1",
+              "locations": [
+                {
+                  "step": 0,
+                  "kind": "declaration",
+                  "importance": "essential",
+                  "fullyQualifiedLogicalName": "collections::list::add",
+                  "physicalLocation": {
+                    "uri": "collections/list.cpp",
+                    "uriBaseId": "SRCROOT",
+                    "region": {
+                      "startLine": 12,
+                      "startColumn": 5,
+                      "endLine": 12,
+                      "endColumn": 11,
+                      "offset": 115,
+                      "length": 6
+                    }
+                  },
+                  "snippet": "int n;"
+                }
+              ]
             }
           ]
         }
@@ -99,7 +139,14 @@
       "rules": {
         "C2001": {
           "id": "C2001",
-          "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions"
+          "name": "UninitializedVariable",
+          "shortDescription": "A variable was used without being initialized.",
+          "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions",
+          "messageFormats": {
+            "default": "Variable \"{0}\" was used without being initialized."
+          },
+          "defaultLevel": "error",
+          "helpUri": "http://www.example.com/tools/codescanner/rules/C2001.aspx"
         }
       }
     }

--- a/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
@@ -1,0 +1,107 @@
+{
+  "version": "1.0.0",
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "runs": [
+    {
+      "id": "BC650830-A9FE-44CB-8818-AD6C387279A0",
+      "stableId": "Nightly code scan",
+      "baselineId": "0A106451-C9B1-4309-A7EE-06988B95F723",
+      "automationId": "Build-14.0.1.2-Release-20160716-13:22:18",
+      "architecture": "x86",
+      "tool": {
+        "name": "CodeScanner",
+        "fullName": "CodeScanner 1.1 for Unix (en-US)",
+        "version": "2.1",
+        "semanticVersion": "2.1.0",
+        "fileVersion": "2.1.0.0",
+        "language": "en-US",
+        "sarifLoggerVersion": "1.25.0",
+        "properties": {
+          "copyright": "Copyright (c) 2016 by Example Corporation. All rights reserved."
+        }
+      },
+      "invocation": {
+        "commandLine": "CodeScanner @collections.rsp",
+        "responseFiles": {
+          "collections.rsp": "-input src/collections/*.cpp -log out/collections.sarif -rules all -disable C9999"
+        },
+        "startTime": "2016-07-16T14:18:25Z",
+        "endTime": "2016-07-16T14:19:01Z",
+        "machine": "BLD01",
+        "account": "builder",
+        "processId": 1218,
+        "fileName": "/bin/tools/CodeScanner",
+        "workingDirectory": "/user/builder/work/src",
+        "environmentVariables": {
+          "PATH": "/usr/local/bin:/bin:/bin/tools:/home/builder/bin",
+          "HOME": "/user/builder",
+          "TZ": "EST"
+        }
+      },
+      "files": {
+        "file:///user/builder/work/src/collections/list.cpp": {
+          "mimeType": "text/x-c"
+        }
+      },
+      "logicalLocations": {
+        "collections::list::add": {
+          "name": "add",
+          "kind": "function",
+          "parentKey": "collections::list"
+        },
+        "collections::list": {
+          "name": "list",
+          "kind": "type",
+          "parentKey": "collections"
+        },
+        "collections": {
+          "name": "collections",
+          "kind": "namespace"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "message": "Variable \"n\" was used without being initialized.",
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///user/builder/work/src/collections/list.cpp",
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list:add"
+            }
+          ]
+        }
+      ],
+      "configurationNotifications": [
+        {
+          "id": "UnknownRule",
+          "ruleId": "ABC0001",
+          "level": "warning",
+          "message": "Could not disable rule \"C9999\" because there is no rule with that id." 
+        }
+      ],
+      "toolNotifications": [
+        {
+          "id": "CTN0001",
+          "level": "note",
+          "message": "Run started."
+        },
+        {
+          "id": "CTN0002",
+          "level": "note",
+          "message": "Run ended."
+        }
+      ],
+      "rules": {
+        "C2001": {
+          "id": "C2001",
+          "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions"
+        }
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/SpecExamples/Minimal.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Minimal.sarif
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0"
+      },
+      "results": [
+      ]
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/SpecExamples/README.md
+++ b/src/Sarif.FunctionalTests/SpecExamples/README.md
@@ -1,0 +1,1 @@
+This directory contains the sample files from Annex G of the specification.

--- a/src/Sarif.FunctionalTests/SpecExamples/Recommended.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Recommended.sarif
@@ -1,0 +1,55 @@
+{
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0"
+      },
+      "files": {
+        "file:///user/builder/work/src/collections/list.cpp": {
+          "mimeType": "text/x-c"
+        }
+      },
+      "logicalLocations": {
+        "collections::list::add": {
+          "name": "add",
+          "kind": "function",
+          "parentKey": "collections::list"
+        },
+        "collections::list": {
+          "name": "list",
+          "kind": "type",
+          "parentKey": "collections"
+        },
+        "collections": {
+          "name": "collections",
+          "kind": "namespace"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "message": "Variable \"n\" was used without being initialized.",
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///user/builder/work/src/collections/list.cpp",
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list:add"
+            }
+          ]
+        }
+      ],
+      "rules": {
+        "C2001": {
+          "id": "C2001",
+          "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions"
+        }
+      }
+    }
+  ]
+}

--- a/src/Sarif.FunctionalTests/SpecExamples/Recommended.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Recommended.sarif
@@ -30,7 +30,7 @@
       "results": [
         {
           "ruleId": "C2001",
-          "message": "Variable \"n\" was used without being initialized.",
+          "message": "Variable \"count\" was used without being initialized.",
           "locations": [
             {
               "analysisTarget": {

--- a/src/Sarif.FunctionalTests/SpecExamples/RuleMetadata.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/RuleMetadata.sarif
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0"
+      },
+      "rules": {
+        "C2001": {
+          "id": "C2001",
+          "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions"
+        }
+      }
+    }
+  ]
+}

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -74,9 +74,11 @@
     <ItemGroup>
       <ConverterTestData Include="$(SolutionDir)\Sarif.FunctionalTests\ConverterTestData\**\*.sarif" />
       <DirectProducerTestData Include="$(SolutionDir)\Sarif.FunctionalTests\DirectProducerTestData\**\*.sarif" />
+      <SpecExamples Include="$(SolutionDir)\Sarif.FunctionalTests\SpecExamples\**\*.sarif" />
     </ItemGroup>
     <Copy SourceFiles="@(ConverterTestData)" DestinationFolder="$(OutDir)ConverterTestData\%(RecursiveDir)" />
     <Copy SourceFiles="@(DirectProducerTestData)" DestinationFolder="$(OutDir)DirectProducerTestData\%(RecursiveDir)" />
+    <Copy SourceFiles="@(SpecExamples)" DestinationFolder="$(OutDir)SpecExamples\%(RecursiveDir)" />
     <Copy SourceFiles="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json" DestinationFolder="$(OutDir)" />
   </Target>
 </Project>

--- a/src/Sarif.ValidationTests/SarifValidatorTests.cs
+++ b/src/Sarif.ValidationTests/SarifValidatorTests.cs
@@ -19,9 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 {
     public class SarifValidatorTests
     {
-        public const string DirectProducerTestDataDirectory = "DirectProducerTestData";
-        public const string ConverterTestDataDirectory = "ConverterTestData";
-        public const string SpectExamplesDirectory = "SpecExamples";
         public const string JsonSchemaFile = "Sarif.schema.json";
 
         private readonly string _jsonSchemaFilePath;
@@ -35,8 +32,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         [Theory]
-        [MemberData(nameof(DirectProducerTestCases))]
-        public void DirectProducerValidation(string inputFile)
+        [MemberData(nameof(TestCases))]
+        public void ValidatesAllTestFiles(string inputFile)
         {
             string instanceText = File.ReadAllText(inputFile);
             var validator = new Validator(_schema);
@@ -51,100 +48,46 @@ namespace Microsoft.CodeAnalysis.Sarif
             errors.Count().Should().Be(0, FailureReason(errors));
         }
 
-        [Theory]
-        [MemberData(nameof(ConverterTestCases))]
-        public void ConverterValidation(string inputFile)
+        private static readonly string[] s_testFileDirectories = new string[]
         {
-            string instanceText = File.ReadAllText(inputFile);
-            var validator = new Validator(_schema);
+            "DirectProducerTestData",
+            "ConverterTestData",
+            "SpecExamples"
+        };
 
-            Result[] errors = validator.Validate(instanceText, inputFile);
-
-            // Test errors.Count(), rather than errors.Should().BeEmpty, because the latter
-            // produces a less clear error message: it calls ToString on each member of
-            // errors, and appends it to the string returned by FailureReason. Since
-            // FailureReason already displayed the error messages in VisualStudio format,
-            // there is no reason to append this additional, less well formatted information.
-            errors.Count().Should().Be(0, FailureReason(errors));
-        }
-
-        [Theory]
-        [MemberData(nameof(SpecExampleTestCases))]
-        public void SpecExampleValidation(string inputFile)
-        {
-            string instanceText = File.ReadAllText(inputFile);
-            var validator = new Validator(_schema);
-
-            Result[] errors = validator.Validate(instanceText, inputFile);
-
-            // Test errors.Count(), rather than errors.Should().BeEmpty, because the latter
-            // produces a less clear error message: it calls ToString on each member of
-            // errors, and appends it to the string returned by FailureReason. Since
-            // FailureReason already displayed the error messages in VisualStudio format,
-            // there is no reason to append this additional, less well formatted information.
-            errors.Count().Should().Be(0, FailureReason(errors));
-        }
-
-        private static IEnumerable<object[]> s_converterTestCases;
-        private static IEnumerable<object[]> s_directProducerTestCases;
-        private static IEnumerable<object[]> s_exampleTestCases;
+        private static IEnumerable<object[]> s_testCases;
 
         private static string[] InvalidFiles = new string[]
         {
         };
 
-        public static IEnumerable<object[]> DirectProducerTestCases
+        public static IEnumerable<object[]> TestCases
         {
             get
             {
-                if (s_directProducerTestCases == null)
+                if (s_testCases == null)
                 {
-                    var sarifFiles = Directory.GetFiles(DirectProducerTestDataDirectory, "*.sarif", SearchOption.AllDirectories);
+                    List<string> sarifFiles = s_testFileDirectories.Aggregate(
+                        new List<string>(),
+                        (allFiles, dir) =>
+                        {
+                            allFiles.AddRange(Directory.GetFiles(dir, "*.sarif", SearchOption.AllDirectories)
 
-                    s_directProducerTestCases = sarifFiles
-                        .Except(InvalidFiles.Select(f => Path.Combine(DirectProducerTestDataDirectory, f)))
-                        .Select(file => new object[] { file.ToLowerInvariant() });
+                                // The converter functional tests produce output files in the test directory
+                                // with the filename extension ".actual.sarif". Don't include those in this test.
+                                .Where(file => !file.EndsWith(".actual.sarif", StringComparison.OrdinalIgnoreCase))
+
+                                // Leave a loophole in case we have to temporarily include a file that doesn't
+                                // conform to the current spec.
+                                .Except(InvalidFiles));
+
+                            return allFiles;
+                        });
+
+                    s_testCases = sarifFiles.Select(file => new object[] { file });
                 }
 
-                return s_directProducerTestCases;
-            }
-        }
-
-        public static IEnumerable<object[]> SpecExampleTestCases
-        {
-            get
-            {
-                if (s_exampleTestCases == null)
-                {
-                    var sarifFiles = Directory.GetFiles(SpectExamplesDirectory, "*.sarif", SearchOption.AllDirectories);
-
-                    s_exampleTestCases = sarifFiles
-                        .Except(InvalidFiles.Select(f => Path.Combine(SpectExamplesDirectory, f)))
-                        .Select(file => new object[] { file.ToLowerInvariant() });
-                }
-
-                return s_exampleTestCases;
-            }
-        }
-
-        public static IEnumerable<object[]> ConverterTestCases
-        {
-            get
-            {
-                if (s_converterTestCases == null)
-                {
-                    var sarifFiles = Directory.GetFiles(ConverterTestDataDirectory, "*.sarif", SearchOption.AllDirectories);
-
-                    // The converter functional tests produce output files in the test directory
-                    // with the filename extension ".actual.sarif". Don't include those in this test.
-                    var actualSarifFiles = Directory.GetFiles(ConverterTestDataDirectory, "*.actual.sarif", SearchOption.AllDirectories);
-
-                    s_converterTestCases = sarifFiles.Except(actualSarifFiles)
-                        .Except(InvalidFiles.Select(f => Path.Combine(ConverterTestDataDirectory, f)))
-                        .Select(file => new object[] { file.ToLowerInvariant() });
-                }
-
-                return s_converterTestCases;
+                return s_testCases;
             }
         }
 


### PR DESCRIPTION
The files in the new Sarif.FunctionalTests\SpecSamples directory are copied from Annex G of the SARIF spec. The idea is to ensure that the files in the spec are valid.

Also:
* DRY out the validation tests. With one small exception, the logic is the same for all the test file subdirectories. So just aggregate the list of files over all subdirectories, and run a single test over the aggregated list.

**NOTES**

1. The "comprehensive" sample file is not yet finished.

2. Look out for the corresponding PR that adds Annex G to the spec; I won't send that PR until the "comprehensive" sample is finished.