### PR TITLE
Arrange VSIX unit test directory like product code directory

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CallTreeNodeToTextConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/CallTreeNodeToTextConverterTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Sarif.Viewer.Converters;
 using Microsoft.Sarif.Viewer.Models;
 using Xunit;
 
-namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
     public class CallTreeNodeToTextConverterTests
     {

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToBackgroundConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToBackgroundConverterTests.cs
@@ -1,42 +1,42 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Drawing;
 using System.Globalization;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
 using Xunit;
 
-namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
-    public class ImportanceToForegroundConverterTests
+    public class ImportanceToBackgroundConverterTests
     {
         [Fact]
-        public void ImportanceToForegroundConverterHandlesUnimportant()
+        public void ImportanceToBackgroundConverterHandlesUnimportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Gray");
+            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Transparent");
         }
 
         [Fact]
-        public void ImportanceToForegroundConverterHandlesImportant()
+        public void ImportanceToBackgroundConverterHandlesImportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Black");
+            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Yellow");
         }
 
         [Fact]
-        public void ImportanceToForegroundConverterHandlesEssential()
+        public void ImportanceToBackgroundConverterHandlesEssential()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Black");
+            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Yellow");
         }
 
         private static void VerifyConversion(AnnotatedCodeLocationImportance importance, string expectedColor)
         {
-            var converter = new ImportanceToForegroundConverter();
+            var converter = new ImportanceToBackgroundConverter();
 
             string color = (string)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
 
             color.Should().Be(expectedColor);
         }
+
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToEssentialMarkerVisibilityConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToEssentialMarkerVisibilityConverterTests.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
 using Xunit;
 
-namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
     public class ImportanceToEssentialMarkerVisibilityConverterTests
     {

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToForegroundConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToForegroundConverterTests.cs
@@ -7,36 +7,35 @@ using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
 using Xunit;
 
-namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
 {
-    public class ImportanceToBackgroundConverterTests
+    public class ImportanceToForegroundConverterTests
     {
         [Fact]
-        public void ImportanceToBackgroundConverterHandlesUnimportant()
+        public void ImportanceToForegroundConverterHandlesUnimportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Transparent");
+            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Gray");
         }
 
         [Fact]
-        public void ImportanceToBackgroundConverterHandlesImportant()
+        public void ImportanceToForegroundConverterHandlesImportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Yellow");
+            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Black");
         }
 
         [Fact]
-        public void ImportanceToBackgroundConverterHandlesEssential()
+        public void ImportanceToForegroundConverterHandlesEssential()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Yellow");
+            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Black");
         }
 
         private static void VerifyConversion(AnnotatedCodeLocationImportance importance, string expectedColor)
         {
-            var converter = new ImportanceToBackgroundConverter();
+            var converter = new ImportanceToForegroundConverter();
 
             string color = (string)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
 
             color.Should().Be(expectedColor);
         }
-
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -52,10 +52,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ImportanceToEssentialMarkerVisibilityConverterTests.cs" />
-    <Compile Include="ImportanceToBackgroundConverterTests.cs" />
-    <Compile Include="ImportanceToForegroundConverterTests .cs" />
-    <Compile Include="CallTreeNodeToTextConverterTests.cs" />
+    <Compile Include="Converters\ImportanceToEssentialMarkerVisibilityConverterTests.cs" />
+    <Compile Include="Converters\ImportanceToBackgroundConverterTests.cs" />
+    <Compile Include="Converters\ImportanceToForegroundConverterTests.cs" />
+    <Compile Include="Converters\CallTreeNodeToTextConverterTests.cs" />
     <Compile Include="CodeFlowToTreeConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Moved the tests of the Converter classes into the Converters directory.

@jericahuang @kschecht FYI that's a convention many teams have: to have the directory structure of a test project mirror that of the product code project. It makes the tests easier to find.