### PR TITLE
Fix Microsoft/sarif-viewer-vsix#27

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -85,10 +85,13 @@ namespace Microsoft.Sarif.Viewer.ErrorList
         {
             List<SarifErrorListItem> sarifErrors = new List<SarifErrorListItem>();
 
-            foreach (Result result in run.Results)
+            if (run.Results != null)
             {
-                SarifErrorListItem sarifError = GetResult(run, result, logFilePath);
-                sarifErrors.Add(sarifError);
+                foreach (Result result in run.Results)
+                {
+                    SarifErrorListItem sarifError = GetResult(run, result, logFilePath);
+                    sarifErrors.Add(sarifError);
+                }
             }
 
             CodeAnalysisResultManager.Instance.SarifErrors = sarifErrors;

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/TableDataSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/TableDataSource.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public void AddErrors(IEnumerable<SarifErrorListItem> errors)
         {
-            if (errors == null || !errors.Any())
+            if (errors == null)
                 return;
 
             CleanAllErrors();


### PR DESCRIPTION
Microsoft/sarif-viewer-vsix#27: Can't open SARIF file without any results

If you try to open a SARIF file with no results (because it only contains rule metadata), you get a null reference exception.

Also:
* If you opened a SARIF file with no results, it left the existing Error List entries in place. Don't do that; clear them.