### PR TITLE
Fix viewer#34: Stack frames don't show line or column numbers

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Themes/Stacks.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Themes/Stacks.xaml
@@ -9,6 +9,7 @@
     
     <!-- Converters -->
     <converters:StringToVisibilityConverter x:Key="stringToVisibilityConverter" />
+    <converters:Int32ToVisibilityConverter x:Key="int32ToVisibilityConverter" />
 
     <DataTemplate x:Key="StackCollectionTemplate">
         <ItemsControl ItemsSource="{Binding}">
@@ -62,14 +63,21 @@
                                                                         <TextBlock Visibility="{Binding Module, Converter={StaticResource stringToVisibilityConverter}}">
                                                                             <Run Text="{Binding Module}" /><Run Text="!" />
                                                                         </TextBlock>
-                                                                    </InlineUIContainer><InlineUIContainer>
+                                                                    </InlineUIContainer>
+                                                                    <InlineUIContainer>
                                                                         <TextBlock Visibility="{Binding FullyQualifiedLogicalName, Converter={StaticResource stringToVisibilityConverter}}">
                                                                             <Run Text="{Binding FullyQualifiedLogicalName}" /><Run Text="!" />
                                                                         </TextBlock>
                                                                     </InlineUIContainer>
-                                                                    <Run Text="{Binding FileName, Mode=OneWay}" /> Line <Run Text="{Binding Region.StartLine, Mode=OneWay}" /><InlineUIContainer>
-                                                                        <TextBlock Visibility="{Binding Column, Converter={StaticResource stringToVisibilityConverter}}">
-                                                                            <Run Text="Col " /><Run Text="{Binding Column}" />
+                                                                    <Run Text="{Binding FileName, Mode=OneWay}" />
+                                                                    <InlineUIContainer>
+                                                                        <TextBlock Visibility="{Binding Line,Converter={StaticResource int32ToVisibilityConverter}}">
+                                                                            <Run Text="Line "/><Run Text="{Binding Line, Mode=OneWay}" />
+                                                                        </TextBlock>
+                                                                    </InlineUIContainer>
+                                                                    <InlineUIContainer>
+                                                                        <TextBlock Visibility="{Binding Column, Converter={StaticResource int32ToVisibilityConverter}}">
+                                                                            <Run Text=", Col " /><Run Text="{Binding Column, Mode=OneWay}" />
                                                                         </TextBlock>
                                                                     </InlineUIContainer>
                                                                 </TextBlock>    


### PR DESCRIPTION
The property path was wrong for the line number (was `Region.StartLine`, changed to `Line`), and the visibility converters were wrong for both the line number and the column number (were `StringToVisibilityConverter`, changed to `Int32ToVisibilityConverter`).

Before:

![image](https://cloud.githubusercontent.com/assets/11762653/17109248/1655a3e2-524c-11e6-8f1a-c138c1158807.png)

After:

![image](https://cloud.githubusercontent.com/assets/11762653/17109392/b09c5694-524c-11e6-83c1-bf15ccd91612.png)



