### PR TITLE
Importance converters return brushes, not strings

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToBackgroundConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToBackgroundConverterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Windows.Media;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
@@ -14,29 +15,28 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         [Fact]
         public void ImportanceToBackgroundConverterHandlesUnimportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Transparent");
+            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, Colors.Transparent);
         }
 
         [Fact]
         public void ImportanceToBackgroundConverterHandlesImportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Yellow");
+            VerifyConversion(AnnotatedCodeLocationImportance.Important, Colors.Yellow);
         }
 
         [Fact]
         public void ImportanceToBackgroundConverterHandlesEssential()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Yellow");
+            VerifyConversion(AnnotatedCodeLocationImportance.Essential, Colors.Yellow);
         }
 
-        private static void VerifyConversion(AnnotatedCodeLocationImportance importance, string expectedColor)
+        private static void VerifyConversion(AnnotatedCodeLocationImportance importance, Color expectedBrushColor)
         {
             var converter = new ImportanceToBackgroundConverter();
 
-            string color = (string)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
+            var brush = (SolidColorBrush)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
 
-            color.Should().Be(expectedColor);
+            brush.Color.Should().Be(expectedBrushColor);
         }
-
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToForegroundConverterTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Converters/ImportanceToForegroundConverterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Windows.Media;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Converters;
@@ -14,28 +15,28 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.Converters.UnitTests
         [Fact]
         public void ImportanceToForegroundConverterHandlesUnimportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, "Gray");
+            VerifyConversion(AnnotatedCodeLocationImportance.Unimportant, Colors.Gray);
         }
 
         [Fact]
         public void ImportanceToForegroundConverterHandlesImportant()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Important, "Black");
+            VerifyConversion(AnnotatedCodeLocationImportance.Important, Colors.Black);
         }
 
         [Fact]
         public void ImportanceToForegroundConverterHandlesEssential()
         {
-            VerifyConversion(AnnotatedCodeLocationImportance.Essential, "Black");
+            VerifyConversion(AnnotatedCodeLocationImportance.Essential, Colors.Black);
         }
 
-        private static void VerifyConversion(AnnotatedCodeLocationImportance importance, string expectedColor)
+        private static void VerifyConversion(AnnotatedCodeLocationImportance importance, Color expectedBrushColor)
         {
             var converter = new ImportanceToForegroundConverter();
 
-            string color = (string)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
+            var brush = (SolidColorBrush)converter.Convert(importance, typeof(string), null, CultureInfo.CurrentCulture);
 
-            color.Should().Be(expectedColor);
+            brush.Color.Should().Be(expectedBrushColor);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToBackgroundConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToBackgroundConverter.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Drawing;
 using System.Globalization;
 using System.Windows.Data;
+using System.Windows.Media;
 using Microsoft.CodeAnalysis.Sarif;
 
 namespace Microsoft.Sarif.Viewer.Converters
@@ -13,15 +13,17 @@ namespace Microsoft.Sarif.Viewer.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            Color brushColor = Colors.Transparent;
             if (value is AnnotatedCodeLocationImportance)
             {
                 var importance = (AnnotatedCodeLocationImportance)value;
-                return importance == AnnotatedCodeLocationImportance.Unimportant ? "Transparent" : "Yellow";
+                if (importance != AnnotatedCodeLocationImportance.Unimportant)
+                {
+                    brushColor = Colors.Yellow;
+                }
             }
-            else
-            {
-                return "Transparent";
-            }
+
+            return new SolidColorBrush(brushColor);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToForegroundConverter.cs
+++ b/src/Sarif.Viewer.VisualStudio/Converters/ImportanceToForegroundConverter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System;
-using System.Drawing;
+using System.Windows.Media;
 using System.Globalization;
 using System.Windows.Data;
 using Microsoft.CodeAnalysis.Sarif;
@@ -13,17 +13,17 @@ namespace Microsoft.Sarif.Viewer.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            Color brushColor = Colors.Black;
             if (value is AnnotatedCodeLocationImportance)
             {
                 var importance = (AnnotatedCodeLocationImportance)value;
-                return importance == AnnotatedCodeLocationImportance.Unimportant
-                    ? "Gray"
-                    : "Black";
+                if (importance == AnnotatedCodeLocationImportance.Unimportant)
+                {
+                    brushColor = Colors.Gray;
+                }
             }
-            else
-            {
-                return "Black";
-            }
+
+            return new SolidColorBrush(brushColor);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
At first, the converters did not work because they produced `Color` values, but `TextBlock.Foreground` and `Background` are of type `Brush`. @rtaket suggested a fix where the converters would return a string, which works because WPF has a converter that can convert a string into a `Brush` (in this case, it creates a `SolidColorBrush`).

But really the fix should be for the converters to return `SolidColorBrush` objects, and that's what I do in this PR. I also simplify the converter logic.
