### PR TITLE
Fix viewer#35: Exception when location lacks region

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -1,17 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
+using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Sarif.Viewer
 {
@@ -25,9 +21,9 @@ namespace Microsoft.Sarif.Viewer
         {
             get
             {
-                if (_lineMarker == null)
+                // Not all locations have regions. Don't try to mark the locations that don't.
+                if (_lineMarker == null && Region != null)
                 {
-                    Debug.Assert(Region != null);
                     _lineMarker = new ResultTextMarker(SarifViewerPackage.ServiceProvider, Region, FilePath);
                 }
 

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -285,23 +285,23 @@ namespace Microsoft.Sarif.Viewer
 
         internal void RemoveMarkers()
         {
-            LineMarker.RemoveMarker();
+            LineMarker?.RemoveMarker();
 
             foreach (AnnotatedCodeLocationModel location in this.Locations)
             {
-                location.LineMarker.RemoveMarker();
+                location.LineMarker?.RemoveMarker();
             }
 
             foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
             {
-                location.LineMarker.RemoveMarker();
+                location.LineMarker?.RemoveMarker();
             }
 
             foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
-                    location.LineMarker.RemoveMarker();
+                    location.LineMarker?.RemoveMarker();
                 }
             }
 
@@ -309,7 +309,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
-                    stackFrame.LineMarker.RemoveMarker();
+                    stackFrame.LineMarker?.RemoveMarker();
                 }
             }
         }
@@ -399,7 +399,7 @@ namespace Microsoft.Sarif.Viewer
 
         internal void AttachToDocument(string documentName, long docCookie, IVsWindowFrame pFrame)
         {
-            LineMarker.AttachToDocument(documentName, docCookie, pFrame);
+            LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
 
             foreach (AnnotatedCodeLocationModel location in this.Locations)
             {
@@ -430,7 +430,7 @@ namespace Microsoft.Sarif.Viewer
 
         internal void DetachFromDocument(long docCookie)
         {
-            LineMarker.DetachFromDocument(docCookie);
+            LineMarker?.DetachFromDocument(docCookie);
 
             foreach (AnnotatedCodeLocationModel location in this.Locations)
             {

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Models;
+using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
-using Microsoft.Sarif.Viewer.Models;
-using System;
-using Microsoft.Sarif.Viewer.Sarif;
 
 namespace Microsoft.Sarif.Viewer
 {
@@ -399,23 +399,23 @@ namespace Microsoft.Sarif.Viewer
 
         internal void AttachToDocument(string documentName, long docCookie, IVsWindowFrame pFrame)
         {
-            LineMarker.AttachToDocument(documentName, (long)docCookie, pFrame);
+            LineMarker.AttachToDocument(documentName, docCookie, pFrame);
 
             foreach (AnnotatedCodeLocationModel location in this.Locations)
             {
-                location.LineMarker.AttachToDocument(documentName, (long)docCookie, pFrame);
+                location.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
             }
 
             foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
             {
-                location.LineMarker.AttachToDocument(documentName, (long)docCookie, pFrame);
+                location.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
             }
 
             foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
-                    location.LineMarker.AttachToDocument(documentName, (long)docCookie, pFrame);
+                    location.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
                 }
             }
 
@@ -423,30 +423,30 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
-                    stackFrame.LineMarker.AttachToDocument(documentName, (long)docCookie, pFrame);
+                    stackFrame.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
                 }
             }
         }
 
         internal void DetachFromDocument(long docCookie)
         {
-            LineMarker.DetachFromDocument((long)docCookie);
+            LineMarker.DetachFromDocument(docCookie);
 
             foreach (AnnotatedCodeLocationModel location in this.Locations)
             {
-                location.LineMarker.DetachFromDocument((long)docCookie);
+                location.LineMarker?.DetachFromDocument(docCookie);
             }
 
             foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
             {
-                location.LineMarker.DetachFromDocument((long)docCookie);
+                location.LineMarker?.DetachFromDocument(docCookie);
             }
 
             foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
-                    location.LineMarker.DetachFromDocument((long)docCookie);
+                    location.LineMarker?.DetachFromDocument(docCookie);
                 }
             }
 
@@ -454,7 +454,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
-                    stackFrame.LineMarker.DetachFromDocument((long)docCookie);
+                    stackFrame.LineMarker?.DetachFromDocument(docCookie);
                 }
             }
         }


### PR DESCRIPTION
If you double-click on an issue which contains any `physicalLocation` object that lacks a `region` property -- whether that be an `analysisTarget`, a `resultFile`, or any occurrence of an `annotatedCodeLocation` -- then the viewer throws an exception.

The exception occurs when the viewer tries to mark the source file line corresponding to the `physicalLocation`, because it assumes that every `physicalLocation` has a `region`.

NOTE: This is one of what I expect to be several issues that will be revealed as I try to view the new "comprehensive" sample file in the viewer.