### PR TITLE
VSIX: Enable vertical scrolling for the tab items

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/CallTrees.xaml
@@ -9,8 +9,20 @@
     </ResourceDictionary.MergedDictionaries>
 
     <DataTemplate x:Key="CallTreeTemplate">
-        <ListView ItemsSource="{Binding}">
-            <ListView.ItemTemplate>
+        <ItemsControl ItemsSource="{Binding}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <DockPanel IsItemsHost="True"
+                               LastChildFill="False" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemContainerStyle>
+                <Style TargetType="{x:Type ContentPresenter}">
+                    <Setter Property="DockPanel.Dock"
+                            Value="Top" />
+                </Style>
+            </ItemsControl.ItemContainerStyle>
+            <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <TreeView ItemsSource="{Binding TopLevelNodes}">
                         <TreeView.Resources>
@@ -35,8 +47,8 @@
                         </TreeView.ItemTemplate>
                     </TreeView>
                 </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </DataTemplate>
 
 </ResourceDictionary>

--- a/src/Sarif.Viewer.VisualStudio/Themes/CodeFlows.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/CodeFlows.xaml
@@ -18,7 +18,7 @@
             <ItemsControl.ItemContainerStyle>
                 <Style TargetType="{x:Type ContentPresenter}">
                     <Setter Property="DockPanel.Dock"
-                            Value="Bottom" />
+                            Value="Top" />
                 </Style>
             </ItemsControl.ItemContainerStyle>
             <ItemsControl.ItemTemplate>

--- a/src/Sarif.Viewer.VisualStudio/Themes/Fixes.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Fixes.xaml
@@ -23,7 +23,7 @@
             <ItemsControl.ItemContainerStyle>
                 <Style TargetType="{x:Type ContentPresenter}">
                     <Setter Property="DockPanel.Dock"
-                            Value="Bottom" />
+                            Value="Top" />
                 </Style>
             </ItemsControl.ItemContainerStyle>
             <ItemsControl.ItemTemplate>

--- a/src/Sarif.Viewer.VisualStudio/Themes/Locations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Locations.xaml
@@ -15,10 +15,10 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
-                <RowDefinition />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <Separator Grid.Row="0"

--- a/src/Sarif.Viewer.VisualStudio/Themes/Stacks.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Stacks.xaml
@@ -21,7 +21,7 @@
             <ItemsControl.ItemContainerStyle>
                 <Style TargetType="{x:Type ContentPresenter}">
                     <Setter Property="DockPanel.Dock"
-                            Value="Bottom" />
+                            Value="Top" />
                 </Style>
             </ItemsControl.ItemContainerStyle>
             <ItemsControl.ItemTemplate>

--- a/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
@@ -40,7 +40,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <!-- This is the header of the dialog. It displays general info about the result. -->


### PR DESCRIPTION
Enabled vertical scrolling for the tab items
Fixed DockPanel.Dock=Bottom bug in the items panel
Call Trees treeview expands to fill the remaining whitespace. https://github.com/Microsoft/sarif-viewer-vsix/issues/12

Here's the screenshots with the scrollbars.

![codeflowswithscroll](https://cloud.githubusercontent.com/assets/15946080/17002988/c6987946-4e82-11e6-8c93-cef28998c191.png)
![calltreewithscroll](https://cloud.githubusercontent.com/assets/15946080/17002989/c8506802-4e82-11e6-97e3-4f012d64cb99.png)
