### PR TITLE
Fix #431: Properly serialize URIs

### DIFF
--- a/src/Sarif.Converters/FileInfoFactory.cs
+++ b/src/Sarif.Converters/FileInfoFactory.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             Uri uri = physicalLocation.Uri;
-            string key = uri.ToString();
+            string key = UriHelper.MakeValidUri(uri.OriginalString);
             string filePath = key;
 
             if (uri.IsAbsoluteUri && uri.IsFile)

--- a/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
@@ -38,76 +38,76 @@
         "zutil.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\infback9\\inftree9.c": {
+        "contrib/infback9/inftree9.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\inflate86\\inffas86.c": {
+        "contrib/inflate86/inffas86.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\iostream2\\zstream_test.cpp": {
+        "contrib/iostream2/zstream_test.cpp": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\masmx64\\inffas8664.c": {
+        "contrib/masmx64/inffas8664.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\iowin32.c": {
+        "contrib/minizip/iowin32.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\miniunz.c": {
+        "contrib/minizip/miniunz.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\minizip.c": {
+        "contrib/minizip/minizip.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\mztools.c": {
+        "contrib/minizip/mztools.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\unzip.c": {
+        "contrib/minizip/unzip.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\zip.c": {
+        "contrib/minizip/zip.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\minizip\\crypt.h": {
+        "contrib/minizip/crypt.h": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\puff\\puff.c": {
+        "contrib/puff/puff.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\puff\\pufftest.c": {
+        "contrib/puff/pufftest.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\testzlib\\testzlib.c": {
+        "contrib/testzlib/testzlib.c": {
           "mimeType": "text/x-cpp"
         },
-        "contrib\\untgz\\untgz.c": {
+        "contrib/untgz/untgz.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\enough.c": {
+        "examples/enough.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\gun.c": {
+        "examples/gun.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\gzappend.c": {
+        "examples/gzappend.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\gzjoin.c": {
+        "examples/gzjoin.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\gzlog.c": {
+        "examples/gzlog.c": {
           "mimeType": "text/x-cpp"
         },
-        "examples\\zran.c": {
+        "examples/zran.c": {
           "mimeType": "text/x-cpp"
         },
-        "test\\example.c": {
+        "test/example.c": {
           "mimeType": "text/x-cpp"
         },
-        "test\\infcover.c": {
+        "test/infcover.c": {
           "mimeType": "text/x-cpp"
         },
-        "test\\minigzip.c": {
+        "test/minigzip.c": {
           "mimeType": "text/x-cpp"
         }
       },
@@ -1128,7 +1128,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\infback9\\inftree9.c",
+                "uri": "contrib/infback9/inftree9.c",
                 "region": {
                   "startLine": 50
                 }
@@ -1145,7 +1145,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\inflate86\\inffas86.c",
+                "uri": "contrib/inflate86/inffas86.c",
                 "region": {
                   "startLine": 79
                 }
@@ -1162,7 +1162,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\inflate86\\inffas86.c",
+                "uri": "contrib/inflate86/inffas86.c",
                 "region": {
                   "startLine": 80
                 }
@@ -1179,7 +1179,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\inflate86\\inffas86.c",
+                "uri": "contrib/inflate86/inffas86.c",
                 "region": {
                   "startLine": 96
                 }
@@ -1196,7 +1196,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\iostream2\\zstream_test.cpp",
+                "uri": "contrib/iostream2/zstream_test.cpp",
                 "region": {
                   "startLine": 10
                 }
@@ -1213,7 +1213,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\iostream2\\zstream_test.cpp",
+                "uri": "contrib/iostream2/zstream_test.cpp",
                 "region": {
                   "startLine": 15
                 }
@@ -1230,7 +1230,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\iostream2\\zstream_test.cpp",
+                "uri": "contrib/iostream2/zstream_test.cpp",
                 "region": {
                   "startLine": 14
                 }
@@ -1247,7 +1247,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 84
                 }
@@ -1264,7 +1264,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 85
                 }
@@ -1281,7 +1281,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 86
                 }
@@ -1298,7 +1298,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 87
                 }
@@ -1315,7 +1315,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 88
                 }
@@ -1332,7 +1332,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 89
                 }
@@ -1349,7 +1349,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 90
                 }
@@ -1366,7 +1366,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 91
                 }
@@ -1383,7 +1383,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 94
                 }
@@ -1400,7 +1400,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 95
                 }
@@ -1417,7 +1417,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 96
                 }
@@ -1434,7 +1434,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 97
                 }
@@ -1451,7 +1451,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 98
                 }
@@ -1468,7 +1468,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 99
                 }
@@ -1485,7 +1485,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 100
                 }
@@ -1502,7 +1502,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 101
                 }
@@ -1519,7 +1519,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\masmx64\\inffas8664.c",
+                "uri": "contrib/masmx64/inffas8664.c",
                 "region": {
                   "startLine": 102
                 }
@@ -1536,7 +1536,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\iowin32.c",
+                "uri": "contrib/minizip/iowin32.c",
                 "region": {
                   "startLine": 97
                 }
@@ -1553,7 +1553,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\iowin32.c",
+                "uri": "contrib/minizip/iowin32.c",
                 "region": {
                   "startLine": 126
                 }
@@ -1570,7 +1570,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\iowin32.c",
+                "uri": "contrib/minizip/iowin32.c",
                 "region": {
                   "startLine": 150
                 }
@@ -1587,7 +1587,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\iowin32.c",
+                "uri": "contrib/minizip/iowin32.c",
                 "region": {
                   "startLine": 170
                 }
@@ -1604,7 +1604,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\iowin32.c",
+                "uri": "contrib/minizip/iowin32.c",
                 "region": {
                   "startLine": 364
                 }
@@ -1621,7 +1621,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 602
                 }
@@ -1633,7 +1633,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\miniunz.c",
+                    "uri": "contrib/minizip/miniunz.c",
                     "region": {
                       "startLine": 632
                     }
@@ -1642,7 +1642,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\miniunz.c",
+                    "uri": "contrib/minizip/miniunz.c",
                     "region": {
                       "startLine": 602
                     }
@@ -1662,7 +1662,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 322
                 }
@@ -1679,7 +1679,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 542
                 }
@@ -1696,7 +1696,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 327
                 }
@@ -1713,7 +1713,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 484
                 }
@@ -1730,7 +1730,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\miniunz.c",
+                "uri": "contrib/minizip/miniunz.c",
                 "region": {
                   "startLine": 518
                 }
@@ -1747,7 +1747,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 235
                 }
@@ -1764,7 +1764,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 193
                 }
@@ -1776,7 +1776,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\minizip.c",
+                    "uri": "contrib/minizip/minizip.c",
                     "region": {
                       "startLine": 204
                     }
@@ -1785,7 +1785,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\minizip.c",
+                    "uri": "contrib/minizip/minizip.c",
                     "region": {
                       "startLine": 193
                     }
@@ -1805,7 +1805,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 191
                 }
@@ -1822,7 +1822,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 192
                 }
@@ -1839,7 +1839,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 227
                 }
@@ -1856,7 +1856,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 257
                 }
@@ -1873,7 +1873,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 399
                 }
@@ -1890,7 +1890,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 212
                 }
@@ -1907,7 +1907,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 232
                 }
@@ -1924,7 +1924,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\minizip.c",
+                "uri": "contrib/minizip/minizip.c",
                 "region": {
                   "startLine": 235
                 }
@@ -1941,7 +1941,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\mztools.c",
+                "uri": "contrib/minizip/mztools.c",
                 "region": {
                   "startLine": 290
                 }
@@ -1958,7 +1958,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\mztools.c",
+                "uri": "contrib/minizip/mztools.c",
                 "region": {
                   "startLine": 290
                 }
@@ -1975,7 +1975,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\mztools.c",
+                "uri": "contrib/minizip/mztools.c",
                 "region": {
                   "startLine": 290
                 }
@@ -1992,7 +1992,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\unzip.c",
+                "uri": "contrib/minizip/unzip.c",
                 "region": {
                   "startLine": 1663
                 }
@@ -2004,7 +2004,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\unzip.c",
+                    "uri": "contrib/minizip/unzip.c",
                     "region": {
                       "startLine": 1665
                     }
@@ -2013,7 +2013,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\unzip.c",
+                    "uri": "contrib/minizip/unzip.c",
                     "region": {
                       "startLine": 1663
                     }
@@ -2033,7 +2033,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\unzip.c",
+                "uri": "contrib/minizip/unzip.c",
                 "region": {
                   "startLine": 1105
                 }
@@ -2050,7 +2050,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1038
                 }
@@ -2062,7 +2062,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1037
                     }
@@ -2071,7 +2071,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1038
                     }
@@ -2091,7 +2091,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1040
                 }
@@ -2103,7 +2103,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1038
                     }
@@ -2112,7 +2112,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1040
                     }
@@ -2132,7 +2132,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1041
                 }
@@ -2144,7 +2144,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1040
                     }
@@ -2153,7 +2153,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "contrib\\minizip\\zip.c",
+                    "uri": "contrib/minizip/zip.c",
                     "region": {
                       "startLine": 1041
                     }
@@ -2173,7 +2173,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1957
                 }
@@ -2190,7 +2190,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1958
                 }
@@ -2207,7 +2207,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\zip.c",
+                "uri": "contrib/minizip/zip.c",
                 "region": {
                   "startLine": 1683
                 }
@@ -2224,7 +2224,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\minizip\\crypt.h",
+                "uri": "contrib/minizip/crypt.h",
                 "region": {
                   "startLine": 99
                 }
@@ -2241,7 +2241,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\puff.c",
+                "uri": "contrib/puff/puff.c",
                 "region": {
                   "startLine": 705
                 }
@@ -2258,7 +2258,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\puff.c",
+                "uri": "contrib/puff/puff.c",
                 "region": {
                   "startLine": 799
                 }
@@ -2275,7 +2275,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\puff.c",
+                "uri": "contrib/puff/puff.c",
                 "region": {
                   "startLine": 799
                 }
@@ -2292,7 +2292,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\puff.c",
+                "uri": "contrib/puff/puff.c",
                 "region": {
                   "startLine": 240
                 }
@@ -2309,7 +2309,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\pufftest.c",
+                "uri": "contrib/puff/pufftest.c",
                 "region": {
                   "startLine": 129
                 }
@@ -2326,7 +2326,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\puff\\pufftest.c",
+                "uri": "contrib/puff/pufftest.c",
                 "region": {
                   "startLine": 93
                 }
@@ -2343,7 +2343,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 172
                 }
@@ -2360,7 +2360,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 220
                 }
@@ -2377,7 +2377,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 220
                 }
@@ -2394,7 +2394,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 261
                 }
@@ -2411,7 +2411,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 261
                 }
@@ -2428,7 +2428,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 154
                 }
@@ -2445,7 +2445,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 210
                 }
@@ -2462,7 +2462,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\testzlib\\testzlib.c",
+                "uri": "contrib/testzlib/testzlib.c",
                 "region": {
                   "startLine": 251
                 }
@@ -2479,7 +2479,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 171
                 }
@@ -2496,7 +2496,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 272
                 }
@@ -2513,7 +2513,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 389
                 }
@@ -2530,7 +2530,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 72
                 }
@@ -2547,7 +2547,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 73
                 }
@@ -2564,7 +2564,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 76
                 }
@@ -2581,7 +2581,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 78
                 }
@@ -2598,7 +2598,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 79
                 }
@@ -2615,7 +2615,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 80
                 }
@@ -2632,7 +2632,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 81
                 }
@@ -2649,7 +2649,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 82
                 }
@@ -2666,7 +2666,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 83
                 }
@@ -2683,7 +2683,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 84
                 }
@@ -2700,7 +2700,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 85
                 }
@@ -2717,7 +2717,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "contrib\\untgz\\untgz.c",
+                "uri": "contrib/untgz/untgz.c",
                 "region": {
                   "startLine": 91
                 }
@@ -2734,7 +2734,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\enough.c",
+                "uri": "examples/enough.c",
                 "region": {
                   "startLine": 184
                 }
@@ -2751,7 +2751,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\enough.c",
+                "uri": "examples/enough.c",
                 "region": {
                   "startLine": 406
                 }
@@ -2768,7 +2768,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\enough.c",
+                "uri": "examples/enough.c",
                 "region": {
                   "startLine": 407
                 }
@@ -2785,7 +2785,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\enough.c",
+                "uri": "examples/enough.c",
                 "region": {
                   "startLine": 462
                 }
@@ -2802,7 +2802,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 133
                 }
@@ -2819,7 +2819,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 208
                 }
@@ -2836,7 +2836,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 385
                 }
@@ -2853,7 +2853,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 386
                 }
@@ -2870,7 +2870,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 633
                 }
@@ -2887,7 +2887,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 634
                 }
@@ -2904,7 +2904,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gun.c",
+                "uri": "examples/gun.c",
                 "region": {
                   "startLine": 337
                 }
@@ -2921,7 +2921,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzappend.c",
+                "uri": "examples/gzappend.c",
                 "region": {
                   "startLine": 396
                 }
@@ -2933,7 +2933,7 @@
               "locations": [
                 {
                   "physicalLocation": {
-                    "uri": "examples\\gzappend.c",
+                    "uri": "examples/gzappend.c",
                     "region": {
                       "startLine": 415
                     }
@@ -2942,7 +2942,7 @@
                 },
                 {
                   "physicalLocation": {
-                    "uri": "examples\\gzappend.c",
+                    "uri": "examples/gzappend.c",
                     "region": {
                       "startLine": 396
                     }
@@ -2962,7 +2962,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzappend.c",
+                "uri": "examples/gzappend.c",
                 "region": {
                   "startLine": 127
                 }
@@ -2979,7 +2979,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzappend.c",
+                "uri": "examples/gzappend.c",
                 "region": {
                   "startLine": 127
                 }
@@ -2996,7 +2996,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzappend.c",
+                "uri": "examples/gzappend.c",
                 "region": {
                   "startLine": 204
                 }
@@ -3013,7 +3013,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzappend.c",
+                "uri": "examples/gzappend.c",
                 "region": {
                   "startLine": 238
                 }
@@ -3030,7 +3030,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzjoin.c",
+                "uri": "examples/gzjoin.c",
                 "region": {
                   "startLine": 391
                 }
@@ -3047,7 +3047,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzjoin.c",
+                "uri": "examples/gzjoin.c",
                 "region": {
                   "startLine": 405
                 }
@@ -3064,7 +3064,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 503
                 }
@@ -3081,7 +3081,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 610
                 }
@@ -3098,7 +3098,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 611
                 }
@@ -3115,7 +3115,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 611
                 }
@@ -3132,7 +3132,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 612
                 }
@@ -3149,7 +3149,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 740
                 }
@@ -3166,7 +3166,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 910
                 }
@@ -3183,7 +3183,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 910
                 }
@@ -3200,7 +3200,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 912
                 }
@@ -3217,7 +3217,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\gzlog.c",
+                "uri": "examples/gzlog.c",
                 "region": {
                   "startLine": 1003
                 }
@@ -3234,7 +3234,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\zran.c",
+                "uri": "examples/zran.c",
                 "region": {
                   "startLine": 229
                 }
@@ -3251,7 +3251,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\zran.c",
+                "uri": "examples/zran.c",
                 "region": {
                   "startLine": 230
                 }
@@ -3268,7 +3268,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "examples\\zran.c",
+                "uri": "examples/zran.c",
                 "region": {
                   "startLine": 232
                 }
@@ -3285,7 +3285,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\example.c",
+                "uri": "test/example.c",
                 "region": {
                   "startLine": 62
                 }
@@ -3302,7 +3302,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\example.c",
+                "uri": "test/example.c",
                 "region": {
                   "startLine": 68
                 }
@@ -3319,7 +3319,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\example.c",
+                "uri": "test/example.c",
                 "region": {
                   "startLine": 576
                 }
@@ -3336,7 +3336,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\infcover.c",
+                "uri": "test/infcover.c",
                 "region": {
                   "startLine": 465
                 }
@@ -3353,7 +3353,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\infcover.c",
+                "uri": "test/infcover.c",
                 "region": {
                   "startLine": 188
                 }
@@ -3370,7 +3370,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\infcover.c",
+                "uri": "test/infcover.c",
                 "region": {
                   "startLine": 196
                 }
@@ -3387,7 +3387,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\infcover.c",
+                "uri": "test/infcover.c",
                 "region": {
                   "startLine": 221
                 }
@@ -3404,7 +3404,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 367
                 }
@@ -3421,7 +3421,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 435
                 }
@@ -3438,7 +3438,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 159
                 }
@@ -3455,7 +3455,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 166
                 }
@@ -3472,7 +3472,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 265
                 }
@@ -3489,7 +3489,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "test\\minigzip.c",
+                "uri": "test/minigzip.c",
                 "region": {
                   "startLine": 266
                 }

--- a/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/FxCop/FxCopReportAllMessageStates.xml.sarif
@@ -7,10 +7,10 @@
         "name": "FxCop"
       },
       "files": {
-        "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe": {
+        "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe": {
           "mimeType": "application/octet-stream"
         },
-        "file:///c:/users/user/documents/visual studio 2015/Projects/WpfApplication5/WpfApplication5/Frz.cs": {
+        "file:///c:/users/user/documents/visual%20studio%202015/Projects/WpfApplication5/WpfApplication5/Frz.cs": {
           "mimeType": "text/x-csharp"
         }
       },
@@ -98,7 +98,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe"
             }
@@ -114,7 +114,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe"
             }
@@ -130,7 +130,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe"
             }
@@ -148,7 +148,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Frz"
             }
@@ -166,10 +166,10 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "resultFile": {
-                "uri": "file:///c:/users/user/documents/visual studio 2015/Projects/WpfApplication5/WpfApplication5/Frz.cs",
+                "uri": "file:///c:/users/user/documents/visual%20studio%202015/Projects/WpfApplication5/WpfApplication5/Frz.cs",
                 "region": {
                   "startLine": 11
                 }
@@ -191,10 +191,10 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "resultFile": {
-                "uri": "file:///c:/users/user/documents/visual studio 2015/Projects/WpfApplication5/WpfApplication5/Frz.cs",
+                "uri": "file:///c:/users/user/documents/visual%20studio%202015/Projects/WpfApplication5/WpfApplication5/Frz.cs",
                 "region": {
                   "startLine": 11
                 }
@@ -212,7 +212,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
@@ -228,7 +228,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
@@ -244,7 +244,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.MainWindow.System.Windows.Markup.IComponentConnector.Connect(System.Int32,System.Object)"
             }
@@ -260,7 +260,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources"
             }
@@ -277,7 +277,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources"
             }
@@ -292,7 +292,7 @@
           "locations": [
             {
               "analysisTarget": {
-                "uri": "file:///C:/Users/user/Documents/Visual Studio 2015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
+                "uri": "file:///C:/Users/user/Documents/Visual%20Studio%202015/Projects/WpfApplication5/WpfApplication5/bin/Debug/WpfApplication5.exe"
               },
               "fullyQualifiedLogicalName": "wpfapplication5.exe!WpfApplication5.Properties.Resources..ctor()"
             }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic": {
+        "rules/WDM/CancelSpinLock.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -24,7 +24,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                "uri": "rules/WDM/CancelSpinLock.slic",
                 "region": {
                   "startLine": 60
                 }
@@ -75,7 +75,7 @@
                 {
                   "step": 4,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                    "uri": "rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -2879,7 +2879,7 @@
                 {
                   "step": 234,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                    "uri": "rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 38
                     }
@@ -2893,7 +2893,7 @@
                 {
                   "step": 235,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                    "uri": "rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 41
                     }
@@ -3032,7 +3032,7 @@
                 {
                   "step": 248,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                    "uri": "rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 58
                     }
@@ -3046,7 +3046,7 @@
                 {
                   "step": 249,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CancelSpinLock.slic",
+                    "uri": "rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 60
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\CheckAddDevice.slic": {
+        "rules/WDM/CheckAddDevice.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\CheckAddDevice.slic",
+                "uri": "rules/WDM/CheckAddDevice.slic",
                 "region": {
                   "startLine": 35
                 }
@@ -1673,7 +1673,7 @@
                 {
                   "step": 134,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckAddDevice.slic",
+                    "uri": "rules/WDM/CheckAddDevice.slic",
                     "region": {
                       "startLine": 33
                     }
@@ -1687,7 +1687,7 @@
                 {
                   "step": 135,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckAddDevice.slic",
+                    "uri": "rules/WDM/CheckAddDevice.slic",
                     "region": {
                       "startLine": 35
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\CheckDriverUnload.slic": {
+        "rules/WDM/CheckDriverUnload.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\CheckDriverUnload.slic",
+                "uri": "rules/WDM/CheckDriverUnload.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1886,7 +1886,7 @@
                 {
                   "step": 152,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckDriverUnload.slic",
+                    "uri": "rules/WDM/CheckDriverUnload.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1900,7 +1900,7 @@
                 {
                   "step": 153,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckDriverUnload.slic",
+                    "uri": "rules/WDM/CheckDriverUnload.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\CheckIrpMjPnp.slic": {
+        "rules/WDM/CheckIrpMjPnp.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\CheckIrpMjPnp.slic",
+                "uri": "rules/WDM/CheckIrpMjPnp.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1744,7 +1744,7 @@
                 {
                   "step": 140,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckIrpMjPnp.slic",
+                    "uri": "rules/WDM/CheckIrpMjPnp.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1758,7 +1758,7 @@
                 {
                   "step": 141,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\CheckIrpMjPnp.slic",
+                    "uri": "rules/WDM/CheckIrpMjPnp.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\DispatchRoutine.slic": {
+        "rules/WDM/DispatchRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\DispatchRoutine.slic",
+                "uri": "rules/WDM/DispatchRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1105,7 +1105,7 @@
                 {
                   "step": 86,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\DispatchRoutine.slic",
+                    "uri": "rules/WDM/DispatchRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1119,7 +1119,7 @@
                 {
                   "step": 87,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\DispatchRoutine.slic",
+                    "uri": "rules/WDM/DispatchRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\IoCompletion.slic": {
+        "rules/WDM/IoCompletion.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\IoCompletion.slic",
+                "uri": "rules/WDM/IoCompletion.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1531,7 +1531,7 @@
                 {
                   "step": 122,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IoCompletion.slic",
+                    "uri": "rules/WDM/IoCompletion.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1545,7 +1545,7 @@
                 {
                   "step": 123,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IoCompletion.slic",
+                    "uri": "rules/WDM/IoCompletion.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\IoDpcRoutine.slic": {
+        "rules/WDM/IoDpcRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\IoDpcRoutine.slic",
+                "uri": "rules/WDM/IoDpcRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1460,7 +1460,7 @@
                 {
                   "step": 116,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IoDpcRoutine.slic",
+                    "uri": "rules/WDM/IoDpcRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1474,7 +1474,7 @@
                 {
                   "step": 117,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IoDpcRoutine.slic",
+                    "uri": "rules/WDM/IoDpcRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "..\\..\\..\\rules\\WDM\\IsrRoutine.slic": {
+        "rules/WDM/IsrRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "..\\..\\..\\rules\\WDM\\IsrRoutine.slic",
+                "uri": "rules/WDM/IsrRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1318,7 +1318,7 @@
                 {
                   "step": 104,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IsrRoutine.slic",
+                    "uri": "rules/WDM/IsrRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1332,7 +1332,7 @@
                 {
                   "step": 105,
                   "physicalLocation": {
-                    "uri": "..\\..\\..\\rules\\WDM\\IsrRoutine.slic",
+                    "uri": "rules/WDM/IsrRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -673,6 +673,9 @@
     <None Include="ConverterTestData\StaticDriverVerifier\cancelspinlock_bug1.tt.sarif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="ConverterTestData\StaticDriverVerifier\checkadddevice_bug1.tt.sarif">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="ConverterTestData\StaticDriverVerifier\checkdriverunload_bug1.tt.sarif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Sarif.FunctionalTests/SarifConverterTests.cs
+++ b/src/Sarif.FunctionalTests/SarifConverterTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         [Fact]
         public void StaticDriverVerifierConverter_EndToEnd()
         {
-            BatchRunConverter(ToolFormat.StaticDriverVerifier, TestMode.CompareFileContents);
+            BatchRunConverter(ToolFormat.StaticDriverVerifier, "*.tt", TestMode.CompareFileContents);
         }
 
         [Fact]

--- a/src/Sarif.UnitTests/Readers/UriConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/UriConverterTests.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers.UnitTests
+{
+    [TestClass]
+    public class UriConverterTests : JsonTests
+    {
+        [TestMethod]
+        public void ConvertsHttpUri()
+        {
+            TestConverter("http://www.example.com/dir/file.c", "http://www.example.com/dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsHttpUriWithEscaping()
+        {
+            TestConverter("http://www.example.com/dir/file name.c", "http://www.example.com/dir/file%20name.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteWindowsFilePath()
+        {
+            TestConverter(@"C:\dir\file.c", "file:///C:/dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteWindowsFilePathWithEscaping()
+        {
+            TestConverter(@"C:\dir\file name.c", "file:///C:/dir/file%20name.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteUnixFilePath()
+        {
+            TestConverter("/dir/file.c", "/dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteUnixFilePathWithEscaping()
+        {
+            TestConverter("/dir/file name.c", "/dir/file%20name.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteWindowsFileUri()
+        {
+            TestConverter("file:///C:/dir/file.c", "file:///C:/dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsAbsoluteWindowsFileUriWithEscaping()
+        {
+            TestConverter("file:///C:/dir/file name.c", "file:///C:/dir/file%20name.c");
+        }
+
+        [TestMethod]
+        public void ConvertsRelativeWindowsFilePath()
+        {
+            TestConverter(@"dir\file.c", "dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsRelativeWindowsFilePathWithEscaping()
+        {
+            TestConverter(@"dir\file name.c", "dir/file%20name.c");
+        }
+
+        [TestMethod]
+        public void ConvertsRelativeUnixFilePath()
+        {
+            TestConverter("dir/file.c", "dir/file.c");
+        }
+
+        [TestMethod]
+        public void ConvertsRelativeUnixFilePathWithEscaping()
+        {
+            TestConverter("dir/file name.c", "dir/file%20name.c");
+        }
+
+        private void TestConverter(string inputUri, string expectedUri)
+        {
+            string expectedOutput =
+@"{
+  ""$schema"": """ + SarifSchemaUri + @""",
+  ""version"": """ + SarifFormatVersion + @""",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": null
+      },
+      ""results"": [
+        {
+          ""locations"": [
+            {
+              ""analysisTarget"": {
+                ""uri"": """ + expectedUri + @"""
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}";
+            string actualOutput = GetJson(uut =>
+            {
+                var run = new Run();
+
+                uut.Initialize(id: null, correlationId: null);
+
+                uut.WriteTool(DefaultTool);
+
+                var result = new Result
+                {
+                    Locations = new List<Location>
+                    {
+                        new Location
+                        {
+                            AnalysisTarget = new PhysicalLocation
+                            {
+                                Uri = new Uri(inputUri, UriKind.RelativeOrAbsolute)
+                            }
+                        }
+                    }
+                };
+
+                uut.WriteResults(new[] { result });
+            });
+
+            Assert.AreEqual(expectedOutput, actualOutput);
+        }
+    }
+}

--- a/src/Sarif.UnitTests/Sarif.UnitTests.csproj
+++ b/src/Sarif.UnitTests/Sarif.UnitTests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Readers\PropertyBagConverterTests.cs" />
     <Compile Include="Readers\ResultDiffingVisitorTests.cs" />
     <Compile Include="Readers\RuleDictionaryConverterTests.cs" />
+    <Compile Include="Readers\UriConverterTests.cs" />
     <Compile Include="ResultLogObjectWriter.cs" />
     <Compile Include="SarifExtensionsTests.cs" />
     <Compile Include="SparseReaderDispatchTableTests.cs" />

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -245,8 +245,8 @@ namespace Microsoft.CodeAnalysis.Sarif
             for (int i = 0; i < fileCount; ++i)
             {
                 string fileName = @"file" + i + ".cpp";
-                string fileDataKey = new Uri("file:///" + fileName).ToString();
-                sarifLog.Runs[0].Files.ContainsKey(fileDataKey).Should().BeTrue("file data for " + fileName + " should exist in files collection");
+                string fileDataKey = "file:///" + fileName;
+                sarifLog.Runs[0].Files.Should().ContainKey(fileDataKey, "file data for " + fileName + " should exist in files collection");
             }
 
             sarifLog.Runs[0].Files.Count.Should().Be(fileCount);

--- a/src/Sarif/Core/FileData.cs
+++ b/src/Sarif/Core/FileData.cs
@@ -3,28 +3,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using SarifWriters = Microsoft.CodeAnalysis.Sarif.Writers;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// A single file. In some cases, this file might be nested within another file.
+    /// Represents a single file. In some cases, this file might be nested within another file.
     /// </summary>
     public partial class FileData : ISarifNode
     {
-        public static FileData Create(Uri uri, bool computeHashes, out string fileDataKey)
+        public static FileData Create(Uri uri, bool computeHashes)
         {
             if (uri == null) { throw new ArgumentNullException(nameof(uri)); }
-
-            fileDataKey = null;
 
             var fileData = new FileData()
             {
                 MimeType = SarifWriters.MimeType.DetermineFromFileExtension(uri)
             };
-
-            fileDataKey = uri.ToString();
 
             if (computeHashes && uri.IsAbsoluteUri && uri.IsFile)
             {
@@ -48,19 +43,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                             },
                         };
             }
-            //else if (files.Count == 1)
-            //{
-            //    fileData.Uri = uri;
-            //    fileDataKey = fileDataKey + "#" + fileData.Uri.ToString();
-            //}
-            //else
-            //{
-            //    Debug.Assert(!uri.IsAbsoluteUri);                    
-            //    fileData.Uri = uri;
-            //    fileDataKey = fileDataKey + fileData.Uri.ToString();
-            //}
-
-            //files.Add(fileData);
 
             return fileData;
         }

--- a/src/Sarif/Readers/UriConverter.cs
+++ b/src/Sarif/Readers/UriConverter.cs
@@ -34,14 +34,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            Uri uri = ((Uri)value);
-
-            if (uri.IsAbsoluteUri && uri.IsFile && (uri.LocalPath == uri.OriginalString))
-            {
-                uri = new Uri(uri.ToString());
-            }
-
-            writer.WriteValue(uri.ToString());
+            string path = ((Uri)value).OriginalString;
+            string validUri = UriHelper.MakeValidUri(path);
+            writer.WriteValue(validUri);
         }
     }
 }

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -109,6 +109,7 @@
     <Compile Include="IToolFileConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TypedPropertyBag.cs" />
+    <Compile Include="UriHelper.cs" />
     <Compile Include="VersionConstants.cs" />
     <Compile Include="Warnings.cs" />
     <Compile Include="Writers\ResultLogJsonWriter.cs" />

--- a/src/Sarif/UriHelper.cs
+++ b/src/Sarif/UriHelper.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public static class UriHelper
+    {
+        /// <summary>
+        /// Create a syntactically valid URI from a path that might be
+        /// absolute or relative, and that might require percent-encoding.
+        /// </summary>
+        /// <param name="path">
+        /// The path to be transformed into a syntactically valid URI.
+        /// </param>
+        /// <returns>
+        /// A syntactically valid URI representing <paramref name="path"/>.
+        /// </returns>
+        /// <remarks>
+        /// In general, <paramref name="path"/> might be:
+        /// 
+        /// 1. Possible to interpret as an absolute path / absolute URI
+        /// 2. Possible to interpret as a relative path / relative URI
+        /// 3. Neither
+        ///
+        /// We must create a valid URI to persist in the SARIF log. We proceed as follows:
+        ///
+        /// 1. Try to create an absolute System.Uri. If that succeeds, take its
+        /// AbsoluteUri, which (unlike Uri.ToString()) will be properly percent-encoded.
+        ///
+        /// 2. Try to create a relative System.Uri. If that succeeds, we want to write it out,
+        /// but since this is a relative URI, we can't access its AbsoluteUri or AbsolutePath
+        /// property -- and again, Uri.ToString() does not perform percent encoding.
+        /// 
+        /// We use this workaround:
+        /// 
+        ///     a. Combine the relative path with an arbitrary scheme and host to form
+        ///        an absolute URI.
+        ///     b. Extract the AbsolutePath property, which will be percent encoded.
+        ///     
+        ///
+        /// 3. If all else fails, we have a string that we can't convert to a System.Uri,
+        /// so just percent encode the whole thing. This should be extremely rare in practice.
+        ///
+        /// Thanks and a tip o' the hat to @nguerrera for this code (and for the comment).
+        /// </remarks>
+        public static string MakeValidUri(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            Uri uri;
+            string validUri;
+            if (Uri.TryCreate(path, UriKind.Absolute, out uri))
+            {
+                validUri = uri.AbsoluteUri;
+            }
+            else if (Uri.TryCreate(path, UriKind.Relative, out uri))
+            {
+                UriBuilder builder = new UriBuilder("http", "www.example.com", 80, path);
+                validUri = builder.Uri.AbsolutePath;
+
+                // Since what we actually want is a relative path, strip the leading "/"
+                // from the AbsolutePath -- unless the input string started with "/".
+                if (!path.StartsWith("/", StringComparison.Ordinal) &&
+                    !path.StartsWith(@"\", StringComparison.Ordinal))
+                {
+                    validUri = validUri.Substring(1);
+                }
+            }
+            else
+            {
+                validUri = System.Net.WebUtility.UrlEncode(path);
+            }
+
+            return validUri;
+        }
+    }
+}

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -37,12 +37,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
                 foreach (string target in analysisTargets)
                 {
-                    string fileDataKey;
+                    string fileDataKey = UriHelper.MakeValidUri(target);
 
                     var fileData = FileData.Create(
                         new Uri(target, UriKind.RelativeOrAbsolute), 
-                        computeTargetsHash, 
-                        out fileDataKey);
+                        computeTargetsHash);
 
                     run.Files.Add(fileDataKey, fileData);
                 }
@@ -364,18 +363,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             _run.Files = _run.Files ?? new Dictionary<string, FileData>();
 
-            FileData fileData;
-
-            if (_run.Files.TryGetValue(uri.ToString(), out fileData))
+            string fileDataKey = UriHelper.MakeValidUri(uri.OriginalString);
+            if (_run.Files.ContainsKey(fileDataKey))
             {
                 // Already populated
                 return;
             }
 
-            string fileDataKey;
-            fileData = FileData.Create(uri, false, out fileDataKey);
-
-            _run.Files[fileDataKey] = fileData;
+            _run.Files[fileDataKey] = FileData.Create(uri, false);
         }
 
         public void AnalyzingTarget(IAnalysisContext context)


### PR DESCRIPTION
Borrow @nguerrera's URI serialization helper from Roslyn to ensure that URIs are correctly serialized to SARIF.

Update the test files to reflect the new (correct) serialization.

Also, fix problems with my implementation of the SDV test files into the functional tests:
* SDV's native output files have extension `.tt`, not  `.xml`, so the functional tests did not find any files to convert. So the SDV tests appeared to pass because there were no files.
* Then once we fixed that, it turned out that for one the `.tt` files (checkadddevice_bug1.tt), we didn't check in the reference file (checkadddevice_but1.tt.sarif).

Fixed those problems, and the SDV functional tests now actually run, and pass.