### PR TITLE
Capture all files referenced in result to files collection. Verify we…

### DIFF
--- a/src/Sarif.Converters/FxCopConverter.cs
+++ b/src/Sarif.Converters/FxCopConverter.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // FxCop provides no MessageLevel. For these issues, we shouldn't
             // emit any value at all
             mapsDirectlyToSarifName = false;
-            return ResultLevel.Unknown;
+            return ResultLevel.Default;
         }
 
         private static string CreateSignature(FxCopLogReader.Context context)

--- a/src/Sarif.Converters/StaticDriverVerifierConverter.cs
+++ b/src/Sarif.Converters/StaticDriverVerifierConverter.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             Debug.Assert(false);
-            return ResultLevel.Unknown;
+            return ResultLevel.Default;
         }
     }
 }

--- a/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/FormatForVisualStudioTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             new object[]
             {
-                ResultLevel.Unknown,
+                ResultLevel.Default,
                 MultiLineTestRegion,
                 $"{TestAnalysisTarget}(2,4,3,5): info {TestRuleId}: First: 42, Second: 54",
                 TestAnalysisTarget

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -216,6 +216,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                                     }
                                 }
                             }
+                        },
+                        CodeFlows = new[]
+                        {
+                            new CodeFlow
+                            {
+                                Locations = new[]
+                                {
+                                    new AnnotatedCodeLocation
+                                    {
+                                        PhysicalLocation = new PhysicalLocation {  Uri = new Uri(@"file:///file5.cpp")}
+                                    }
+                                }
+                            }
                         }
                     };
 
@@ -227,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string logText = sb.ToString();
             var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
 
-            int fileCount = 5;
+            int fileCount = 6;
 
             for (int i = 0; i < fileCount; ++i)
             {

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string logText = sb.ToString();
             var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
 
-            sarifLog.Runs[0].Files.Count.Should().Be(0);
+            sarifLog.Runs[0].Files.Should().BeNull();
         }
 
         [TestMethod]

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                         // the directory of the test driver (the location of which we can't retrieve
                         // from Assembly.GetEntryAssembly() as we are running in an AppDomain).
                         pathToExe = pathToExe.Substring(0, pathToExe.Length - @"\Extensions".Length);
-                        tokensToRedact = new string[] { "TestExecution", pathToExe };
+                        tokensToRedact = new string[] {  pathToExe };
                     }
                 }
                 else
@@ -135,14 +135,16 @@ namespace Microsoft.CodeAnalysis.Sarif
                     computeTargetsHash: true,
                     logEnvironment: false,
                     prereleaseInfo: null,
-                    invocationTokensToRedact: null)) { }
+                    invocationTokensToRedact: null))
+                {
+                }
             }
 
-            string result = sb.ToString();
+            string logText = sb.ToString();
 
             string fileDataKey = new Uri(file).ToString();
 
-            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(result);
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
             sarifLog.Runs[0].Files[fileDataKey].MimeType.Should().Be(MimeType.Cpp);
             sarifLog.Runs[0].Files[fileDataKey].Hashes[0].Algorithm.Should().Be(AlgorithmKind.MD5);
             sarifLog.Runs[0].Files[fileDataKey].Hashes[0].Value.Should().Be("4B9DC12934390387862CC4AB5E4A2159");
@@ -150,6 +152,128 @@ namespace Microsoft.CodeAnalysis.Sarif
             sarifLog.Runs[0].Files[fileDataKey].Hashes[1].Value.Should().Be("9B59B1C1E3F5F7013B10F6C6B7436293685BAACE");
             sarifLog.Runs[0].Files[fileDataKey].Hashes[2].Algorithm.Should().Be(AlgorithmKind.Sha256);
             sarifLog.Runs[0].Files[fileDataKey].Hashes[2].Value.Should().Be("0953D7B3ADA7FED683680D2107EE517A9DBEC2D0AF7594A91F058D104B7A2AEB");
+        }
+
+        [TestMethod]
+        public void SarifLogger_ScrapesFilesFromResult()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(
+                    textWriter,
+                    analysisTargets: null,
+                    verbose: false,
+                    computeTargetsHash: true,
+                    logEnvironment: false,
+                    prereleaseInfo: null,
+                    invocationTokensToRedact: null))
+                {
+                    string ruleId = "RuleId";
+                    var rule = new Rule() { Id = ruleId };
+
+                    var result = new Result()
+                    {
+                        RuleId = ruleId,
+                        Locations = new[]
+                        {
+                            new Location
+                            {
+                                AnalysisTarget = new PhysicalLocation {  Uri = new Uri(@"file:///file0.cpp")},
+                                ResultFile = new PhysicalLocation {  Uri = new Uri(@"file:///file1.cpp")}
+                            },
+                        },
+                        Fixes = new[]
+                        {
+                            new Fix
+                            {
+                                FileChanges = new[]
+                                {
+                                   new FileChange
+                                   {
+                                        Uri = new Uri(@"file:///file2.cpp")
+                                   }
+                                }
+                            }
+                        },
+                        RelatedLocations = new[]
+                        {
+                            new AnnotatedCodeLocation
+                            {
+                                PhysicalLocation = new PhysicalLocation {  Uri = new Uri(@"file:///file3.cpp")}
+                            }
+                        },
+                        Stacks = new[]
+                        {
+                            new Stack
+                            {
+                                Frames = new[]
+                                {
+                                    new StackFrame
+                                    {
+                                        Uri = new Uri(@"file:///file4.cpp")
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    sarifLogger.Log(rule, result);
+
+                }
+            }
+
+            string logText = sb.ToString();
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            int fileCount = 5;
+
+            for (int i = 0; i < fileCount; ++i)
+            {
+                string fileName = @"file" + i + ".cpp";
+                string fileDataKey = new Uri("file:///" + fileName).ToString();
+                sarifLog.Runs[0].Files.ContainsKey(fileDataKey).Should().BeTrue("file data for " + fileName + " should exist in files collection");
+            }
+
+            sarifLog.Runs[0].Files.Count.Should().Be(fileCount);
+        }
+
+        [TestMethod]
+        public void SarifLogger_DoNotScrapeFilesFromNotifications()
+        {
+            var sb = new StringBuilder();
+
+            using (var textWriter = new StringWriter(sb))
+            {
+                using (var sarifLogger = new SarifLogger(
+                    textWriter,
+                    analysisTargets: null,
+                    verbose: false,
+                    computeTargetsHash: true,
+                    logEnvironment: false,
+                    prereleaseInfo: null,
+                    invocationTokensToRedact: null))
+                {                    
+                    var toolNotification = new Notification
+                    {
+                        PhysicalLocation = new PhysicalLocation { Uri = new Uri(@"file:///file0.cpp") }
+                    };
+                    sarifLogger.LogToolNotification(toolNotification);
+
+                    var configurationNotification = new Notification
+                    {
+                        PhysicalLocation = new PhysicalLocation { Uri = new Uri(@"file:///file0.cpp") }
+                    };
+                    sarifLogger.LogConfigurationNotification(configurationNotification);
+
+                }
+            }
+
+            string logText = sb.ToString();
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
+
+            sarifLog.Runs[0].Files.Count.Should().Be(0);
         }
 
         [TestMethod]

--- a/src/Sarif/Autogenerated/IRule.cs
+++ b/src/Sarif/Autogenerated/IRule.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         IDictionary<string, string> MessageFormats { get; }
 
         /// <summary>
-        /// A value specifying the default severity level of the notification.
+        /// A value specifying the default severity level of the result.
         /// </summary>
         ResultLevel DefaultLevel { get; }
 

--- a/src/Sarif/Autogenerated/NotificationLevel.cs
+++ b/src/Sarif/Autogenerated/NotificationLevel.cs
@@ -11,9 +11,8 @@ namespace Microsoft.CodeAnalysis.Sarif
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.42.0.0")]
     public enum NotificationLevel
     {
-        Unknown,
-        Note,
         Warning,
+        Note,
         Error
     }
 }

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -9,7 +9,7 @@ using System.Runtime.Serialization;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// The physical location where a result was detected. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.
+    /// A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.
     /// </summary>
     [DataContract]
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.42.0.0")]

--- a/src/Sarif/Autogenerated/ResultLevel.cs
+++ b/src/Sarif/Autogenerated/ResultLevel.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.42.0.0")]
     public enum ResultLevel
     {
-        Unknown,
+        Default,
         NotApplicable,
         Pass,
         Note,

--- a/src/Sarif/Autogenerated/Rule.cs
+++ b/src/Sarif/Autogenerated/Rule.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public IDictionary<string, string> MessageFormats { get; set; }
 
         /// <summary>
-        /// A value specifying the default severity level of the notification.
+        /// A value specifying the default severity level of the result.
         /// </summary>
         [DataMember(Name = "defaultLevel", IsRequired = false, EmitDefaultValue = false)]
         public ResultLevel DefaultLevel { get; set; }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -232,10 +232,9 @@
       "arguments": {
         "typeName": "NotificationLevel",
         "description": "Values specifying the level of a notification.",
-        "zeroValueName": "Unknown",
         "memberNames": [
-          "Note",
           "Warning",
+          "Note",
           "Error"
         ]
       }
@@ -272,7 +271,7 @@
       "arguments": {
         "typeName": "ResultLevel",
         "description": "Values specifying the level of a result.",
-        "zeroValueName": "Unknown",
+        "zeroValueName": "Default",
         "memberNames": [
           "NotApplicable",
           "Pass",
@@ -320,7 +319,7 @@
       "arguments": {
         "typeName": "ResultLevel",
         "description": "Values specifying the level of a result.",
-        "zeroValueName": "Unknown",
+        "zeroValueName": "Default",
         "memberNames": [
           "NotApplicable",
           "Pass",

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -581,7 +581,7 @@
       "required": [ "message" ]
     },
     "physicalLocation": {
-      "description": "The physical location where a result was detected. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
@@ -843,7 +843,7 @@
         },
 
         "defaultLevel": {
-          "description": "A value specifying the default severity level of the notification.",
+          "description": "A value specifying the default severity level of the result.",
           "default": "warning",
           "enum": [ "note", "warning", "error" ]
         },


### PR DESCRIPTION
… do not capture files referenced in tool notifications. Update result level default to 'Default' rather than 'Unknown' (because the default value does not indicate something unknown but an actual default, such as Warning).

@lgolding @rtaket 