### PR TITLE
Update AppVeyor config to include the VSIX test library

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ test:
     - '**\Sarif.Driver.UnitTests.dll'
     - '**\Sarif.FunctionalTests.dll'
     - '**\Sarif.ValidationTests.dll'
+    - '**\Sarif.Viewer.VisualStudio.UnitTests.dll'
 
 notifications:
   - provider: Email


### PR DESCRIPTION
@michaelcfanning 

Note: This will break the build since there are VSIX tests that are failing. I'll fix those tests after we see that the AppVeyor runs fail due to the test failures.