### PR TITLE
Handle dot-segments when normalizing URIs

### DIFF
--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/CancelSpinLock.slic": {
+        "../../../rules/WDM/CancelSpinLock.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -24,7 +24,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/CancelSpinLock.slic",
+                "uri": "../../../rules/WDM/CancelSpinLock.slic",
                 "region": {
                   "startLine": 60
                 }
@@ -75,7 +75,7 @@
                 {
                   "step": 4,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CancelSpinLock.slic",
+                    "uri": "../../../rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -2879,7 +2879,7 @@
                 {
                   "step": 234,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CancelSpinLock.slic",
+                    "uri": "../../../rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 38
                     }
@@ -2893,7 +2893,7 @@
                 {
                   "step": 235,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CancelSpinLock.slic",
+                    "uri": "../../../rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 41
                     }
@@ -3032,7 +3032,7 @@
                 {
                   "step": 248,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CancelSpinLock.slic",
+                    "uri": "../../../rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 58
                     }
@@ -3046,7 +3046,7 @@
                 {
                   "step": 249,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CancelSpinLock.slic",
+                    "uri": "../../../rules/WDM/CancelSpinLock.slic",
                     "region": {
                       "startLine": 60
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/CheckAddDevice.slic": {
+        "../../../rules/WDM/CheckAddDevice.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/CheckAddDevice.slic",
+                "uri": "../../../rules/WDM/CheckAddDevice.slic",
                 "region": {
                   "startLine": 35
                 }
@@ -1673,7 +1673,7 @@
                 {
                   "step": 134,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckAddDevice.slic",
+                    "uri": "../../../rules/WDM/CheckAddDevice.slic",
                     "region": {
                       "startLine": 33
                     }
@@ -1687,7 +1687,7 @@
                 {
                   "step": 135,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckAddDevice.slic",
+                    "uri": "../../../rules/WDM/CheckAddDevice.slic",
                     "region": {
                       "startLine": 35
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/CheckDriverUnload.slic": {
+        "../../../rules/WDM/CheckDriverUnload.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/CheckDriverUnload.slic",
+                "uri": "../../../rules/WDM/CheckDriverUnload.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1886,7 +1886,7 @@
                 {
                   "step": 152,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckDriverUnload.slic",
+                    "uri": "../../../rules/WDM/CheckDriverUnload.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1900,7 +1900,7 @@
                 {
                   "step": 153,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckDriverUnload.slic",
+                    "uri": "../../../rules/WDM/CheckDriverUnload.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/CheckIrpMjPnp.slic": {
+        "../../../rules/WDM/CheckIrpMjPnp.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/CheckIrpMjPnp.slic",
+                "uri": "../../../rules/WDM/CheckIrpMjPnp.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1744,7 +1744,7 @@
                 {
                   "step": 140,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckIrpMjPnp.slic",
+                    "uri": "../../../rules/WDM/CheckIrpMjPnp.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1758,7 +1758,7 @@
                 {
                   "step": 141,
                   "physicalLocation": {
-                    "uri": "rules/WDM/CheckIrpMjPnp.slic",
+                    "uri": "../../../rules/WDM/CheckIrpMjPnp.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/DispatchRoutine.slic": {
+        "../../../rules/WDM/DispatchRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/DispatchRoutine.slic",
+                "uri": "../../../rules/WDM/DispatchRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1105,7 +1105,7 @@
                 {
                   "step": 86,
                   "physicalLocation": {
-                    "uri": "rules/WDM/DispatchRoutine.slic",
+                    "uri": "../../../rules/WDM/DispatchRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1119,7 +1119,7 @@
                 {
                   "step": 87,
                   "physicalLocation": {
-                    "uri": "rules/WDM/DispatchRoutine.slic",
+                    "uri": "../../../rules/WDM/DispatchRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/IoCompletion.slic": {
+        "../../../rules/WDM/IoCompletion.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/IoCompletion.slic",
+                "uri": "../../../rules/WDM/IoCompletion.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1531,7 +1531,7 @@
                 {
                   "step": 122,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IoCompletion.slic",
+                    "uri": "../../../rules/WDM/IoCompletion.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1545,7 +1545,7 @@
                 {
                   "step": 123,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IoCompletion.slic",
+                    "uri": "../../../rules/WDM/IoCompletion.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/IoDpcRoutine.slic": {
+        "../../../rules/WDM/IoDpcRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/IoDpcRoutine.slic",
+                "uri": "../../../rules/WDM/IoDpcRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1460,7 +1460,7 @@
                 {
                   "step": 116,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IoDpcRoutine.slic",
+                    "uri": "../../../rules/WDM/IoDpcRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1474,7 +1474,7 @@
                 {
                   "step": 117,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IoDpcRoutine.slic",
+                    "uri": "../../../rules/WDM/IoDpcRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
@@ -7,7 +7,7 @@
         "name": "StaticDriverVerifier"
       },
       "files": {
-        "rules/WDM/IsrRoutine.slic": {
+        "../../../rules/WDM/IsrRoutine.slic": {
           "mimeType": "text/x-cpp"
         },
         "file:///d:/slam1/wdk/src_5043/fail_drivers/wdm/fail_driver1/sdv/sdv-harness.c": {
@@ -21,7 +21,7 @@
           "locations": [
             {
               "resultFile": {
-                "uri": "rules/WDM/IsrRoutine.slic",
+                "uri": "../../../rules/WDM/IsrRoutine.slic",
                 "region": {
                   "startLine": 34
                 }
@@ -1318,7 +1318,7 @@
                 {
                   "step": 104,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IsrRoutine.slic",
+                    "uri": "../../../rules/WDM/IsrRoutine.slic",
                     "region": {
                       "startLine": 32
                     }
@@ -1332,7 +1332,7 @@
                 {
                   "step": 105,
                   "physicalLocation": {
-                    "uri": "rules/WDM/IsrRoutine.slic",
+                    "uri": "../../../rules/WDM/IsrRoutine.slic",
                     "region": {
                       "startLine": 34
                     }

--- a/src/Sarif.UnitTests/Readers/UriConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/UriConverterTests.cs
@@ -88,6 +88,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.UnitTests
             TestConverter(@"..\..\.\.\..\dir1\dir2\file.c", "../../../dir1/dir2/file.c");
         }
 
+        [TestMethod]
+        public void ConvertPathWithOnlyDotSegments()
+        {
+            TestConverter(@"..\..", "../..");
+        }
+
         private void TestConverter(string inputUri, string expectedUri)
         {
             string expectedOutput =

--- a/src/Sarif.UnitTests/Readers/UriConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/UriConverterTests.cs
@@ -82,6 +82,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.UnitTests
             TestConverter("dir/file name.c", "dir/file%20name.c");
         }
 
+        [TestMethod]
+        public void ConvertsRelativePathWithDotSegments()
+        {
+            TestConverter(@"..\..\.\.\..\dir1\dir2\file.c", "../../../dir1/dir2/file.c");
+        }
+
         private void TestConverter(string inputUri, string expectedUri)
         {
             string expectedOutput =

--- a/src/Sarif/UriHelper.cs
+++ b/src/Sarif/UriHelper.cs
@@ -119,6 +119,13 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
             }
 
+            // Corner case: the path is entirely composed of a single two-dot segment,
+            // or ends with a two-dot segment.
+            if (path.Equals("..", StringComparison.Ordinal))
+            {
+                sb.Append("..");
+            }
+
             return sb.ToString();
         }
     }


### PR DESCRIPTION
In PR #458, we fixed Issue #431, using @nguerrera's code from Roslyn to always serialize valid URIs (whether they were absolute or relative, and whether or not they required percent encoding).

@rtaket noticed a bug in the implementation, namely that it erroneously stripped leading "dot-segments" ("../", "./"). This change fixes that problem. It retains leading "../" segments (but it does drop any leading "./" segments, which are useless).

Add unit test for new functionality.