### PR TITLE
VSIX: Display properties of the selected CallTreeNode in the Properties window

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Sarif.Viewer
         private Region _region;
         protected string _filePath;
 
-        public ResultTextMarker LineMarker
+        internal ResultTextMarker LineMarker
         {
             get
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        public Region Region
+        internal Region Region
         {
             get
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        public virtual string FilePath
+        internal virtual string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Sarif.Viewer
         public void OnDeselectKeyEvent()
         {
             // Remove hover marker
-            LineMarker.RemoveMarker();
+            LineMarker?.RemoveMarker();
 
             // Add default marker instead
-            LineMarker.NavigateTo(true, null, false);
+            LineMarker?.NavigateTo(true, null, false);
         }
 
         /// <summary>
@@ -82,8 +82,8 @@ namespace Microsoft.Sarif.Viewer
         public void OnSelectKeyEvent()
         {
             // Remove previous highlighting and replace with hover color
-            LineMarker.RemoveMarker();
-            LineMarker.NavigateTo(true, ResultTextMarker.HOVER_SELECTION_COLOR, true);
+            LineMarker?.RemoveMarker();
+            LineMarker?.NavigateTo(true, ResultTextMarker.HOVER_SELECTION_COLOR, true);
         }
 
         private IVsTextView GetTextViewFromFrame(IVsWindowFrame frame)

--- a/src/Sarif.Viewer.VisualStudio/Models/AnnotatedCodeLocationModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/AnnotatedCodeLocationModel.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        public override string FilePath
+        internal override string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Sarif.Viewer.Models
                 // Navigate to the source of the selected node and highlight the region.
                 if (_selectedItem != null)
                 {
+                    // Update the VS Properties window with the properties of the selected CallTreeNode.
                     SarifViewerPackage.SarifToolWindow.UpdateSelectionList(_selectedItem);
+
+                    // Navigate to the source file of the selected CallTreeNode.
                     _selectedItem.OnSelectKeyEvent();
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     public class CallTree : NotifyPropertyChangedObject
     {
-        private CallTreeNode _selectedItem;
+        private CodeLocationObject _selectedItem;
 
         public CallTree(IList<CallTreeNode> topLevelNodes)
         {
@@ -17,7 +17,7 @@ namespace Microsoft.Sarif.Viewer.Models
 
         public ObservableCollection<CallTreeNode> TopLevelNodes { get; }
 
-        public CallTreeNode SelectedItem
+        public CodeLocationObject SelectedItem
         {
             get
             {
@@ -32,18 +32,7 @@ namespace Microsoft.Sarif.Viewer.Models
                 if (_selectedItem != null)
                 {
                     SarifViewerPackage.SarifToolWindow.ApplySelectionList(_selectedItem);
-
-                    try
-                    {
-                        if (_selectedItem.LineMarker != null)
-                        {
-                            _selectedItem.OnSelectKeyEvent();
-                        }
-                    }
-                    catch (System.Exception e)
-                    {
-                        e.ToString();
-                    }
+                    _selectedItem.OnSelectKeyEvent();
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Sarif.Viewer.Models
                 // Navigate to the source of the selected node and highlight the region.
                 if (_selectedItem != null)
                 {
-                    SarifViewerPackage.SarifToolWindow.ApplySelectionList(_selectedItem);
+                    SarifViewerPackage.SarifToolWindow.UpdateSelectionList(_selectedItem);
                     _selectedItem.OnSelectKeyEvent();
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Sarif.Viewer.Models
                 // Navigate to the source of the selected node and highlight the region.
                 if (_selectedItem != null)
                 {
-                    SarifViewerPackage.SarifToolWindow.SelectionList(_selectedItem);
+                    SarifViewerPackage.SarifToolWindow.ApplySelectionList(_selectedItem);
 
                     try
                     {

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTree.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Sarif.Viewer.Models
 {
     public class CallTree : NotifyPropertyChangedObject
     {
-        private CodeLocationObject _selectedItem;
+        private CallTreeNode _selectedItem;
 
         public CallTree(IList<CallTreeNode> topLevelNodes)
         {
@@ -17,7 +17,7 @@ namespace Microsoft.Sarif.Viewer.Models
 
         public ObservableCollection<CallTreeNode> TopLevelNodes { get; }
 
-        public CodeLocationObject SelectedItem
+        public CallTreeNode SelectedItem
         {
             get
             {
@@ -31,7 +31,19 @@ namespace Microsoft.Sarif.Viewer.Models
                 // Navigate to the source of the selected node and highlight the region.
                 if (_selectedItem != null)
                 {
-                    _selectedItem.OnSelectKeyEvent();
+                    SarifViewerPackage.SarifToolWindow.SelectionList(_selectedItem);
+
+                    try
+                    {
+                        if (_selectedItem.LineMarker != null)
+                        {
+                            _selectedItem.OnSelectKeyEvent();
+                        }
+                    }
+                    catch (System.Exception e)
+                    {
+                        e.ToString();
+                    }
                 }
             }
         }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.Sarif;
+using System.ComponentModel;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
@@ -12,6 +13,7 @@ namespace Microsoft.Sarif.Viewer.Models
     {
         private AnnotatedCodeLocation _location;
 
+        [Browsable(false)]
         public AnnotatedCodeLocation Location
         {
             get
@@ -49,6 +51,15 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
+        [Browsable(false)]
         public List<CallTreeNode> Children { get; set; }
+
+        public int? Step
+        {
+            get
+            {
+                return Location?.Step;
+            }
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/CallTreeNode.cs
@@ -61,5 +61,86 @@ namespace Microsoft.Sarif.Viewer.Models
                 return Location?.Step;
             }
         }
+
+        [Category("Location")]
+        [DisplayName("Source file")]
+        public string SourceFile
+        {
+            get
+            {
+                Uri sourceUrl = Location?.PhysicalLocation?.Uri;
+                
+                if (sourceUrl != null)
+                {
+                    return Path.GetFileName(sourceUrl.LocalPath);
+                }
+
+                return null;
+            }
+        }
+
+        [Category("Location")]
+        [DisplayName("Start line")]
+        public int? StartLine
+        {
+            get
+            {
+                return Location?.PhysicalLocation?.Region?.StartLine;
+            }
+        }
+
+        [Category("Location")]
+        [DisplayName("End line")]
+        public int? EndLine
+        {
+            get
+            {
+                return Location?.PhysicalLocation?.Region?.EndLine;
+            }
+        }
+
+        [Category("Location")]
+        [DisplayName("Start column")]
+        public int? StartColumn
+        {
+            get
+            {
+                return Location?.PhysicalLocation?.Region?.StartColumn;
+            }
+        }
+
+        [Category("Location")]
+        [DisplayName("End column")]
+        public int? EndColumn
+        {
+            get
+            {
+                return Location?.PhysicalLocation?.Region?.EndColumn;
+            }
+        }
+
+        public AnnotatedCodeLocationImportance? Importance
+        {
+            get
+            {
+                return Location?.Importance;
+            }
+        }
+
+        public string Message
+        {
+            get
+            {
+                return Location?.Message;
+            }
+        }
+
+        public string Snippet
+        {
+            get
+            {
+                return Location?.Snippet;
+            }
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -10,6 +10,7 @@ using Microsoft.Sarif.Viewer.Models;
 using Microsoft.Sarif.Viewer.Sarif;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using System.ComponentModel;
 
 namespace Microsoft.Sarif.Viewer
 {
@@ -27,45 +28,46 @@ namespace Microsoft.Sarif.Viewer
         private ObservableCollection<StackCollection> _stacks;
         private ObservableCollection<FixModel> _fixes;
         private DelegateCommand _openLogFileCommand;
+        ResultTextMarker _lineMarker;
 
         internal SarifErrorListItem()
         {
-            this._locations = new AnnotatedCodeLocationCollection(String.Empty);
-            this._relatedLocations = new AnnotatedCodeLocationCollection(String.Empty);
-            this._codeFlows = new ObservableCollection<AnnotatedCodeLocationCollection>();
-            this._callTrees = new ObservableCollection<CallTree>();
-            this._stacks = new ObservableCollection<StackCollection>();
-            this._fixes = new ObservableCollection<FixModel>();
+            _locations = new AnnotatedCodeLocationCollection(String.Empty);
+            _relatedLocations = new AnnotatedCodeLocationCollection(String.Empty);
+            _codeFlows = new ObservableCollection<AnnotatedCodeLocationCollection>();
+            _callTrees = new ObservableCollection<CallTree>();
+            _stacks = new ObservableCollection<StackCollection>();
+            _fixes = new ObservableCollection<FixModel>();
         }
 
         public SarifErrorListItem(Run run, Result result, string logFilePath) : this()
         {
             IRule rule;
             run.TryGetRule(result.RuleId, result.RuleKey, out rule);
-            this.Message = result.GetMessageText(rule, concise: false);
-            this.ShortMessage = result.GetMessageText(rule, concise: true);
-            this.FileName = result.GetPrimaryTargetFile();
-            this.Category = result.GetCategory();
-            this.Region = result.GetPrimaryTargetRegion();
-            this.Level = result.Level;
-            this.SuppressionStates = result.SuppressionStates;
-            this.LogFilePath = logFilePath;
+            Message = result.GetMessageText(rule, concise: false);
+            ShortMessage = result.GetMessageText(rule, concise: true);
+            FileName = result.GetPrimaryTargetFile();
+            Category = result.GetCategory();
+            Region = result.GetPrimaryTargetRegion();
+            Level = result.Level;
+            SuppressionStates = result.SuppressionStates;
+            LogFilePath = logFilePath;
 
-            if (this.Region != null)
+            if (Region != null)
             {
-                this.LineNumber = this.Region.StartLine;
-                this.ColumnNumber = this.Region.StartColumn;
+                LineNumber = Region.StartLine;
+                ColumnNumber = Region.StartColumn;
             }
 
-            this.Tool = run.Tool.ToToolModel();
-            this.Rule = rule?.ToRuleModel(result.RuleId);
-            this.Invocation = run.Invocation.ToInvocationModel();
+            Tool = run.Tool.ToToolModel();
+            Rule = rule?.ToRuleModel(result.RuleId);
+            Invocation = run.Invocation.ToInvocationModel();
 
             if (result.Locations != null)
             {
                 foreach (Location location in result.Locations)
                 {
-                    this.Locations.Add(location.ToAnnotatedCodeLocationModel());
+                    Locations.Add(location.ToAnnotatedCodeLocationModel());
                 }
             }
 
@@ -73,7 +75,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (AnnotatedCodeLocation annotatedCodeLocation in result.RelatedLocations)
                 {
-                    this.RelatedLocations.Add(annotatedCodeLocation.ToAnnotatedCodeLocationModel());
+                    RelatedLocations.Add(annotatedCodeLocation.ToAnnotatedCodeLocationModel());
                 }
             }
 
@@ -81,8 +83,8 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (CodeFlow codeFlow in result.CodeFlows)
                 {
-                    this.CodeFlows.Add(codeFlow.ToAnnotatedCodeLocationCollection());
-                    this.CallTrees.Add(codeFlow.ToCallTree());
+                    CodeFlows.Add(codeFlow.ToAnnotatedCodeLocationCollection());
+                    CallTrees.Add(codeFlow.ToCallTree());
                 }
             }
 
@@ -90,7 +92,7 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (Stack stack in result.Stacks)
                 {
-                    this.Stacks.Add(stack.ToStackCollection());
+                    Stacks.Add(stack.ToStackCollection());
                 }
             }
 
@@ -98,15 +100,19 @@ namespace Microsoft.Sarif.Viewer
             {
                 foreach (Fix fix in result.Fixes)
                 {
-                    this.Fixes.Add(fix.ToFixModel());
+                    Fixes.Add(fix.ToFixModel());
                 }
             }
         }
 
+        [Browsable(false)]
         public string MimeType { get; set; }
 
+
+        [Browsable(false)]
         public Region Region { get; set; }
 
+        [Browsable(false)]
         public string FileName
         {
             get
@@ -122,165 +128,195 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
+        [Browsable(false)]
         public bool RegionPopulated { get; set; }
 
+        [Browsable(false)]
         public string ShortMessage { get; set; }
 
+        [Browsable(false)]
         public string Message { get; set; }
 
+        [Browsable(false)]
         public SnapshotSpan Span { get; set; }
 
+        [Browsable(false)]
         public int LineNumber { get; set; }
 
+        [Browsable(false)]
         public int ColumnNumber { get; set; }
 
+        [Browsable(false)]
         public string Category { get; set; }
 
+        [ReadOnly(true)]
         public ResultLevel Level { get; set; }
 
+        [Browsable(false)]
         public string HelpLink { get; set; }
 
+        [DisplayName("Suppression states")]
+        [ReadOnly(true)]
         public SuppressionStates SuppressionStates { get; set; }
 
+        [DisplayName("Log file")]
+        [ReadOnly(true)]
         public string LogFilePath { get; set; }
 
+        [Browsable(false)]
         public ToolModel Tool
         {
             get
             {
-                return this._tool;
+                return _tool;
             }
             set
             {
-                this._tool = value;
+                _tool = value;
                 NotifyPropertyChanged("Tool");
             }
         }
 
+        [Browsable(false)]
         public RuleModel Rule
         {
             get
             {
-                return this._rule;
+                return _rule;
             }
             set
             {
-                this._rule = value;
+                _rule = value;
                 NotifyPropertyChanged("Rule");
             }
         }
 
+        [Browsable(false)]
         public InvocationModel Invocation
         {
             get
             {
-                return this._invocation;
+                return _invocation;
             }
             set
             {
-                this._invocation = value;
+                _invocation = value;
                 NotifyPropertyChanged("Invocation");
             }
         }
 
+        [Browsable(false)]
         public string SelectedTab
         {
             get
             {
-                return this._selectedTab;
+                return _selectedTab;
             }
             set
             {
-                this._selectedTab = value;
+                _selectedTab = value;
 
                 // If a new tab is selected, remove all the the markers for the
                 // previous tab.
-                this.RemoveMarkers();
+                RemoveMarkers();
+
+                // If a new tab is selected, reset the Properties window.
+                SarifViewerPackage.SarifToolWindow.ResetSelection();
             }
         }
 
+        [Browsable(false)]
         public AnnotatedCodeLocationCollection Locations
         {
             get
             {
-                return this._locations;
+                return _locations;
             }
         }
 
+        [Browsable(false)]
         public AnnotatedCodeLocationCollection RelatedLocations
         {
             get
             {
-                return this._relatedLocations;
+                return _relatedLocations;
             }
         }
 
+        [Browsable(false)]
         public ObservableCollection<AnnotatedCodeLocationCollection> CodeFlows
         {
             get
             {
-                return this._codeFlows;
+                return _codeFlows;
             }
         }
 
+        [Browsable(false)]
         public ObservableCollection<CallTree> CallTrees
         {
             get
             {
-                return this._callTrees;
+                return _callTrees;
             }
         }
 
+        [Browsable(false)]
         public ObservableCollection<StackCollection> Stacks
         {
             get
             {
-                return this._stacks;
+                return _stacks;
             }
         }
 
+        [Browsable(false)]
         public ObservableCollection<FixModel> Fixes
         {
             get
             {
-                return this._fixes;
+                return _fixes;
             }
         }
 
+        [Browsable(false)]
         public bool HasDetails
         {
             get
             {
-                return (this.Locations.Count + this.RelatedLocations.Count) > 0 || this.CallTrees.Count > 0 || this.Stacks.Count > 0 || this.Fixes.Count > 0;
+                return (Locations.Count + RelatedLocations.Count) > 0 || CallTrees.Count > 0 || Stacks.Count > 0 || Fixes.Count > 0;
             }
         }
 
+        [Browsable(false)]
         public int LocationsCount
         {
             get
             {
-                return this.Locations.Count + this.RelatedLocations.Count;
+                return Locations.Count + RelatedLocations.Count;
             }
         }
 
+        [Browsable(false)]
         public bool HasMultipleLocations
         {
             get
             {
-                return this.LocationsCount > 1;
+                return LocationsCount > 1;
             }
         }
 
+        [Browsable(false)]
         public DelegateCommand OpenLogFileCommand
         {
             get
             {
-                if (this._openLogFileCommand == null)
+                if (_openLogFileCommand == null)
                 {
-                    this._openLogFileCommand = new DelegateCommand(() => this.OpenLogFile());
+                    _openLogFileCommand = new DelegateCommand(() => OpenLogFile());
                 }
 
-                return this._openLogFileCommand;
+                return _openLogFileCommand;
             }
         }
 
@@ -288,17 +324,17 @@ namespace Microsoft.Sarif.Viewer
         {
             LineMarker?.RemoveMarker();
 
-            foreach (AnnotatedCodeLocationModel location in this.Locations)
+            foreach (AnnotatedCodeLocationModel location in Locations)
             {
                 location.LineMarker?.RemoveMarker();
             }
 
-            foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
+            foreach (AnnotatedCodeLocationModel location in RelatedLocations)
             {
                 location.LineMarker?.RemoveMarker();
             }
 
-            foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
+            foreach (AnnotatedCodeLocationCollection locationCollection in CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
@@ -306,7 +342,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (StackCollection stackCollection in this.Stacks)
+            foreach (StackCollection stackCollection in Stacks)
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
@@ -317,9 +353,9 @@ namespace Microsoft.Sarif.Viewer
 
         internal void OpenLogFile()
         {
-            if (this.LogFilePath != null && System.IO.File.Exists(this.LogFilePath))
+            if (LogFilePath != null && System.IO.File.Exists(LogFilePath))
             {
-                SarifViewerPackage.Dte.ExecuteCommand("File.OpenFile", $@"""{this.LogFilePath}"" /e:""JSON Editor""");
+                SarifViewerPackage.Dte.ExecuteCommand("File.OpenFile", $@"""{LogFilePath}"" /e:""JSON Editor""");
             }
         }
 
@@ -328,45 +364,38 @@ namespace Microsoft.Sarif.Viewer
             return Message;
         }
 
-        ResultTextMarker m_lineMarker;
+
+        [Browsable(false)]
         public ResultTextMarker LineMarker
         {
             get
             {
-                if (m_lineMarker == null)
+                if (_lineMarker == null)
                 {
                     if (System.ComponentModel.LicenseManager.UsageMode != System.ComponentModel.LicenseUsageMode.Designtime)
                     {
                         Debug.Assert(Region != null);
                     }
 
-                    m_lineMarker = new ResultTextMarker(SarifViewerPackage.ServiceProvider, Region, FileName);
+                    _lineMarker = new ResultTextMarker(SarifViewerPackage.ServiceProvider, Region, FileName);
                 }
 
-                return m_lineMarker;
+                return _lineMarker;
             }
             set
             {
-                m_lineMarker = value;
+                _lineMarker = value;
             }
         }
 
         internal void RemapFilePath(string originalPath, string remappedPath)
         {
-            if (this.FileName != null && this.FileName.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
+            if (FileName != null && FileName.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
             {
-                this.FileName = remappedPath;
+                FileName = remappedPath;
             }
 
-            foreach (AnnotatedCodeLocationModel location in this.Locations)
-            {
-                if (location.FilePath.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    location.FilePath = remappedPath;
-                }
-            }
-
-            foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
+            foreach (AnnotatedCodeLocationModel location in Locations)
             {
                 if (location.FilePath.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
                 {
@@ -374,7 +403,15 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
+            foreach (AnnotatedCodeLocationModel location in RelatedLocations)
+            {
+                if (location.FilePath.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    location.FilePath = remappedPath;
+                }
+            }
+
+            foreach (AnnotatedCodeLocationCollection locationCollection in CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
@@ -386,7 +423,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (CallTree callTree in this.CallTrees)
+            foreach (CallTree callTree in CallTrees)
             {
                 Stack<CallTreeNode> nodesToProcess = new Stack<CallTreeNode>();
 
@@ -420,7 +457,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (StackCollection stackCollection in this.Stacks)
+            foreach (StackCollection stackCollection in Stacks)
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
@@ -436,17 +473,17 @@ namespace Microsoft.Sarif.Viewer
         {
             LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
 
-            foreach (AnnotatedCodeLocationModel location in this.Locations)
+            foreach (AnnotatedCodeLocationModel location in Locations)
             {
                 location.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
             }
 
-            foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
+            foreach (AnnotatedCodeLocationModel location in RelatedLocations)
             {
                 location.LineMarker?.AttachToDocument(documentName, docCookie, pFrame);
             }
 
-            foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
+            foreach (AnnotatedCodeLocationCollection locationCollection in CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
@@ -454,7 +491,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (CallTree callTree in this.CallTrees)
+            foreach (CallTree callTree in CallTrees)
             {
                 Stack<CallTreeNode> nodesToProcess = new Stack<CallTreeNode>();
 
@@ -475,7 +512,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (StackCollection stackCollection in this.Stacks)
+            foreach (StackCollection stackCollection in Stacks)
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {
@@ -488,17 +525,17 @@ namespace Microsoft.Sarif.Viewer
         {
             LineMarker?.DetachFromDocument(docCookie);
 
-            foreach (AnnotatedCodeLocationModel location in this.Locations)
+            foreach (AnnotatedCodeLocationModel location in Locations)
             {
                 location.LineMarker?.DetachFromDocument(docCookie);
             }
 
-            foreach (AnnotatedCodeLocationModel location in this.RelatedLocations)
+            foreach (AnnotatedCodeLocationModel location in RelatedLocations)
             {
                 location.LineMarker?.DetachFromDocument(docCookie);
             }
 
-            foreach (AnnotatedCodeLocationCollection locationCollection in this.CodeFlows)
+            foreach (AnnotatedCodeLocationCollection locationCollection in CodeFlows)
             {
                 foreach (AnnotatedCodeLocationModel location in locationCollection)
                 {
@@ -506,7 +543,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (CallTree callTree in this.CallTrees)
+            foreach (CallTree callTree in CallTrees)
             {
                 Stack<CallTreeNode> nodesToProcess = new Stack<CallTreeNode>();
 
@@ -527,7 +564,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            foreach (StackCollection stackCollection in this.Stacks)
+            foreach (StackCollection stackCollection in Stacks)
             {
                 foreach (StackFrameModel stackFrame in stackCollection)
                 {

--- a/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        public override string FilePath
+        internal override string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
@@ -69,7 +69,10 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        public void UpdateSelection()
+        /// <summary>
+        /// Updates the Properties window with the public properties of the selection objects.
+        /// </summary>
+        public void ApplySelection()
         {
             ITrackSelection track = TrackSelection;
             if (track != null)
@@ -78,17 +81,24 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        public void ApplySelectionList(params Object[] items)
+        /// <summary>
+        /// Replaces the collection of objects who's values are displayed in the Properties window.
+        /// </summary>
+        /// <param name="items"></param>
+        public void UpdateSelectionList(params Object[] items)
         {
             _selectionContainer = new SelectionContainer(true, false);
             _selectionContainer.SelectableObjects = items;
             _selectionContainer.SelectedObjects = items;
-            UpdateSelection();
+            ApplySelection();
         }
 
+        /// <summary>
+        /// Reset the Properties window to display the properties of the selected Error List item.
+        /// </summary>
         public void ResetSelection()
         {
-            ApplySelectionList(Control?.DataContext);
+            UpdateSelectionList(Control?.DataContext);
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Sarif.Viewer.Views;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System.Collections.Generic;
 
 namespace Microsoft.Sarif.Viewer
 {
@@ -23,6 +24,9 @@ namespace Microsoft.Sarif.Viewer
     [Guid("ab561bcc-e01d-4781-8c2e-95a9170bfdd5")]
     public class SarifToolWindow : ToolWindowPane
     {
+        private ITrackSelection _trackSelection;
+        private SelectionContainer _selectionContainer;
+
         internal SarifToolWindowControl Control
         {
             get
@@ -48,6 +52,36 @@ namespace Microsoft.Sarif.Viewer
         public void Show()
         {
             ((IVsWindowFrame)Frame).Show();
+        }
+
+        private ITrackSelection TrackSelection
+        {
+            get
+            {
+                if (_trackSelection == null)
+                {
+                    _trackSelection = GetService(typeof(STrackSelection)) as ITrackSelection;
+                }
+
+                return _trackSelection;
+            }
+        }
+
+        public void UpdateSelection()
+        {
+            ITrackSelection track = TrackSelection;
+            if (track != null)
+            {
+                track.OnSelectChange((ISelectionContainer)_selectionContainer);
+            }
+        }
+
+        public void SelectionList(params Object[] items)
+        {
+            _selectionContainer = new SelectionContainer(true, false);
+            _selectionContainer.SelectableObjects = items;
+            _selectionContainer.SelectedObjects = items;
+            UpdateSelection();
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifToolWindow.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Sarif.Viewer
             // the object returned by the Content property.
             Content = new SarifToolWindowControl();
             Control.DataContext = null;
+
+            ResetSelection();
         }
 
         public void Show()
@@ -76,12 +78,17 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        public void SelectionList(params Object[] items)
+        public void ApplySelectionList(params Object[] items)
         {
             _selectionContainer = new SelectionContainer(true, false);
             _selectionContainer.SelectableObjects = items;
             _selectionContainer.SelectedObjects = items;
             UpdateSelection();
+        }
+
+        public void ResetSelection()
+        {
+            ApplySelectionList(Control?.DataContext);
         }
     }
 }


### PR DESCRIPTION
- Display properties of the selected CallTreeNode in the Properties window
- Removed the usages of "this." for consistency.

The Properties window interaction works by setting the Selection objects in the SarifToolWindow. Any object which is added to the selection list (by calling UpdateSelectionList()) will have its public properties displayed in the Properties window. To make a public property not display in the Properties window, the property must be decorated with the Browsable(false) attribute.

![propertieswindow](https://cloud.githubusercontent.com/assets/15946080/17122902/6a4a20d4-5294-11e6-8201-78aa258a8fc8.png)
