### PR TITLE
Fix broken validation tests

### DIFF
--- a/src/Sarif.Driver/VersionConstants.cs
+++ b/src/Sarif.Driver/VersionConstants.cs
@@ -4,8 +4,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "";                       
-        public const string AssemblyVersion = "1.5.25";       
+        public const string Prerelease = "-developer";                       
+        public const string AssemblyVersion = "1.5.26";       
         public const string FileVersion = AssemblyVersion + ".0";              
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -39,7 +39,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="Sarif, Version=1.5.25.0, Culture=neutral, PublicKeyToken=a567ef0185dba9aa, processorArchitecture=MSIL">		
+       <HintPath>..\packages\Sarif.Sdk.1.5.25\lib\net45\Sarif.dll</HintPath>		
+       <Private>True</Private>		
+     </Reference>
+     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
@@ -67,12 +71,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Sarif\Sarif.csproj">
-      <Project>{cc9b247e-7103-4bf7-bdab-6e625b3680a8}</Project>
-      <Name>Sarif</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="CopyTestData" AfterTargets="Build">

--- a/src/Sarif.ValidationTests/packages.config
+++ b/src/Sarif.ValidationTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="4.2.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Sarif.Sdk" version="1.5.25" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -4,9 +4,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 {                                                                              
     public static class VersionConstants                                       
     {                                                                          
-        public const string Prerelease = "";                       
-        public const string AssemblyVersion = "1.5.25";       
-        public const string FileVersion = "1.5.25" + ".0";    
+        public const string Prerelease = "-developer";                       
+        public const string AssemblyVersion = "1.5.26";       
+        public const string FileVersion = "1.5.26" + ".0";    
         public const string Version = AssemblyVersion + Prerelease;            
     }                                                                          
  }                                                                             


### PR DESCRIPTION
The validation tests project must refer to Sarif.dll via the same NuGet package that JSchema (upon which it depends) was built against.

BuildAndTest.cmd now passes.

Also:
* Update version files