### PR TITLE
Rename converter for "essential" icon visibility

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ImportanceToEssentialMarkerVisibilityConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ImportanceToEssentialMarkerVisibilityConverterTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
+using System.Windows;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
-using System.Globalization;
 using Xunit;
-using System.Windows;
 
 namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 {
-    public class ImportanceToExclamationPointConverterTests
+    public class ImportanceToEssentialMarkerVisibilityConverterTests
     {
         [Fact]
         public void ImportanceToExclamationPointConverterHandlesUnimportant()
@@ -32,7 +32,7 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
         private static void VerifyConversion(AnnotatedCodeLocationImportance importance, Visibility expectedVisibility)
         {
-            var converter = new ImportanceToExclamationPointConverter();
+            var converter = new ImportanceToEssentialMarkerVisibilityConverter();
 
             Visibility visibility = (Visibility)converter.Convert(importance, typeof(Visibility), null, CultureInfo.CurrentCulture);
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -52,7 +52,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ImportanceToExclamationPointConverterTests.cs" />
+    <Compile Include="ImportanceToEssentialMarkerVisibilityConverterTests.cs" />
     <Compile Include="ImportanceToBackgroundConverterTests.cs" />
     <Compile Include="ImportanceToForegroundConverterTests .cs" />
     <Compile Include="CallTreeNodeToTextConverterTests.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToEssentialMarkerVisibilityConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToEssentialMarkerVisibilityConverter.cs
@@ -5,11 +5,10 @@ using System;
 using System.Windows;
 using System.Windows.Data;
 using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.Sarif.Viewer.Models;
 
 namespace Microsoft.Sarif.Viewer.Converters
 {
-    public class ImportanceToExclamationPointConverter : IValueConverter
+    public class ImportanceToEssentialMarkerVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -43,7 +43,7 @@
       <DependentUpon>InternetHyperlink.xaml</DependentUpon>
     </Compile>
     <Compile Include="Converters\BooleanToCollapsedVisibilityConverter.cs" />
-    <Compile Include="Converters\ImportanceToExclamationPointConverter.cs" />
+    <Compile Include="Converters\ImportanceToEssentialMarkerVisibilityConverter.cs" />
     <Compile Include="Converters\CallTreeNodeToTextConverter.cs" />
     <Compile Include="Converters\ImportanceToBackgroundConverter.cs" />
     <Compile Include="Converters\CollectionToVisiblity1Converter.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
@@ -17,14 +17,14 @@
                             <cvt:CallTreeNodeToTextConverter x:Key="callTreeToTextConverter" />
                             <cvt:ImportanceToForegroundConverter x:Key="importanceToForegroundConverter" />
                             <cvt:ImportanceToBackgroundConverter x:Key="importanceToBackgroundConverter" />
-                            <cvt:ImportanceToExclamationPointConverter x:Key="importanceToExclamationPointVisibilityConverter" />
+                            <cvt:ImportanceToEssentialMarkerVisibilityConverter x:Key="importanceToEssentialMarkerVisibilityConverter" />
                         </TreeView.Resources>
                         <TreeView.ItemTemplate>
                             <HierarchicalDataTemplate DataType="x:Type local:CallTreeNode" ItemsSource="{Binding Children}">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="!  " FontWeight="Bold" Foreground="Red" 
                                                Visibility="{Binding Location.Importance, 
-                                                            Converter={StaticResource importanceToExclamationPointVisibilityConverter}}" />
+                                                            Converter={StaticResource importanceToEssentialMarkerVisibilityConverter}}" />
                                     <TextBlock Text="{Binding Converter={StaticResource callTreeToTextConverter}}"
                                                Foreground="{Binding Location.Importance, 
                                                             Converter={StaticResource importanceToForegroundConverter}}"


### PR DESCRIPTION
... from `ImportanceToExclamationPointConverter` to `ImportanceToEssentialMarkerVisibilityConverter`.