### PR TITLE
Fix #497: Modify PREfast converter per recent aCL changes

### DIFF
--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AA_IndexAlias.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AA_IndexAlias.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'contentStores' is an array of 2 elements (8 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":19,
                     "startLine":7
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_indexalias.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":19,
                     "startLine":9
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_indexalias.cpp",
@@ -71,7 +78,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'inputIndex>1')"
               },{
@@ -82,7 +92,10 @@
                     "startLine":13
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"alias",
                 "message":"(alias) 'index' receives the value of 'inputIndex'",
                 "importance":"essential"
@@ -94,7 +107,10 @@
                     "startLine":15
                   }
                 },
-                "step":3,
+                "step":6,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'contentStores[2]', (readable range is 0 to 1)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AA_RememberOldAlias.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AA_RememberOldAlias.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":7
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is not initialized",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -70,7 +77,9 @@
                     "startColumn":4,
                     "startLine":11
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -79,7 +88,10 @@
                     "startLine":13
                   }
                 },
-                "step":1,
+                "step":5,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is used, but may not have been initialized",
                 "importance":"essential"
@@ -122,7 +134,10 @@
                     "startLine":7
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 10 elements (40 bytes)",
                 "importance":"essential"
@@ -133,7 +148,9 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -141,7 +158,9 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -150,7 +169,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'b' is equal to 10",
                 "importance":"essential"
@@ -162,7 +184,10 @@
                     "startLine":13
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[10]', (readable range is 0 to 9)",
                 "importance":"essential"
@@ -205,7 +230,10 @@
                     "startLine":18
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is NULL",
                 "importance":"essential"
@@ -216,7 +244,9 @@
                     "startColumn":6,
                     "startLine":19
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -224,7 +254,9 @@
                     "startColumn":6,
                     "startLine":20
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -232,7 +264,9 @@
                     "startColumn":7,
                     "startLine":21
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -240,7 +274,9 @@
                     "startColumn":11,
                     "startLine":23
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -249,7 +285,10 @@
                     "startLine":23
                   }
                 },
-                "step":1,
+                "step":6,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<2')"
               },{
@@ -260,7 +299,10 @@
                     "startLine":25
                   }
                 },
-                "step":2,
+                "step":7,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'flag')"
               },{
@@ -271,7 +313,10 @@
                     "startLine":26
                   }
                 },
-                "step":3,
+                "step":8,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"alias",
                 "message":"(alias) 'b' receives the value of 'a' (which may be NULL)",
                 "importance":"essential"
@@ -283,7 +328,10 @@
                     "startLine":27
                   }
                 },
-                "step":4,
+                "step":9,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"alias",
                 "message":"(alias) 'c' receives the value of 'b' (which may be NULL)",
                 "importance":"essential"
@@ -294,7 +342,9 @@
                     "startColumn":9,
                     "startLine":28
                   }
-                }
+                },
+                "step":10,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -302,7 +352,9 @@
                     "startColumn":24,
                     "startLine":23
                   }
-                }
+                },
+                "step":11,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -311,7 +363,10 @@
                     "startLine":23
                   }
                 },
-                "step":5,
+                "step":12,
+                "properties":{
+                  "keyEventId":"6"
+                },
                 "kind":"branch",
                 "message":"Continue this loop, (assume 'i<2')"
               },{
@@ -322,7 +377,10 @@
                     "startLine":25
                   }
                 },
-                "step":6,
+                "step":13,
+                "properties":{
+                  "keyEventId":"7"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'flag' is false)"
               },{
@@ -332,7 +390,9 @@
                     "startColumn":6,
                     "startLine":30
                   }
-                }
+                },
+                "step":14,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -340,7 +400,9 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":15,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedaliasing/aa_rememberoldalias.cpp",
@@ -349,7 +411,10 @@
                     "startLine":32
                   }
                 },
-                "step":7,
+                "step":16,
+                "properties":{
+                  "keyEventId":"8"
+                },
                 "kind":"usage",
                 "message":"'c' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantBranch.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantBranch.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source1' is NULL",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":20,
                     "startLine":5
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantbranch.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantbranch.cpp",
@@ -71,7 +78,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'target' receives the value of 'source1' (which may be NULL)",
                 "importance":"essential"
@@ -83,7 +93,10 @@
                     "startLine":12
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'target' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -126,7 +139,10 @@
                     "startLine":20
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is not initialized",
                 "importance":"essential"
@@ -137,7 +153,9 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantbranch.cpp",
@@ -145,7 +163,9 @@
                     "startColumn":10,
                     "startLine":23
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantbranch.cpp",
@@ -154,7 +174,10 @@
                     "startLine":27
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is used, but may not have been initialized",
                 "importance":"essential"
@@ -197,7 +220,10 @@
                     "startLine":20
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 10 elements (40 bytes)",
                 "importance":"essential"
@@ -209,7 +235,10 @@
                     "startLine":21
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'index' is equal to 10",
                 "importance":"essential"
@@ -221,7 +250,10 @@
                     "startLine":23
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'flag<10' is false)"
               },{
@@ -232,7 +264,10 @@
                     "startLine":27
                   }
                 },
-                "step":3,
+                "step":4,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[10]', (readable range is 0 to 9)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantLoop.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantLoop.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":8
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 10 elements (40 bytes)",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":9
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'maxSize' is equal to 10",
                 "importance":"essential"
@@ -66,7 +72,9 @@
                     "startColumn":11,
                     "startLine":11
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -74,7 +82,9 @@
                     "startColumn":17,
                     "startLine":11
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -82,7 +92,9 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -90,7 +102,9 @@
                     "startColumn":28,
                     "startLine":11
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -98,7 +112,9 @@
                     "startColumn":17,
                     "startLine":11
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -106,7 +122,9 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -114,7 +132,9 @@
                     "startColumn":28,
                     "startLine":11
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -122,7 +142,9 @@
                     "startColumn":17,
                     "startLine":11
                   }
-                }
+                },
+                "step":10,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantloop.cpp",
@@ -131,7 +153,10 @@
                     "startLine":14
                   }
                 },
-                "step":2,
+                "step":11,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[10]', (readable range is 0 to 9)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantSwitch.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_IrrelevantSwitch.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":11
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 2 elements (8 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantswitch.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":23,
                     "startLine":12
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantswitch.cpp",
@@ -71,7 +78,10 @@
                     "startLine":14
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'index' is equal to 2",
                 "importance":"essential"
@@ -83,7 +93,10 @@
                     "startLine":16
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Assume switch ( 'flag' ) resolves to case 1: "
               },{
@@ -93,7 +106,9 @@
                     "startColumn":2,
                     "startLine":18
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_irrelevantswitch.cpp",
@@ -102,7 +117,10 @@
                     "startLine":30
                   }
                 },
-                "step":3,
+                "step":7,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[2]', (readable range is 0 to 1)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_SecondLoop.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AB_SecondLoop.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":10
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' is NULL",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":7,
                     "startLine":11
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -71,7 +78,10 @@
                     "startLine":13
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<3')"
               },{
@@ -82,7 +92,10 @@
                     "startLine":15
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!flag')"
               },{
@@ -92,7 +105,9 @@
                     "startColumn":9,
                     "startLine":16
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -100,7 +115,9 @@
                     "startColumn":22,
                     "startLine":13
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -109,7 +126,10 @@
                     "startLine":13
                   }
                 },
-                "step":3,
+                "step":8,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Continue this loop, (assume 'i<3')"
               },{
@@ -120,7 +140,10 @@
                     "startLine":15
                   }
                 },
-                "step":4,
+                "step":9,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!flag' is false)"
               },{
@@ -131,7 +154,10 @@
                     "startLine":18
                   }
                 },
-                "step":5,
+                "step":10,
+                "properties":{
+                  "keyEventId":"6"
+                },
                 "kind":"usage",
                 "message":"'source' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -174,7 +200,10 @@
                     "startLine":25
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' is NULL",
                 "importance":"essential"
@@ -185,7 +214,9 @@
                     "startColumn":7,
                     "startLine":26
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -193,7 +224,9 @@
                     "startColumn":11,
                     "startLine":28
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -202,7 +235,10 @@
                     "startLine":28
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<param')"
               },{
@@ -213,7 +249,10 @@
                     "startLine":30
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!flag')"
               },{
@@ -223,7 +262,9 @@
                     "startColumn":9,
                     "startLine":31
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -231,7 +272,9 @@
                     "startColumn":26,
                     "startLine":28
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -240,7 +283,10 @@
                     "startLine":28
                   }
                 },
-                "step":3,
+                "step":8,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Continue this loop, (assume 'i<param')"
               },{
@@ -251,7 +297,10 @@
                     "startLine":30
                   }
                 },
-                "step":4,
+                "step":9,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!flag' is false)"
               },{
@@ -262,7 +311,10 @@
                     "startLine":33
                   }
                 },
-                "step":5,
+                "step":10,
+                "properties":{
+                  "keyEventId":"6"
+                },
                 "kind":"usage",
                 "message":"'source' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -304,7 +356,9 @@
                     "startColumn":6,
                     "startLine":40
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -312,7 +366,9 @@
                     "startColumn":7,
                     "startLine":41
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -321,7 +377,10 @@
                     "startLine":42
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'x' is an array of 2 elements (8 bytes)",
                 "importance":"essential"
@@ -332,7 +391,9 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -340,7 +401,9 @@
                     "startColumn":11,
                     "startLine":44
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -349,7 +412,10 @@
                     "startLine":44
                   }
                 },
-                "step":1,
+                "step":6,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<param')"
               },{
@@ -360,7 +426,10 @@
                     "startLine":46
                   }
                 },
-                "step":2,
+                "step":7,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!flag')"
               },{
@@ -370,7 +439,9 @@
                     "startColumn":9,
                     "startLine":47
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -378,7 +449,9 @@
                     "startColumn":26,
                     "startLine":44
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -387,7 +460,10 @@
                     "startLine":44
                   }
                 },
-                "step":3,
+                "step":10,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Continue this loop, (assume 'i<param')"
               },{
@@ -398,7 +474,10 @@
                     "startLine":46
                   }
                 },
-                "step":4,
+                "step":11,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!flag' is false)"
               },{
@@ -408,7 +487,9 @@
                     "startColumn":8,
                     "startLine":49
                   }
-                }
+                },
+                "step":12,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -416,7 +497,9 @@
                     "startColumn":26,
                     "startLine":44
                   }
-                }
+                },
+                "step":13,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -425,7 +508,10 @@
                     "startLine":44
                   }
                 },
-                "step":5,
+                "step":14,
+                "properties":{
+                  "keyEventId":"6"
+                },
                 "kind":"branch",
                 "message":"'param' may equal 2 (Exit this loop)"
               },{
@@ -436,7 +522,10 @@
                     "startLine":52
                   }
                 },
-                "step":6,
+                "step":15,
+                "properties":{
+                  "keyEventId":"7"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'x[2]', (readable range is 0 to 1)",
                 "importance":"essential"
@@ -478,7 +567,9 @@
                     "startColumn":6,
                     "startLine":40
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -486,7 +577,9 @@
                     "startColumn":7,
                     "startLine":41
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -494,7 +587,9 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -503,7 +598,10 @@
                     "startLine":42
                   }
                 },
-                "step":0,
+                "step":4,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'y' is an array of 2 elements (8 bytes)",
                 "importance":"essential"
@@ -514,7 +612,9 @@
                     "startColumn":11,
                     "startLine":44
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -523,7 +623,10 @@
                     "startLine":44
                   }
                 },
-                "step":1,
+                "step":6,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<param')"
               },{
@@ -534,7 +637,10 @@
                     "startLine":46
                   }
                 },
-                "step":2,
+                "step":7,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!flag')"
               },{
@@ -544,7 +650,9 @@
                     "startColumn":9,
                     "startLine":47
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -552,7 +660,9 @@
                     "startColumn":26,
                     "startLine":44
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -561,7 +671,10 @@
                     "startLine":44
                   }
                 },
-                "step":3,
+                "step":10,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"'param' may equal 1 (Exit this loop)"
               },{
@@ -571,7 +684,9 @@
                     "startColumn":9,
                     "startLine":52
                   }
-                }
+                },
+                "step":11,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -580,7 +695,10 @@
                     "startLine":53
                   }
                 },
-                "step":4,
+                "step":12,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'y[2]', (readable range is 0 to 1)",
                 "importance":"essential"
@@ -623,7 +741,10 @@
                     "startLine":40
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' is NULL",
                 "importance":"essential"
@@ -634,7 +755,9 @@
                     "startColumn":7,
                     "startLine":41
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -642,7 +765,9 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -650,7 +775,9 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -658,7 +785,9 @@
                     "startColumn":11,
                     "startLine":44
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -667,7 +796,10 @@
                     "startLine":44
                   }
                 },
-                "step":1,
+                "step":6,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<param')"
               },{
@@ -678,7 +810,10 @@
                     "startLine":46
                   }
                 },
-                "step":2,
+                "step":7,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!flag')"
               },{
@@ -688,7 +823,9 @@
                     "startColumn":9,
                     "startLine":47
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -696,7 +833,9 @@
                     "startColumn":26,
                     "startLine":44
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedbranches/ab_secondloop.cpp",
@@ -705,7 +844,10 @@
                     "startLine":44
                   }
                 },
-                "step":3,
+                "step":10,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Continue this loop, (assume 'i<param')"
               },{
@@ -716,7 +858,10 @@
                     "startLine":46
                   }
                 },
-                "step":4,
+                "step":11,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!flag' is false)"
               },{
@@ -727,7 +872,10 @@
                     "startLine":49
                   }
                 },
-                "step":5,
+                "step":12,
+                "properties":{
+                  "keyEventId":"6"
+                },
                 "kind":"usage",
                 "message":"'source' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AF_LocalRemoteFunctions.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AF_LocalRemoteFunctions.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":9
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'p' may be NULL (Enter this branch)"
               },{
@@ -53,7 +56,9 @@
                     "startColumn":7,
                     "startLine":10
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedfunctions/af_localremotefunctions.cpp",
@@ -62,7 +67,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'p' is an In\/Out argument to 'LocalFunction' (declared on line 3)"
               },{
@@ -73,7 +81,10 @@
                     "startLine":12
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"declaration",
                 "message":"'p' is an In\/Out argument to 'RemoteFunction' (declared at d:\\src\\sarif-sdk\\src\\sarif.functionaltests\\convertertestdata\\prefast\\src\\advancedfunctions\\af_localremotefunctions.h:4)"
               },{
@@ -84,7 +95,10 @@
                     "startLine":13
                   }
                 },
-                "step":3,
+                "step":5,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"'p' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_AliasAndMaybeZero.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_AliasAndMaybeZero.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' is NULL",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":5
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'y' receives the value of 'source' (which may be NULL)",
                 "importance":"essential"
@@ -67,7 +73,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'y' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_AliasAndSetValue.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_AliasAndSetValue.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'TwoElementArray' is an array of 2 elements (8 bytes)",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":5
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"'b' may equal 10 (Enter this branch)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"alias",
                 "message":"(alias) 'index' receives the value of 'b' (which may be 10)",
                 "importance":"essential"
@@ -78,7 +87,10 @@
                     "startLine":9
                   }
                 },
-                "step":3,
+                "step":4,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'TwoElementArray[10]', (readable range is 0 to 1)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_BranchAndMaybeZero.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_BranchAndMaybeZero.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":6,
                     "startLine":5
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedmerging/am_branchandmaybezero.cpp",
@@ -51,7 +53,10 @@
                     "startLine":6
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'p' may be NULL (Enter this branch)"
               },{
@@ -61,7 +66,9 @@
                     "startColumn":7,
                     "startLine":7
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedmerging/am_branchandmaybezero.cpp",
@@ -70,7 +77,10 @@
                     "startLine":8
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'p' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -113,7 +123,10 @@
                     "startLine":13
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'input' may be NULL (Skip this branch)"
               },{
@@ -124,7 +137,10 @@
                     "startLine":15
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'input' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -166,7 +182,9 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedmerging/am_branchandmaybezero.cpp",
@@ -175,7 +193,10 @@
                     "startLine":22
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'p' may be NULL (Skip this branch)"
               },{
@@ -186,7 +207,10 @@
                     "startLine":24
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'p' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_BranchAndSetValue.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AM_BranchAndSetValue.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is not initialized",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":6
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedmerging/am_branchandsetvalue.cpp",
@@ -63,7 +68,10 @@
                     "startLine":8
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is used, but may not have been initialized",
                 "importance":"essential"
@@ -106,7 +114,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 10 elements (40 bytes)",
                 "importance":"essential"
@@ -118,7 +129,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"'b' may equal 10 (Enter this branch)"
               },{
@@ -129,7 +143,10 @@
                     "startLine":8
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[10]', (readable range is 0 to 9)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_Basic_C6053_4.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_Basic_C6053_4.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":11
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'x' is Output from 'DoesNotZ', which may not zero-terminate it",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":13
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'x' is an Input to 'RequiresZ' (declared on line 5)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":13
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'x' is required to be zero-terminated by a SAL annotation on 'RequiresZ'",
                 "importance":"essential"
@@ -109,7 +118,10 @@
                     "startLine":19
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"This expression may not zero-terminate 'a'",
                 "importance":"essential"
@@ -121,7 +133,10 @@
                     "startLine":21
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'a' is an Input to 'RequiresZ' (declared on line 5)"
               },{
@@ -132,7 +147,10 @@
                     "startLine":21
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'a' is required to be zero-terminated by a SAL annotation on 'RequiresZ'",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_Basic_C6387.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_Basic_C6387.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":14
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":16
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is an Input to 'RequiresNotNull' (declared on line 5)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":16
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' should not be NULL, because this is not consistent with the SAL annotation on 'RequiresNotNull'",
                 "importance":"essential"
@@ -109,7 +118,10 @@
                     "startLine":20
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' may be NULL",
                 "importance":"essential"
@@ -121,7 +133,10 @@
                     "startLine":22
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is an Input to 'RequiresNotNull' (declared on line 5)"
               },{
@@ -132,7 +147,10 @@
                     "startLine":22
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' should not be NULL, because this is not consistent with the SAL annotation on 'RequiresNotNull'",
                 "importance":"essential"
@@ -175,7 +193,10 @@
                     "startLine":28
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' may be NULL",
                 "importance":"essential"
@@ -187,7 +208,10 @@
                     "startLine":30
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'data' is an Input to 'RequiresNotNull' (declared on line 5)"
               },{
@@ -198,7 +222,10 @@
                     "startLine":30
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' should not be NULL, because this is not consistent with the SAL annotation on 'RequiresNotNull'",
                 "importance":"essential"
@@ -241,7 +268,10 @@
                     "startLine":36
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -253,7 +283,10 @@
                     "startLine":38
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'data' is an In\/Out argument to 'RequiresNotNullOut' (declared on line 7)"
               },{
@@ -264,7 +297,10 @@
                     "startLine":38
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' should not be NULL, because this is not consistent with the SAL annotation on 'RequiresNotNullOut'",
                 "importance":"essential"
@@ -306,7 +342,9 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedannotations/an_basic_c6387.cpp",
@@ -315,7 +353,10 @@
                     "startLine":47
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'*pOut' may be NULL",
                 "importance":"essential"
@@ -326,7 +367,9 @@
                     "startColumn":1,
                     "startLine":48
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedannotations/an_basic_c6387.cpp",
@@ -335,7 +378,10 @@
                     "startLine":43
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'*pOut' should not be NULL, because this is not consistent with the SAL annotation on 'BasicC6387_OutNotNull'",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_FunctionAndInAnnotations.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_FunctionAndInAnnotations.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":8
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":9
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'flag')"
               },{
@@ -66,7 +72,10 @@
                     "startLine":10
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'source' is an Input to 'UseValues' (declared on line 4)"
               },{
@@ -77,7 +86,10 @@
                     "startLine":10
                   }
                 },
-                "step":3,
+                "step":4,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"'source' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_InOptAnnotations.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_InOptAnnotations.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'source' may be NULL",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'flag')"
               },{
@@ -66,7 +72,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'source' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_OutWithDefect.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AN_OutWithDefect.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'*target' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'flag' is false)"
               },{
@@ -65,7 +71,9 @@
                     "startColumn":1,
                     "startLine":8
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/advancedannotations/an_outwithdefect.cpp",
@@ -74,7 +82,10 @@
                     "startLine":4
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'*target' is an _Out_ parameter that may not have been assigned to",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AdvancedC6305.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/AdvancedC6305.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'inc' is a byte quantity",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":7,
                     "startLine":10
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -63,7 +68,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'b')"
               },{
@@ -74,7 +82,10 @@
                     "startLine":12
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -116,7 +127,9 @@
                     "startColumn":9,
                     "startLine":20
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -125,7 +138,10 @@
                     "startLine":22
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'j' is a byte quantity",
                 "importance":"essential"
@@ -137,7 +153,10 @@
                     "startLine":24
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -179,7 +198,9 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -187,7 +208,9 @@
                     "startColumn":4,
                     "startLine":33
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -195,7 +218,9 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -203,7 +228,9 @@
                     "startColumn":4,
                     "startLine":35
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -212,7 +239,10 @@
                     "startLine":36
                   }
                 },
-                "step":0,
+                "step":5,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -224,7 +254,10 @@
                     "startLine":38
                   }
                 },
-                "step":1,
+                "step":6,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -266,7 +299,9 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -275,7 +310,10 @@
                     "startLine":33
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -286,7 +324,9 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -295,7 +335,10 @@
                     "startLine":35
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -337,7 +380,9 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -345,7 +390,9 @@
                     "startColumn":4,
                     "startLine":33
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -353,7 +400,9 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -362,7 +411,10 @@
                     "startLine":35
                   }
                 },
-                "step":0,
+                "step":4,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -374,7 +426,10 @@
                     "startLine":36
                   }
                 },
-                "step":1,
+                "step":5,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -417,7 +472,10 @@
                     "startLine":31
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -429,7 +487,10 @@
                     "startLine":33
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -471,7 +532,9 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -479,7 +542,9 @@
                     "startColumn":4,
                     "startLine":33
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -487,7 +552,9 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -495,7 +562,9 @@
                     "startColumn":4,
                     "startLine":35
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -503,7 +572,9 @@
                     "startColumn":4,
                     "startLine":36
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -512,7 +583,10 @@
                     "startLine":38
                   }
                 },
-                "step":0,
+                "step":6,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -524,7 +598,10 @@
                     "startLine":39
                   }
                 },
-                "step":1,
+                "step":7,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -566,7 +643,9 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -575,7 +654,10 @@
                     "startLine":47
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'j' is a byte quantity",
                 "importance":"essential"
@@ -587,7 +669,10 @@
                     "startLine":49
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'i' receives a byte quantity from 'j'",
                 "importance":"essential"
@@ -599,7 +684,10 @@
                     "startLine":51
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -641,7 +729,9 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -649,7 +739,9 @@
                     "startColumn":9,
                     "startLine":59
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -658,7 +750,10 @@
                     "startLine":61
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -700,7 +795,9 @@
                     "startColumn":6,
                     "startLine":68
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -708,7 +805,9 @@
                     "startColumn":5,
                     "startLine":69
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/advancedc6305.cpp",
@@ -717,7 +816,10 @@
                     "startLine":70
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -760,7 +862,10 @@
                     "startLine":75
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'cb' is a byte quantity",
                 "importance":"essential"
@@ -772,7 +877,10 @@
                     "startLine":77
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C28182Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C28182Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":13
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'pNodeFree' may be NULL (Enter this branch)"
               },{
@@ -54,7 +57,10 @@
                     "startLine":15
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'pNode' receives the value of 'pNodeFree' (which may be NULL)",
                 "importance":"essential"
@@ -66,7 +72,10 @@
                     "startLine":16
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'pNode' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":5
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'b&&c' is false)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":9
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'i' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example2.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example2.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":8,
                     "startLine":4
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example2.cpp",
@@ -51,7 +53,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is not initialized",
                 "importance":"essential"
@@ -63,7 +68,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'c')"
               },{
@@ -73,7 +81,9 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example2.cpp",
@@ -82,7 +92,10 @@
                     "startLine":8
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'b' is false)"
               },{
@@ -92,7 +105,9 @@
                     "startColumn":7,
                     "startLine":12
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example2.cpp",
@@ -101,7 +116,10 @@
                     "startLine":17
                   }
                 },
-                "step":3,
+                "step":7,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"'i' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example3.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6001Example3.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":5
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Go to labelb"
               },{
@@ -65,7 +71,9 @@
                     "startColumn":1,
                     "startLine":8
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example3.cpp",
@@ -74,7 +82,10 @@
                     "startLine":9
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Go to labela"
               },{
@@ -84,7 +95,9 @@
                     "startColumn":1,
                     "startLine":6
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example3.cpp",
@@ -93,7 +106,10 @@
                     "startLine":7
                   }
                 },
-                "step":3,
+                "step":6,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Go to labelc"
               },{
@@ -103,7 +119,9 @@
                     "startColumn":1,
                     "startLine":10
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6001/c6001example3.cpp",
@@ -112,7 +130,10 @@
                     "startLine":11
                   }
                 },
-                "step":4,
+                "step":8,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"usage",
                 "message":"'i' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6011Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6011Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'p' may be NULL",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'p' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6059Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6059Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":6
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 35 elements (35 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":7
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6059/c6059example.cpp",
@@ -63,7 +68,10 @@
                     "startLine":9
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'a' is an Output from 'strcpy' (declared at c:\\program files (x86)\\microsoft visual studio 11.0\\vc\\wpsdk\\wp80\\include\\string.h:110)"
               },{
@@ -74,7 +82,10 @@
                     "startLine":10
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"declaration",
                 "message":"'a' is an Output from 'strncat' (declared at c:\\program files (x86)\\microsoft visual studio 11.0\\vc\\wpsdk\\wp80\\include\\string.h:182)"
               },{
@@ -85,7 +96,10 @@
                     "startLine":10
                   }
                 },
-                "step":3,
+                "step":5,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Length argument to 'strncat' should be less than the length of 'a'",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6305Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6305Example.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":8,
                     "startLine":3
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/c6305/c6305example.cpp",
@@ -51,7 +53,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'cb' is a byte quantity",
                 "importance":"essential"
@@ -63,7 +68,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 5 elements (5 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":13,
                     "startLine":4
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -70,7 +77,9 @@
                     "startColumn":33,
                     "startLine":4
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -78,7 +87,9 @@
                     "startColumn":24,
                     "startLine":4
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -86,7 +97,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -94,7 +107,9 @@
                     "startColumn":33,
                     "startLine":4
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -102,7 +117,9 @@
                     "startColumn":24,
                     "startLine":4
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -110,7 +127,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -118,7 +137,9 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":10,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/combinedwarnings/c6385example.cpp",
@@ -127,7 +148,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":11,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'i<=5')"
               },{
@@ -138,7 +162,10 @@
                     "startLine":8
                   }
                 },
-                "step":2,
+                "step":12,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'a[5]', (readable range is 0 to 4)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example2.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example2.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 20 elements (80 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":5
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6385/c6385example2.cpp",
@@ -63,7 +68,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<=20')"
               },{
@@ -74,7 +82,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'a[20]', (readable range is 0 to 19)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example3.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6385Example3.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":4
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 20 elements (80 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":5
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6385/c6385example3.cpp",
@@ -63,7 +68,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'i' is equal to 20",
                 "importance":"essential"
@@ -75,7 +83,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'i>=0&&i<=20')"
               },{
@@ -86,7 +97,10 @@
                     "startLine":9
                   }
                 },
-                "step":3,
+                "step":5,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'a[20]', (readable range is 0 to 19)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 4 elements (4 bytes)",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":4
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'j' is equal to 4",
                 "importance":"essential"
@@ -67,7 +73,10 @@
                     "startLine":5
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'j<4' is false)"
               },{
@@ -78,7 +87,10 @@
                     "startLine":9
                   }
                 },
-                "step":3,
+                "step":4,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'a[4]', (writable range is 0 to 3)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example2.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example2.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 20 elements (80 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":4
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6386/c6386example2.cpp",
@@ -63,7 +68,10 @@
                     "startLine":5
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'i<=21')"
               },{
@@ -74,7 +82,10 @@
                     "startLine":7
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'a[20]', (writable range is 0 to 19)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example3.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/C6386Example3.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 4 elements (4 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":8,
                     "startLine":4
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6386/c6386example3.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":13,
                     "startLine":4
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/complex/c6386/c6386example3.cpp",
@@ -71,7 +78,10 @@
                     "startLine":8
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'a[4]', (writable range is 0 to 3)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-001.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-001.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":18,
                     "startLine":9
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":5,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":18,
                     "startLine":9
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":11,
                     "startLine":11
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":21,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":13,
                     "startLine":13
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":30,
                     "startLine":13
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":5,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":9,
                     "startLine":34
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":14,
                     "startLine":36
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":19,
                     "startLine":36
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":15,
                     "startLine":37
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":19,
                     "startLine":37
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":17,
                     "startLine":38
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":14,
                     "startLine":40
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":14,
                     "startLine":41
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -307,7 +331,8 @@
                     "startColumn":5,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":9,
                     "startLine":34
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":18,
                     "startLine":49
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":10,
                     "startLine":50
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":28,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":14,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":26,
                     "startLine":53
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test001.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":26,
                     "startLine":54
                   }
-                }
+                },
+                "step":14
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-002.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-002.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":41
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":41
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":10,
                     "startLine":42
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":14,
                     "startLine":46
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test002.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":14,
                     "startLine":48
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-003.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-003.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test003.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test003.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test003.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test003.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":14
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test003.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":15
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-005.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-005.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":23,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":23,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":16
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":15,
                     "startLine":18
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":17,
                     "startLine":19
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":9,
                     "startLine":20
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test005.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":12
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-008.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-008.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":8,
                     "startLine":15
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":20
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":31,
                     "startLine":20
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":34,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":28
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":17,
                     "startLine":29
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":14,
                     "startLine":35
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":18,
                     "startLine":35
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":23,
                     "startLine":35
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":29,
                     "startLine":37
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":34,
                     "startLine":35
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":23,
                     "startLine":35
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":14,
                     "startLine":40
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":18,
                     "startLine":40
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":23,
                     "startLine":40
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test008.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":33,
                     "startLine":42
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-010.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-010.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test010.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test010.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test010.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":19,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":18,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":29,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":18,
                     "startLine":14
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -77,31 +82,8 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":18,
-                    "startLine":16
-                  }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":54,
-                    "startLine":14
-                  }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":23,
-                    "startLine":14
-                  }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -109,7 +91,8 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -117,7 +100,8 @@
                     "startColumn":54,
                     "startLine":14
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -125,7 +109,8 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -133,7 +118,8 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -141,7 +127,8 @@
                     "startColumn":54,
                     "startLine":14
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -149,7 +136,35 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
+                },
+                "step":12
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":18,
+                    "startLine":16
+                  }
+                },
+                "step":13
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":54,
+                    "startLine":14
+                  }
+                },
+                "step":14
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":23,
+                    "startLine":14
+                  }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":38,
                     "startLine":18
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -191,7 +207,8 @@
                     "startColumn":9,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":19,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":19,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":9,
                     "startLine":24
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":10,
                     "startLine":27
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":18,
                     "startLine":27
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":10,
                     "startLine":28
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":10,
                     "startLine":29
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":10,
                     "startLine":30
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":10,
                     "startLine":31
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":10,
                     "startLine":34
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":10,
                     "startLine":35
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":14,
                     "startLine":36
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":10,
                     "startLine":37
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":10,
                     "startLine":38
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":19
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-011.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":29,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":18,
                     "startLine":14
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -77,31 +82,8 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":18,
-                    "startLine":16
-                  }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":54,
-                    "startLine":14
-                  }
-                }
-              },{
-                "physicalLocation":{
-                  "uri":"file:///c:/somepath/test011.cpp",
-                  "region":{
-                    "startColumn":23,
-                    "startLine":14
-                  }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -109,7 +91,8 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -117,7 +100,8 @@
                     "startColumn":54,
                     "startLine":14
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -125,7 +109,8 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -133,7 +118,8 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -141,7 +127,8 @@
                     "startColumn":54,
                     "startLine":14
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -149,7 +136,35 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
+                },
+                "step":12
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":18,
+                    "startLine":16
+                  }
+                },
+                "step":13
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":54,
+                    "startLine":14
+                  }
+                },
+                "step":14
+              },{
+                "physicalLocation":{
+                  "uri":"file:///c:/somepath/test011.cpp",
+                  "region":{
+                    "startColumn":23,
+                    "startLine":14
+                  }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":38,
                     "startLine":18
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -191,7 +207,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":15,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":19,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":19,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":9,
                     "startLine":24
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":11,
                     "startLine":27
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":18,
                     "startLine":27
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":10,
                     "startLine":28
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":10,
                     "startLine":29
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":10,
                     "startLine":30
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":10,
                     "startLine":31
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":10,
                     "startLine":34
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":10,
                     "startLine":35
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":14,
                     "startLine":36
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":10,
                     "startLine":37
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":10,
                     "startLine":38
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test011.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":19
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-013.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-013.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":26,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":33,
                     "startLine":12
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":33,
                     "startLine":12
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":13
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":21,
                     "startLine":13
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":36,
                     "startLine":13
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -135,7 +144,8 @@
                     "startColumn":5,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":10,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":14,
                     "startLine":26
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":9,
                     "startLine":27
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":13,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":9,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":13,
                     "startLine":28
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":13,
                     "startLine":29
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -233,7 +251,8 @@
                     "startColumn":5,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":10,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":14,
                     "startLine":26
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":9,
                     "startLine":27
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":13,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":9,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":13,
                     "startLine":28
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":13,
                     "startLine":29
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":9,
                     "startLine":30
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":13,
                     "startLine":30
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":9,
                     "startLine":31
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":16,
                     "startLine":31
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -337,7 +368,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -345,7 +377,8 @@
                     "startColumn":14,
                     "startLine":32
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -353,7 +386,8 @@
                     "startColumn":9,
                     "startLine":33
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -361,7 +395,8 @@
                     "startColumn":13,
                     "startLine":33
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":10,
                     "startLine":34
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":14,
                     "startLine":34
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":9,
                     "startLine":35
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test013.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":14,
                     "startLine":37
                   }
-                }
+                },
+                "step":22
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-014.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-014.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":23,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":23,
                     "startLine":12
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":17,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":23,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":23,
                     "startLine":12
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test014.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":23,
                     "startLine":13
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":12,
                     "startLine":60
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":5,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":67
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":73
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -207,7 +225,8 @@
                     "startColumn":12,
                     "startLine":84
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":5,
                     "startLine":90
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":5,
                     "startLine":91
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":9,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":14,
                     "startLine":97
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":18,
                     "startLine":97
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -377,7 +413,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":9,
                     "startLine":110
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":5,
                     "startLine":111
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":9,
                     "startLine":116
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":13,
                     "startLine":116
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":14,
                     "startLine":117
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":18,
                     "startLine":117
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-016.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":12,
                     "startLine":60
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":5,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":67
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":73
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":29,
                     "startLine":73
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":23,
                     "startLine":73
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -207,7 +225,8 @@
                     "startColumn":12,
                     "startLine":84
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":5,
                     "startLine":90
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":5,
                     "startLine":91
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":9,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":14,
                     "startLine":97
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":18,
                     "startLine":97
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":31,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":24,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":31,
                     "startLine":99
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -377,7 +413,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":9,
                     "startLine":110
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":5,
                     "startLine":111
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":9,
                     "startLine":116
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":13,
                     "startLine":116
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":14,
                     "startLine":117
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":18,
                     "startLine":117
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":24,
                     "startLine":117
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test016.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":30,
                     "startLine":119
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-017.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-017.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":30,
                     "startLine":31
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":32
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":34
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":21,
                     "startLine":34
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":21,
                     "startLine":34
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":13,
                     "startLine":35
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":17,
                     "startLine":37
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":37,
                     "startLine":37
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":17,
                     "startLine":38
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":41,
                     "startLine":38
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":26,
                     "startLine":39
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":17,
                     "startLine":41
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":39,
                     "startLine":41
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":25,
                     "startLine":41
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":23,
                     "startLine":44
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":21,
                     "startLine":47
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":29,
                     "startLine":47
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":29,
                     "startLine":47
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":29,
                     "startLine":50
                   }
-                }
+                },
+                "step":26
               }
             ]
           }
@@ -271,7 +297,8 @@
                     "startColumn":9,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":19,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":9,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":30,
                     "startLine":31
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":16,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":9,
                     "startLine":32
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":13,
                     "startLine":34
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":21,
                     "startLine":34
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":21,
                     "startLine":34
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":13,
                     "startLine":35
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":17,
                     "startLine":37
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":37,
                     "startLine":37
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":17,
                     "startLine":38
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":41,
                     "startLine":38
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":26,
                     "startLine":39
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":17,
                     "startLine":41
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":39,
                     "startLine":41
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":25,
                     "startLine":41
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":23,
                     "startLine":44
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":21,
                     "startLine":47
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":29,
                     "startLine":47
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":29,
                     "startLine":47
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":24,
                     "startLine":53
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":35,
                     "startLine":53
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":35,
                     "startLine":53
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":21,
                     "startLine":54
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test017.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":27,
                     "startLine":56
                   }
-                }
+                },
+                "step":30
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-020.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-020.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test020.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":6,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test020.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test020.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":6,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test020.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":3,
                     "startLine":14
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test020.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":6,
                     "startLine":15
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-021.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-021.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test021.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":7,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test021.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":8,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test021.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":7,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test021.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":8,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-022.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-022.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":30
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -129,7 +134,8 @@
                     "startColumn":6,
                     "startLine":33
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":20,
                     "startLine":35
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -171,7 +178,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -179,7 +187,8 @@
                     "startColumn":18,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -213,7 +222,8 @@
                     "startColumn":6,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -221,7 +231,8 @@
                     "startColumn":14,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -229,7 +240,8 @@
                     "startColumn":26,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -237,7 +249,8 @@
                     "startColumn":26,
                     "startLine":66
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -245,7 +258,8 @@
                     "startColumn":13,
                     "startLine":67
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -253,7 +267,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -287,7 +302,8 @@
                     "startColumn":6,
                     "startLine":78
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -295,7 +311,8 @@
                     "startColumn":7,
                     "startLine":80
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -329,7 +346,8 @@
                     "startColumn":6,
                     "startLine":89
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -337,7 +355,8 @@
                     "startColumn":10,
                     "startLine":91
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -345,7 +364,8 @@
                     "startColumn":9,
                     "startLine":92
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -353,7 +373,8 @@
                     "startColumn":12,
                     "startLine":93
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -361,7 +382,8 @@
                     "startColumn":24,
                     "startLine":93
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -395,7 +417,8 @@
                     "startColumn":6,
                     "startLine":97
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -403,7 +426,8 @@
                     "startColumn":12,
                     "startLine":99
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -411,7 +435,8 @@
                     "startColumn":16,
                     "startLine":99
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -419,7 +444,8 @@
                     "startColumn":17,
                     "startLine":100
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -427,7 +453,8 @@
                     "startColumn":21,
                     "startLine":100
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -435,7 +462,8 @@
                     "startColumn":26,
                     "startLine":100
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -443,7 +471,8 @@
                     "startColumn":21,
                     "startLine":101
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -451,7 +480,8 @@
                     "startColumn":25,
                     "startLine":101
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -459,7 +489,8 @@
                     "startColumn":30,
                     "startLine":101
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -467,7 +498,8 @@
                     "startColumn":22,
                     "startLine":102
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -475,7 +507,8 @@
                     "startColumn":36,
                     "startLine":101
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -483,7 +516,8 @@
                     "startColumn":30,
                     "startLine":101
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -491,7 +525,8 @@
                     "startColumn":22,
                     "startLine":102
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -525,7 +560,8 @@
                     "startColumn":6,
                     "startLine":109
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -533,7 +569,8 @@
                     "startColumn":14,
                     "startLine":111
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -541,7 +578,8 @@
                     "startColumn":18,
                     "startLine":111
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -549,7 +587,8 @@
                     "startColumn":23,
                     "startLine":111
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -557,7 +596,8 @@
                     "startColumn":16,
                     "startLine":112
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -565,7 +605,8 @@
                     "startColumn":39,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -573,7 +614,8 @@
                     "startColumn":23,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -581,7 +623,8 @@
                     "startColumn":16,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -589,7 +632,8 @@
                     "startColumn":39,
                     "startLine":111
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -597,7 +641,8 @@
                     "startColumn":23,
                     "startLine":111
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -605,7 +650,8 @@
                     "startColumn":16,
                     "startLine":112
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -613,7 +659,8 @@
                     "startColumn":39,
                     "startLine":111
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -621,7 +668,8 @@
                     "startColumn":23,
                     "startLine":111
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -629,7 +677,8 @@
                     "startColumn":16,
                     "startLine":112
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -663,7 +712,8 @@
                     "startColumn":6,
                     "startLine":122
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -671,7 +721,8 @@
                     "startColumn":9,
                     "startLine":124
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -679,7 +730,8 @@
                     "startColumn":6,
                     "startLine":125
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -713,7 +765,8 @@
                     "startColumn":6,
                     "startLine":128
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -721,7 +774,8 @@
                     "startColumn":9,
                     "startLine":130
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test022.cpp",
@@ -729,7 +783,8 @@
                     "startColumn":7,
                     "startLine":131
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-023.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-023.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":7,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":2,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -145,7 +152,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":10,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":10,
                     "startLine":58
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":6,
                     "startLine":59
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -203,7 +214,8 @@
                     "startColumn":6,
                     "startLine":62
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -211,7 +223,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -219,7 +232,8 @@
                     "startColumn":8,
                     "startLine":67
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":12,
                     "startLine":67
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -261,7 +276,8 @@
                     "startColumn":6,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -269,7 +285,8 @@
                     "startColumn":16,
                     "startLine":86
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -277,7 +294,8 @@
                     "startColumn":20,
                     "startLine":86
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -285,7 +303,8 @@
                     "startColumn":12,
                     "startLine":87
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -293,7 +312,8 @@
                     "startColumn":7,
                     "startLine":88
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -327,7 +347,8 @@
                     "startColumn":6,
                     "startLine":91
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -335,7 +356,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -343,7 +365,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -351,7 +374,8 @@
                     "startColumn":8,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test023.cpp",
@@ -359,7 +383,8 @@
                     "startColumn":8,
                     "startLine":97
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-024.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-024.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test024.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-031.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-031.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":8,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":23,
                     "startLine":14
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":17,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":15,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":21,
                     "startLine":72
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":9,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":13,
                     "startLine":78
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":14,
                     "startLine":80
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":18,
                     "startLine":80
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":39,
                     "startLine":80
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":14,
                     "startLine":85
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":18,
                     "startLine":85
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":19
               }
             ]
           }
@@ -273,7 +296,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":17,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":15,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":21,
                     "startLine":72
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":9,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":13,
                     "startLine":78
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":14,
                     "startLine":80
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":18,
                     "startLine":80
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -337,7 +368,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -345,7 +377,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -353,7 +386,8 @@
                     "startColumn":39,
                     "startLine":80
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -361,7 +395,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":14,
                     "startLine":85
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":18,
                     "startLine":85
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":14,
                     "startLine":92
                   }
-                }
+                },
+                "step":25
               }
             ]
           }
@@ -499,7 +547,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -507,7 +556,8 @@
                     "startColumn":17,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -515,7 +565,8 @@
                     "startColumn":15,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -523,7 +574,8 @@
                     "startColumn":21,
                     "startLine":72
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -531,7 +583,8 @@
                     "startColumn":9,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -539,7 +592,8 @@
                     "startColumn":13,
                     "startLine":78
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -547,7 +601,8 @@
                     "startColumn":14,
                     "startLine":80
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -555,7 +610,8 @@
                     "startColumn":18,
                     "startLine":80
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -563,7 +619,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -571,7 +628,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -579,7 +637,8 @@
                     "startColumn":39,
                     "startLine":80
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -587,7 +646,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -595,7 +655,8 @@
                     "startColumn":14,
                     "startLine":85
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -603,7 +664,8 @@
                     "startColumn":18,
                     "startLine":85
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -611,7 +673,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -619,7 +682,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -627,7 +691,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -635,7 +700,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -643,7 +709,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -651,7 +718,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -659,7 +727,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -667,7 +736,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -675,7 +745,8 @@
                     "startColumn":40,
                     "startLine":85
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -683,7 +754,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -691,7 +763,8 @@
                     "startColumn":14,
                     "startLine":92
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -699,7 +772,8 @@
                     "startColumn":9,
                     "startLine":95
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -707,7 +781,8 @@
                     "startColumn":19,
                     "startLine":95
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -715,7 +790,8 @@
                     "startColumn":9,
                     "startLine":96
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":19,
                     "startLine":96
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test031.cpp",
@@ -739,7 +817,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":31
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-032.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-032.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":8,
                     "startLine":20
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":22
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":22
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test032.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":12
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-035.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-035.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":6
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":8
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":7,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":8,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":7,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":13
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":8,
                     "startLine":17
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":10,
                     "startLine":19
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":7,
                     "startLine":20
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":8,
                     "startLine":21
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -183,7 +198,8 @@
                     "startColumn":6,
                     "startLine":6
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":10,
                     "startLine":8
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":7,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":8,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":13,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":7,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":9,
                     "startLine":13
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":8,
                     "startLine":17
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":10,
                     "startLine":19
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":7,
                     "startLine":20
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":8,
                     "startLine":21
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":10,
                     "startLine":23
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":7,
                     "startLine":24
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test035.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":8,
                     "startLine":25
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-036.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-036.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test036.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":6,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test036.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":8,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test036.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":60
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-037.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-037.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":20,
                     "startLine":7
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":10,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":10,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":20,
                     "startLine":7
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":20,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -259,7 +277,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test037.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":20,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":8,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":8,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -137,7 +143,8 @@
                     "startColumn":7,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":11,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":21,
                     "startLine":26
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":21,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":7,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":12,
                     "startLine":27
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-038.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -137,7 +143,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":11,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":21,
                     "startLine":26
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":21,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":8,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test038.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":12,
                     "startLine":27
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-039.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-039.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":50
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":7,
                     "startLine":52
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":11,
                     "startLine":53
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":18,
                     "startLine":53
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":7,
                     "startLine":54
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":12,
                     "startLine":55
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":6,
                     "startLine":58
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":7,
                     "startLine":60
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":18,
                     "startLine":61
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":7,
                     "startLine":62
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":12,
                     "startLine":63
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -259,7 +277,8 @@
                     "startColumn":6,
                     "startLine":66
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":7,
                     "startLine":68
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":11,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":18,
                     "startLine":69
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":7,
                     "startLine":70
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test039.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":12,
                     "startLine":71
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-040.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-040.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":55
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test040.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":8,
                     "startLine":57
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test040.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":8,
                     "startLine":58
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":61
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test040.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":9,
                     "startLine":63
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test040.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":12,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test040.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":13,
                     "startLine":67
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-041.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-041.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":26
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":32,
                     "startLine":28
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":48
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":10,
                     "startLine":50
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -121,7 +125,8 @@
                     "startColumn":6,
                     "startLine":53
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":12,
                     "startLine":55
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -163,7 +169,8 @@
                     "startColumn":6,
                     "startLine":68
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -171,7 +178,8 @@
                     "startColumn":12,
                     "startLine":70
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -179,7 +187,8 @@
                     "startColumn":10,
                     "startLine":70
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -213,7 +222,8 @@
                     "startColumn":6,
                     "startLine":75
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -221,7 +231,8 @@
                     "startColumn":9,
                     "startLine":77
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -229,7 +240,8 @@
                     "startColumn":8,
                     "startLine":78
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -263,7 +275,8 @@
                     "startColumn":6,
                     "startLine":106
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -271,7 +284,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -279,7 +293,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -313,7 +328,8 @@
                     "startColumn":6,
                     "startLine":118
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -321,7 +337,8 @@
                     "startColumn":10,
                     "startLine":120
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -355,7 +372,8 @@
                     "startColumn":6,
                     "startLine":191
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -363,7 +381,8 @@
                     "startColumn":9,
                     "startLine":193
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -371,7 +390,8 @@
                     "startColumn":10,
                     "startLine":194
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -379,7 +399,8 @@
                     "startColumn":8,
                     "startLine":195
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -387,7 +408,8 @@
                     "startColumn":9,
                     "startLine":197
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -395,7 +417,8 @@
                     "startColumn":9,
                     "startLine":198
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -403,7 +426,8 @@
                     "startColumn":9,
                     "startLine":200
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -411,7 +435,8 @@
                     "startColumn":9,
                     "startLine":201
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -419,7 +444,8 @@
                     "startColumn":10,
                     "startLine":203
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -427,7 +453,8 @@
                     "startColumn":9,
                     "startLine":204
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -435,7 +462,8 @@
                     "startColumn":9,
                     "startLine":205
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -443,7 +471,8 @@
                     "startColumn":9,
                     "startLine":206
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -451,7 +480,8 @@
                     "startColumn":22,
                     "startLine":208
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -459,7 +489,8 @@
                     "startColumn":18,
                     "startLine":209
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -493,7 +524,8 @@
                     "startColumn":6,
                     "startLine":191
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -501,7 +533,8 @@
                     "startColumn":9,
                     "startLine":193
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -509,7 +542,8 @@
                     "startColumn":10,
                     "startLine":194
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -517,7 +551,8 @@
                     "startColumn":8,
                     "startLine":195
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -525,7 +560,8 @@
                     "startColumn":9,
                     "startLine":197
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -533,7 +569,8 @@
                     "startColumn":9,
                     "startLine":198
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -541,7 +578,8 @@
                     "startColumn":9,
                     "startLine":200
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -549,7 +587,8 @@
                     "startColumn":9,
                     "startLine":201
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -557,7 +596,8 @@
                     "startColumn":10,
                     "startLine":203
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -565,7 +605,8 @@
                     "startColumn":9,
                     "startLine":204
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -573,7 +614,8 @@
                     "startColumn":9,
                     "startLine":205
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -581,7 +623,8 @@
                     "startColumn":9,
                     "startLine":206
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -589,7 +632,8 @@
                     "startColumn":22,
                     "startLine":208
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -597,7 +641,8 @@
                     "startColumn":18,
                     "startLine":209
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -605,7 +650,8 @@
                     "startColumn":9,
                     "startLine":212
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -613,7 +659,8 @@
                     "startColumn":9,
                     "startLine":213
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -621,7 +668,8 @@
                     "startColumn":9,
                     "startLine":214
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -629,7 +677,8 @@
                     "startColumn":22,
                     "startLine":216
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test041.cpp",
@@ -637,7 +686,8 @@
                     "startColumn":18,
                     "startLine":217
                   }
-                }
+                },
+                "step":19
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-042.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-042.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":18,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":7
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":18,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":10
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":27,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":18,
                     "startLine":11
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":34,
                     "startLine":10
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":27,
                     "startLine":10
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":5,
                     "startLine":13
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -159,7 +171,8 @@
                     "startColumn":6,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":14,
                     "startLine":18
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":18
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":18,
                     "startLine":21
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":22,
                     "startLine":21
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":27,
                     "startLine":21
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":18,
                     "startLine":22
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":34,
                     "startLine":21
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":27,
                     "startLine":21
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":10,
                     "startLine":24
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -281,7 +305,8 @@
                     "startColumn":6,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":29,
                     "startLine":29
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":50,
                     "startLine":29
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":12,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -347,7 +376,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":12,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":5,
                     "startLine":36
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -397,7 +429,8 @@
                     "startColumn":18,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -405,7 +438,8 @@
                     "startColumn":5,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -439,7 +473,8 @@
                     "startColumn":18,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -447,7 +482,8 @@
                     "startColumn":5,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -481,7 +517,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -489,7 +526,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -497,7 +535,8 @@
                     "startColumn":25,
                     "startLine":58
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -505,7 +544,8 @@
                     "startColumn":14,
                     "startLine":61
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":18,
                     "startLine":61
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":23,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -529,7 +571,8 @@
                     "startColumn":14,
                     "startLine":62
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -537,7 +580,8 @@
                     "startColumn":30,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -545,7 +589,8 @@
                     "startColumn":23,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -553,7 +598,8 @@
                     "startColumn":8,
                     "startLine":64
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -587,7 +633,8 @@
                     "startColumn":6,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -595,7 +642,8 @@
                     "startColumn":9,
                     "startLine":74
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -603,7 +651,8 @@
                     "startColumn":15,
                     "startLine":78
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -611,7 +660,8 @@
                     "startColumn":19,
                     "startLine":78
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -619,7 +669,8 @@
                     "startColumn":14,
                     "startLine":79
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -627,7 +678,8 @@
                     "startColumn":13,
                     "startLine":80
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -635,7 +687,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -643,7 +696,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -651,7 +705,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -659,7 +714,8 @@
                     "startColumn":14,
                     "startLine":79
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -667,7 +723,8 @@
                     "startColumn":13,
                     "startLine":80
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -675,7 +732,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -683,7 +741,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -691,7 +750,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -699,7 +759,8 @@
                     "startColumn":20,
                     "startLine":82
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -707,7 +768,8 @@
                     "startColumn":14,
                     "startLine":79
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -715,7 +777,8 @@
                     "startColumn":13,
                     "startLine":80
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -723,7 +786,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -731,7 +795,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -739,7 +804,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -747,7 +813,8 @@
                     "startColumn":20,
                     "startLine":82
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -781,7 +848,8 @@
                     "startColumn":6,
                     "startLine":88
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -789,7 +857,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -797,7 +866,8 @@
                     "startColumn":15,
                     "startLine":94
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -805,7 +875,8 @@
                     "startColumn":19,
                     "startLine":94
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -813,7 +884,8 @@
                     "startColumn":14,
                     "startLine":95
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -821,7 +893,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -829,7 +902,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -837,7 +911,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -845,7 +920,8 @@
                     "startColumn":15,
                     "startLine":97
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -853,7 +929,8 @@
                     "startColumn":14,
                     "startLine":95
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -861,7 +938,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -869,7 +947,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -877,7 +956,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -885,7 +965,8 @@
                     "startColumn":15,
                     "startLine":97
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -893,7 +974,8 @@
                     "startColumn":20,
                     "startLine":98
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -901,7 +983,8 @@
                     "startColumn":14,
                     "startLine":95
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -909,7 +992,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -917,7 +1001,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -925,7 +1010,8 @@
                     "startColumn":21,
                     "startLine":96
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -933,7 +1019,8 @@
                     "startColumn":15,
                     "startLine":97
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -941,7 +1028,8 @@
                     "startColumn":20,
                     "startLine":98
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -975,7 +1063,8 @@
                     "startColumn":6,
                     "startLine":127
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -983,7 +1072,8 @@
                     "startColumn":10,
                     "startLine":129
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -991,7 +1081,8 @@
                     "startColumn":9,
                     "startLine":130
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -999,7 +1090,8 @@
                     "startColumn":9,
                     "startLine":131
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1007,7 +1099,8 @@
                     "startColumn":10,
                     "startLine":133
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1015,7 +1108,8 @@
                     "startColumn":10,
                     "startLine":134
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1023,7 +1117,8 @@
                     "startColumn":7,
                     "startLine":134
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1031,7 +1126,8 @@
                     "startColumn":9,
                     "startLine":135
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1039,7 +1135,8 @@
                     "startColumn":16,
                     "startLine":136
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1047,7 +1144,8 @@
                     "startColumn":6,
                     "startLine":138
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1055,7 +1153,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1063,7 +1162,8 @@
                     "startColumn":16,
                     "startLine":140
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1071,7 +1171,8 @@
                     "startColumn":9,
                     "startLine":142
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1079,7 +1180,8 @@
                     "startColumn":10,
                     "startLine":143
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1087,7 +1189,8 @@
                     "startColumn":6,
                     "startLine":145
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1095,7 +1198,8 @@
                     "startColumn":17,
                     "startLine":146
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1103,7 +1207,8 @@
                     "startColumn":17,
                     "startLine":148
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1111,7 +1216,8 @@
                     "startColumn":7,
                     "startLine":148
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1119,7 +1225,8 @@
                     "startColumn":9,
                     "startLine":149
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1127,7 +1234,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1135,7 +1243,8 @@
                     "startColumn":11,
                     "startLine":152
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1143,7 +1252,8 @@
                     "startColumn":7,
                     "startLine":152
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1151,7 +1261,8 @@
                     "startColumn":9,
                     "startLine":153
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1159,7 +1270,8 @@
                     "startColumn":14,
                     "startLine":155
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1167,7 +1279,8 @@
                     "startColumn":15,
                     "startLine":156
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1175,7 +1288,8 @@
                     "startColumn":8,
                     "startLine":159
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1183,7 +1297,8 @@
                     "startColumn":12,
                     "startLine":160
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1191,7 +1306,8 @@
                     "startColumn":8,
                     "startLine":162
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test042.cpp",
@@ -1199,7 +1315,8 @@
                     "startColumn":12,
                     "startLine":163
                   }
-                }
+                },
+                "step":29
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-043.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-043.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":19
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":17,
                     "startLine":19
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":13,
                     "startLine":20
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":17,
                     "startLine":19
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":17,
                     "startLine":19
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":13,
                     "startLine":20
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":30,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":14,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":12,
                     "startLine":27
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":9,
                     "startLine":28
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -251,7 +268,8 @@
                     "startColumn":9,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":16,
                     "startLine":42
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -365,7 +393,8 @@
                     "startColumn":9,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":16,
                     "startLine":42
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -389,7 +420,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -397,7 +429,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -405,7 +438,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -421,7 +456,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -429,7 +465,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -437,7 +474,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -445,7 +483,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -453,7 +492,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -461,7 +501,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -469,7 +510,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -477,7 +519,8 @@
                     "startColumn":17,
                     "startLine":47
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -485,7 +528,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -493,7 +537,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -501,7 +546,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -509,7 +555,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -517,7 +564,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -525,7 +573,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -533,7 +582,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -541,7 +591,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -549,7 +600,8 @@
                     "startColumn":14,
                     "startLine":50
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -557,7 +609,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -565,7 +618,8 @@
                     "startColumn":9,
                     "startLine":53
                   }
-                }
+                },
+                "step":26
               }
             ]
           }
@@ -599,7 +653,8 @@
                     "startColumn":9,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -607,7 +662,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -615,7 +671,8 @@
                     "startColumn":16,
                     "startLine":42
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -623,7 +680,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -631,7 +689,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -639,7 +698,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -647,7 +707,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -655,7 +716,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -663,7 +725,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -671,7 +734,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -679,7 +743,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -687,7 +752,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -695,7 +761,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -703,7 +770,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -711,7 +779,8 @@
                     "startColumn":17,
                     "startLine":47
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -719,7 +788,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -727,7 +797,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -735,7 +806,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -743,7 +815,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -751,7 +824,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -759,7 +833,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -767,7 +842,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -775,7 +851,8 @@
                     "startColumn":16,
                     "startLine":44
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -783,7 +860,8 @@
                     "startColumn":14,
                     "startLine":50
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -791,7 +869,8 @@
                     "startColumn":7,
                     "startLine":55
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -799,7 +878,8 @@
                     "startColumn":9,
                     "startLine":56
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -807,7 +887,8 @@
                     "startColumn":13,
                     "startLine":56
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -815,7 +896,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -823,7 +905,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -831,7 +914,8 @@
                     "startColumn":28,
                     "startLine":57
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -839,7 +923,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -847,7 +932,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -855,7 +941,8 @@
                     "startColumn":10,
                     "startLine":61
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -863,7 +950,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -871,7 +959,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -879,7 +968,8 @@
                     "startColumn":28,
                     "startLine":57
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -887,7 +977,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -895,7 +986,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -903,7 +995,8 @@
                     "startColumn":22,
                     "startLine":60
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -911,7 +1004,8 @@
                     "startColumn":10,
                     "startLine":61
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -919,7 +1013,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -927,7 +1022,8 @@
                     "startColumn":16,
                     "startLine":57
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -935,7 +1031,8 @@
                     "startColumn":28,
                     "startLine":57
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -943,7 +1040,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -951,7 +1049,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -959,7 +1058,8 @@
                     "startColumn":22,
                     "startLine":60
                   }
-                }
+                },
+                "step":46
               }
             ]
           }
@@ -993,7 +1093,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1001,7 +1102,8 @@
                     "startColumn":10,
                     "startLine":69
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1009,7 +1111,8 @@
                     "startColumn":15,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1017,7 +1120,8 @@
                     "startColumn":9,
                     "startLine":71
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1025,7 +1129,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1033,7 +1138,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1041,7 +1147,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1075,7 +1182,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1083,7 +1191,8 @@
                     "startColumn":10,
                     "startLine":69
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1091,7 +1200,8 @@
                     "startColumn":15,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1099,7 +1209,8 @@
                     "startColumn":9,
                     "startLine":71
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1107,7 +1218,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1115,7 +1227,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1123,7 +1236,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1131,7 +1245,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1139,7 +1254,8 @@
                     "startColumn":14,
                     "startLine":76
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1147,7 +1263,8 @@
                     "startColumn":24,
                     "startLine":76
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -1181,7 +1298,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1189,7 +1307,8 @@
                     "startColumn":10,
                     "startLine":69
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1197,7 +1316,8 @@
                     "startColumn":15,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1205,7 +1325,8 @@
                     "startColumn":9,
                     "startLine":71
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1213,7 +1334,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1221,7 +1343,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1229,7 +1352,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1237,7 +1361,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1245,7 +1370,8 @@
                     "startColumn":14,
                     "startLine":76
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1253,7 +1379,8 @@
                     "startColumn":24,
                     "startLine":76
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -1287,7 +1414,8 @@
                     "startColumn":25,
                     "startLine":88
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1295,7 +1423,8 @@
                     "startColumn":10,
                     "startLine":90
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1303,7 +1432,8 @@
                     "startColumn":8,
                     "startLine":90
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1311,7 +1441,8 @@
                     "startColumn":5,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -1345,7 +1476,8 @@
                     "startColumn":14,
                     "startLine":94
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1353,7 +1485,8 @@
                     "startColumn":10,
                     "startLine":96
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1361,7 +1494,8 @@
                     "startColumn":8,
                     "startLine":96
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1369,7 +1503,8 @@
                     "startColumn":5,
                     "startLine":97
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -1403,7 +1538,8 @@
                     "startColumn":31,
                     "startLine":105
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1411,7 +1547,8 @@
                     "startColumn":10,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1419,7 +1556,8 @@
                     "startColumn":8,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1427,7 +1565,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1435,7 +1574,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1443,7 +1583,8 @@
                     "startColumn":5,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -1477,7 +1618,8 @@
                     "startColumn":22,
                     "startLine":138
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1485,7 +1627,8 @@
                     "startColumn":10,
                     "startLine":140
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1493,7 +1636,8 @@
                     "startColumn":12,
                     "startLine":141
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1501,7 +1645,8 @@
                     "startColumn":25,
                     "startLine":141
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1509,7 +1654,8 @@
                     "startColumn":13,
                     "startLine":142
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1517,7 +1663,8 @@
                     "startColumn":34,
                     "startLine":142
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1525,7 +1672,8 @@
                     "startColumn":34,
                     "startLine":142
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1533,7 +1681,8 @@
                     "startColumn":12,
                     "startLine":143
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test043.cpp",
@@ -1541,7 +1690,8 @@
                     "startColumn":28,
                     "startLine":145
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-045.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-045.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":72
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":8,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":72
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":16,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test045.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":7,
                     "startLine":74
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-046.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-046.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":13
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":15
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -129,7 +134,8 @@
                     "startColumn":6,
                     "startLine":23
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":12,
                     "startLine":24
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":12,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -179,7 +187,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -187,7 +196,8 @@
                     "startColumn":12,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -195,7 +205,8 @@
                     "startColumn":12,
                     "startLine":29
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -229,7 +240,8 @@
                     "startColumn":6,
                     "startLine":38
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -237,7 +249,8 @@
                     "startColumn":12,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test046.cpp",
@@ -245,7 +258,8 @@
                     "startColumn":12,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-047.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-047.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":174
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":176
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":177
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":18,
                     "startLine":177
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":178
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":20,
                     "startLine":178
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":26,
                     "startLine":178
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":180
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":31,
                     "startLine":178
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":26,
                     "startLine":178
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":14,
                     "startLine":180
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":22,
                     "startLine":181
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":31,
                     "startLine":178
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":26,
                     "startLine":178
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":14,
                     "startLine":180
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":22,
                     "startLine":181
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":31,
                     "startLine":178
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":26,
                     "startLine":178
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":14,
                     "startLine":180
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":22,
                     "startLine":181
                   }
-                }
+                },
+                "step":20
               }
             ]
           }
@@ -223,7 +243,8 @@
                     "startColumn":6,
                     "startLine":186
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":9,
                     "startLine":188
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":9,
                     "startLine":189
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":13,
                     "startLine":189
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":11,
                     "startLine":190
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":15,
                     "startLine":190
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":9,
                     "startLine":191
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":11,
                     "startLine":193
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":9,
                     "startLine":195
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":11,
                     "startLine":197
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":11,
                     "startLine":198
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":10,
                     "startLine":201
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test047.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":14,
                     "startLine":202
                   }
-                }
+                },
+                "step":13
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-048.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-048.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":13,
                     "startLine":13
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":7,
                     "startLine":15
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":13,
                     "startLine":13
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":7,
                     "startLine":15
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":7,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":11,
                     "startLine":16
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":11,
                     "startLine":16
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test048.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":3,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-049.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-049.xml.sarif
@@ -56,7 +56,8 @@
                     "startColumn":14,
                     "startLine":29
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test049.cpp",
@@ -64,7 +65,8 @@
                     "startColumn":13,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -98,7 +100,8 @@
                     "startColumn":14,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test049.cpp",
@@ -106,7 +109,8 @@
                     "startColumn":13,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -140,7 +144,8 @@
                     "startColumn":14,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test049.cpp",
@@ -148,7 +153,8 @@
                     "startColumn":13,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-050.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-050.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":13,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -145,7 +152,8 @@
                     "startColumn":6,
                     "startLine":30
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":15,
                     "startLine":32
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":15,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":15,
                     "startLine":34
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":20,
                     "startLine":36
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":20,
                     "startLine":37
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -219,7 +232,8 @@
                     "startColumn":6,
                     "startLine":30
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":15,
                     "startLine":32
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":15,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":15,
                     "startLine":34
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":20,
                     "startLine":36
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test050.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":20,
                     "startLine":37
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-051.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-051.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test051.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test051.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test051.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":27
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test051.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":28
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-052.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-052.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":33
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":35
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":19,
                     "startLine":35
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":36
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":27,
                     "startLine":36
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":26,
                     "startLine":37
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":12,
                     "startLine":38
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":32,
                     "startLine":38
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":11,
                     "startLine":39
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":31,
                     "startLine":39
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":11,
                     "startLine":40
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":33,
                     "startLine":40
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":11,
                     "startLine":41
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":33,
                     "startLine":41
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":27,
                     "startLine":42
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":17,
                     "startLine":43
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":34,
                     "startLine":43
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":12,
                     "startLine":45
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":32,
                     "startLine":45
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":17,
                     "startLine":51
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":26,
                     "startLine":52
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":28,
                     "startLine":54
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":26,
                     "startLine":55
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":20,
                     "startLine":56
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":13,
                     "startLine":59
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":25,
                     "startLine":71
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":30,
                     "startLine":72
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":40,
                     "startLine":78
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":23,
                     "startLine":78
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":10,
                     "startLine":79
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":17,
                     "startLine":85
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -301,7 +334,8 @@
                     "startColumn":17,
                     "startLine":86
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -309,7 +343,8 @@
                     "startColumn":26,
                     "startLine":87
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -317,7 +352,8 @@
                     "startColumn":24,
                     "startLine":89
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -325,7 +361,8 @@
                     "startColumn":24,
                     "startLine":90
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -333,7 +370,8 @@
                     "startColumn":20,
                     "startLine":91
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -341,7 +379,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -349,7 +388,8 @@
                     "startColumn":29,
                     "startLine":96
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -357,7 +397,8 @@
                     "startColumn":66,
                     "startLine":96
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -365,7 +406,8 @@
                     "startColumn":28,
                     "startLine":98
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -373,7 +415,8 @@
                     "startColumn":28,
                     "startLine":99
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -381,7 +424,8 @@
                     "startColumn":20,
                     "startLine":106
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -389,7 +433,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -397,7 +442,8 @@
                     "startColumn":29,
                     "startLine":96
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -405,7 +451,8 @@
                     "startColumn":66,
                     "startLine":96
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test052.cpp",
@@ -413,7 +460,8 @@
                     "startColumn":28,
                     "startLine":98
                   }
-                }
+                },
+                "step":48
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-054.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-054.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -121,7 +125,8 @@
                     "startColumn":23,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":20,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":5,
                     "startLine":22
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -187,7 +196,8 @@
                     "startColumn":6,
                     "startLine":50
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -195,7 +205,8 @@
                     "startColumn":9,
                     "startLine":52
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -203,7 +214,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -211,7 +223,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -219,7 +232,8 @@
                     "startColumn":10,
                     "startLine":53
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -253,7 +267,8 @@
                     "startColumn":6,
                     "startLine":50
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -261,7 +276,8 @@
                     "startColumn":9,
                     "startLine":52
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -269,7 +285,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -277,7 +294,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -285,7 +303,8 @@
                     "startColumn":10,
                     "startLine":53
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -319,7 +338,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -327,7 +347,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -335,7 +356,8 @@
                     "startColumn":18,
                     "startLine":58
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -343,7 +365,8 @@
                     "startColumn":18,
                     "startLine":58
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -351,7 +374,8 @@
                     "startColumn":11,
                     "startLine":59
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -359,7 +383,8 @@
                     "startColumn":14,
                     "startLine":60
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -393,7 +418,8 @@
                     "startColumn":6,
                     "startLine":63
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -401,7 +427,8 @@
                     "startColumn":12,
                     "startLine":65
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -435,7 +462,8 @@
                     "startColumn":6,
                     "startLine":99
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -443,7 +471,8 @@
                     "startColumn":9,
                     "startLine":101
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -451,7 +480,8 @@
                     "startColumn":9,
                     "startLine":101
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -459,7 +489,8 @@
                     "startColumn":8,
                     "startLine":102
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -493,7 +524,8 @@
                     "startColumn":6,
                     "startLine":204
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -501,7 +533,8 @@
                     "startColumn":14,
                     "startLine":206
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -509,7 +542,8 @@
                     "startColumn":18,
                     "startLine":206
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -517,7 +551,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -525,7 +560,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -533,7 +569,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -541,7 +578,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -549,7 +587,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -557,7 +596,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -565,7 +605,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -573,7 +614,8 @@
                     "startColumn":6,
                     "startLine":209
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -581,7 +623,8 @@
                     "startColumn":6,
                     "startLine":210
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -589,7 +632,8 @@
                     "startColumn":6,
                     "startLine":211
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -597,7 +641,8 @@
                     "startColumn":9,
                     "startLine":213
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -605,7 +650,8 @@
                     "startColumn":9,
                     "startLine":214
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -613,7 +659,8 @@
                     "startColumn":15,
                     "startLine":216
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -621,7 +668,8 @@
                     "startColumn":9,
                     "startLine":216
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -629,7 +677,8 @@
                     "startColumn":9,
                     "startLine":217
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -663,7 +712,8 @@
                     "startColumn":6,
                     "startLine":204
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -671,7 +721,8 @@
                     "startColumn":14,
                     "startLine":206
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -679,7 +730,8 @@
                     "startColumn":18,
                     "startLine":206
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -687,7 +739,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -695,7 +748,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -703,7 +757,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -711,7 +766,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -719,7 +775,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -727,7 +784,8 @@
                     "startColumn":14,
                     "startLine":207
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -735,7 +793,8 @@
                     "startColumn":23,
                     "startLine":206
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -743,7 +802,8 @@
                     "startColumn":6,
                     "startLine":209
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -751,7 +811,8 @@
                     "startColumn":6,
                     "startLine":210
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -759,7 +820,8 @@
                     "startColumn":6,
                     "startLine":211
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -767,7 +829,8 @@
                     "startColumn":9,
                     "startLine":213
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -775,7 +838,8 @@
                     "startColumn":9,
                     "startLine":214
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -783,7 +847,8 @@
                     "startColumn":15,
                     "startLine":216
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -791,7 +856,8 @@
                     "startColumn":9,
                     "startLine":216
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -799,7 +865,8 @@
                     "startColumn":9,
                     "startLine":217
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -807,7 +874,8 @@
                     "startColumn":16,
                     "startLine":219
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -815,7 +883,8 @@
                     "startColumn":9,
                     "startLine":219
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test054.cpp",
@@ -823,7 +892,8 @@
                     "startColumn":9,
                     "startLine":220
                   }
-                }
+                },
+                "step":21
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-055.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-055.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":7,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":7,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":7,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":7,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":7,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":7,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":7,
                     "startLine":13
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":10,
                     "startLine":14
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -291,7 +313,8 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":7,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":14,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":9,
                     "startLine":26
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":13,
                     "startLine":34
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":11,
                     "startLine":34
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":9,
                     "startLine":37
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":5,
                     "startLine":40
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":19,
                     "startLine":46
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -405,7 +438,8 @@
                     "startColumn":9,
                     "startLine":62
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":19,
                     "startLine":64
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -447,7 +482,8 @@
                     "startColumn":16,
                     "startLine":71
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -455,7 +491,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -463,7 +500,8 @@
                     "startColumn":34,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -471,7 +509,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -479,7 +518,8 @@
                     "startColumn":16,
                     "startLine":74
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -513,7 +553,8 @@
                     "startColumn":16,
                     "startLine":71
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -529,7 +571,8 @@
                     "startColumn":34,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -537,7 +580,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -545,7 +589,8 @@
                     "startColumn":16,
                     "startLine":74
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -553,7 +598,8 @@
                     "startColumn":14,
                     "startLine":75
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -561,7 +607,8 @@
                     "startColumn":27,
                     "startLine":75
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -569,7 +616,8 @@
                     "startColumn":19,
                     "startLine":75
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -577,7 +625,8 @@
                     "startColumn":16,
                     "startLine":76
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -611,7 +660,8 @@
                     "startColumn":14,
                     "startLine":83
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -619,7 +669,8 @@
                     "startColumn":10,
                     "startLine":85
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -627,7 +678,8 @@
                     "startColumn":13,
                     "startLine":86
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -661,7 +713,8 @@
                     "startColumn":14,
                     "startLine":106
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -669,7 +722,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -677,7 +731,8 @@
                     "startColumn":19,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -685,7 +740,8 @@
                     "startColumn":20,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -693,7 +749,8 @@
                     "startColumn":20,
                     "startLine":109
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -701,7 +758,8 @@
                     "startColumn":18,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -709,7 +767,8 @@
                     "startColumn":18,
                     "startLine":113
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -717,7 +776,8 @@
                     "startColumn":25,
                     "startLine":113
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -725,7 +785,8 @@
                     "startColumn":25,
                     "startLine":113
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -733,7 +794,8 @@
                     "startColumn":17,
                     "startLine":114
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -741,7 +803,8 @@
                     "startColumn":27,
                     "startLine":116
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -775,7 +838,8 @@
                     "startColumn":20,
                     "startLine":125
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -783,7 +847,8 @@
                     "startColumn":19,
                     "startLine":125
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -817,7 +882,8 @@
                     "startColumn":10,
                     "startLine":127
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -825,7 +891,8 @@
                     "startColumn":6,
                     "startLine":129
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -833,7 +900,8 @@
                     "startColumn":6,
                     "startLine":130
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -841,7 +909,8 @@
                     "startColumn":8,
                     "startLine":132
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -849,7 +918,8 @@
                     "startColumn":8,
                     "startLine":133
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -857,7 +927,8 @@
                     "startColumn":10,
                     "startLine":135
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -865,7 +936,8 @@
                     "startColumn":13,
                     "startLine":136
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -873,7 +945,8 @@
                     "startColumn":15,
                     "startLine":138
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -881,7 +954,8 @@
                     "startColumn":24,
                     "startLine":138
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -889,7 +963,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test055.cpp",
@@ -897,7 +972,8 @@
                     "startColumn":21,
                     "startLine":139
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-057.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-057.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":24,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":15
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":9,
                     "startLine":17
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":17,
                     "startLine":18
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -129,7 +134,8 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":14,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":14,
                     "startLine":34
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -179,7 +187,8 @@
                     "startColumn":6,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -187,7 +196,8 @@
                     "startColumn":11,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -195,7 +205,8 @@
                     "startColumn":17,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -203,7 +214,8 @@
                     "startColumn":16,
                     "startLine":67
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -211,7 +223,8 @@
                     "startColumn":14,
                     "startLine":69
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -219,7 +232,8 @@
                     "startColumn":26,
                     "startLine":69
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":26,
                     "startLine":69
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":13,
                     "startLine":70
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":16,
                     "startLine":72
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":16,
                     "startLine":67
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":14,
                     "startLine":69
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":26,
                     "startLine":69
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":26,
                     "startLine":69
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":13,
                     "startLine":70
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":16,
                     "startLine":72
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -325,7 +348,8 @@
                     "startColumn":6,
                     "startLine":92
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":15,
                     "startLine":94
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":19,
                     "startLine":94
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":28,
                     "startLine":94
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":12,
                     "startLine":95
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":37,
                     "startLine":94
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":28,
                     "startLine":94
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test057.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":12,
                     "startLine":95
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-058.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-058.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":2
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test058.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":4
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test058.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test058.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test058.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test058.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":13,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-059.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-059.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":44
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":16,
                     "startLine":46
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":18,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":23,
                     "startLine":47
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":15,
                     "startLine":78
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":14,
                     "startLine":79
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":13,
                     "startLine":81
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":30,
                     "startLine":47
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":23,
                     "startLine":47
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":15,
                     "startLine":78
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":14,
                     "startLine":79
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -301,7 +334,8 @@
                     "startColumn":13,
                     "startLine":81
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -309,7 +343,8 @@
                     "startColumn":30,
                     "startLine":47
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -317,7 +352,8 @@
                     "startColumn":23,
                     "startLine":47
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -325,7 +361,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -333,7 +370,8 @@
                     "startColumn":9,
                     "startLine":49
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -341,7 +379,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -349,7 +388,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -357,7 +397,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -365,7 +406,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -373,7 +415,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -381,7 +424,8 @@
                     "startColumn":17,
                     "startLine":54
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -389,7 +433,8 @@
                     "startColumn":21,
                     "startLine":54
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -397,7 +442,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -405,7 +451,8 @@
                     "startColumn":26,
                     "startLine":57
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -413,7 +460,8 @@
                     "startColumn":35,
                     "startLine":59
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -421,7 +469,8 @@
                     "startColumn":21,
                     "startLine":62
                   }
-                }
+                },
+                "step":49
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -429,7 +478,8 @@
                     "startColumn":26,
                     "startLine":62
                   }
-                }
+                },
+                "step":50
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -437,7 +487,8 @@
                     "startColumn":21,
                     "startLine":63
                   }
-                }
+                },
+                "step":51
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -445,7 +496,8 @@
                     "startColumn":26,
                     "startLine":63
                   }
-                }
+                },
+                "step":52
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -453,7 +505,8 @@
                     "startColumn":31,
                     "startLine":64
                   }
-                }
+                },
+                "step":53
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -461,7 +514,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":54
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -469,7 +523,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":55
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -477,7 +532,8 @@
                     "startColumn":26,
                     "startLine":57
                   }
-                }
+                },
+                "step":56
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -485,7 +541,8 @@
                     "startColumn":35,
                     "startLine":59
                   }
-                }
+                },
+                "step":57
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -493,7 +550,8 @@
                     "startColumn":21,
                     "startLine":62
                   }
-                }
+                },
+                "step":58
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -501,7 +559,8 @@
                     "startColumn":26,
                     "startLine":62
                   }
-                }
+                },
+                "step":59
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -509,7 +568,8 @@
                     "startColumn":21,
                     "startLine":63
                   }
-                }
+                },
+                "step":60
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -517,7 +577,8 @@
                     "startColumn":26,
                     "startLine":63
                   }
-                }
+                },
+                "step":61
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -525,7 +586,8 @@
                     "startColumn":31,
                     "startLine":64
                   }
-                }
+                },
+                "step":62
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -533,7 +595,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":63
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -541,7 +604,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":64
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test059.cpp",
@@ -549,7 +613,8 @@
                     "startColumn":26,
                     "startLine":57
                   }
-                }
+                },
+                "step":65
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-060.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-060.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":23,
                     "startLine":5
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":7
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":29,
                     "startLine":5
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":23,
                     "startLine":5
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":7
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -127,7 +135,8 @@
                     "startColumn":5,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":5,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -177,7 +188,8 @@
                     "startColumn":5,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":5,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -227,7 +241,8 @@
                     "startColumn":6,
                     "startLine":33
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":10,
                     "startLine":35
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":9,
                     "startLine":36
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":18,
                     "startLine":36
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":9,
                     "startLine":37
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":15,
                     "startLine":38
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -301,7 +321,8 @@
                     "startColumn":5,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -309,7 +330,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -317,7 +339,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -325,7 +348,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":18,
                     "startLine":45
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":15,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":18,
                     "startLine":49
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":30,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":15,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -389,7 +420,8 @@
                     "startColumn":18,
                     "startLine":49
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -397,7 +429,8 @@
                     "startColumn":30,
                     "startLine":45
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -405,7 +438,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":15,
                     "startLine":47
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -421,7 +456,8 @@
                     "startColumn":18,
                     "startLine":49
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -429,7 +465,8 @@
                     "startColumn":30,
                     "startLine":45
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -437,7 +474,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -445,7 +483,8 @@
                     "startColumn":5,
                     "startLine":54
                   }
-                }
+                },
+                "step":19
               }
             ]
           }
@@ -479,7 +518,8 @@
                     "startColumn":5,
                     "startLine":76
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -487,7 +527,8 @@
                     "startColumn":11,
                     "startLine":78
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -495,7 +536,8 @@
                     "startColumn":16,
                     "startLine":80
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test060.cpp",
@@ -503,7 +545,8 @@
                     "startColumn":9,
                     "startLine":83
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-061.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-061.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":17,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":27,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":22,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":38,
                     "startLine":34
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":30,
                     "startLine":39
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":19,
                     "startLine":41
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":34,
                     "startLine":43
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":21,
                     "startLine":44
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":22,
                     "startLine":48
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":19,
                     "startLine":49
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":23,
                     "startLine":50
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":26,
                     "startLine":53
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":25,
                     "startLine":54
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":31,
                     "startLine":62
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":29,
                     "startLine":65
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":38,
                     "startLine":34
                   }
-                }
+                },
+                "step":25
               }
             ]
           }
@@ -329,7 +359,8 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -337,7 +368,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -345,7 +377,8 @@
                     "startColumn":22,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -353,7 +386,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -361,7 +395,8 @@
                     "startColumn":38,
                     "startLine":34
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":30,
                     "startLine":39
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":19,
                     "startLine":41
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":34,
                     "startLine":43
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":21,
                     "startLine":44
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":22,
                     "startLine":48
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":19,
                     "startLine":49
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":23,
                     "startLine":50
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":26,
                     "startLine":53
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":25,
                     "startLine":54
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":31,
                     "startLine":62
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":29,
                     "startLine":65
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -521,7 +575,8 @@
                     "startColumn":38,
                     "startLine":34
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -529,7 +584,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -537,7 +593,8 @@
                     "startColumn":30,
                     "startLine":39
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -545,7 +602,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -553,7 +611,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -561,7 +620,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -569,7 +629,8 @@
                     "startColumn":19,
                     "startLine":41
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -577,7 +638,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -585,7 +647,8 @@
                     "startColumn":34,
                     "startLine":43
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":21,
                     "startLine":44
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":22,
                     "startLine":48
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":19,
                     "startLine":49
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":23,
                     "startLine":50
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":26,
                     "startLine":58
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":31,
                     "startLine":62
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":29,
                     "startLine":65
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -665,7 +737,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -673,7 +746,8 @@
                     "startColumn":38,
                     "startLine":34
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -681,7 +755,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":30,
                     "startLine":39
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":36,
                     "startLine":40
                   }
-                }
+                },
+                "step":49
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -721,7 +800,8 @@
                     "startColumn":19,
                     "startLine":41
                   }
-                }
+                },
+                "step":50
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -729,7 +809,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":51
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -737,7 +818,8 @@
                     "startColumn":34,
                     "startLine":43
                   }
-                }
+                },
+                "step":52
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -745,7 +827,8 @@
                     "startColumn":21,
                     "startLine":44
                   }
-                }
+                },
+                "step":53
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -753,7 +836,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":54
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -761,7 +845,8 @@
                     "startColumn":22,
                     "startLine":48
                   }
-                }
+                },
+                "step":55
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -769,7 +854,8 @@
                     "startColumn":19,
                     "startLine":49
                   }
-                }
+                },
+                "step":56
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -777,7 +863,8 @@
                     "startColumn":23,
                     "startLine":50
                   }
-                }
+                },
+                "step":57
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -785,7 +872,8 @@
                     "startColumn":26,
                     "startLine":53
                   }
-                }
+                },
+                "step":58
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -793,7 +881,8 @@
                     "startColumn":25,
                     "startLine":54
                   }
-                }
+                },
+                "step":59
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -801,7 +890,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":60
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -809,7 +899,8 @@
                     "startColumn":31,
                     "startLine":62
                   }
-                }
+                },
+                "step":61
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test061.cpp",
@@ -817,7 +908,8 @@
                     "startColumn":29,
                     "startLine":65
                   }
-                }
+                },
+                "step":62
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-062.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-062.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":14
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":16,
                     "startLine":17
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":17
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":47,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":33,
                     "startLine":20
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":60,
                     "startLine":17
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":62,
                     "startLine":17
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":47,
                     "startLine":17
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":33,
                     "startLine":20
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -167,7 +180,8 @@
                     "startColumn":6,
                     "startLine":29
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":11,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":17,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":11,
                     "startLine":32
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":23,
                     "startLine":32
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":23,
                     "startLine":32
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":5,
                     "startLine":33
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":12,
                     "startLine":34
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":33,
                     "startLine":34
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":9,
                     "startLine":35
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":14,
                     "startLine":37
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":37,
                     "startLine":37
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":37,
                     "startLine":37
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":13,
                     "startLine":38
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":19,
                     "startLine":39
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test062.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":32,
                     "startLine":39
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-063.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-063.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":28,
                     "startLine":18
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":10,
                     "startLine":19
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":15,
                     "startLine":20
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":15
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test063.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":28,
                     "startLine":18
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-065.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-065.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":32,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":20,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":13,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":12,
                     "startLine":13
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":32,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":20,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":35,
                     "startLine":17
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":29,
                     "startLine":19
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":35,
                     "startLine":17
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":29,
                     "startLine":19
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":35,
                     "startLine":17
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":29,
                     "startLine":19
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":35,
                     "startLine":17
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":29,
                     "startLine":19
                   }
-                }
+                },
+                "step":17
               }
             ]
           }
@@ -273,7 +296,8 @@
                     "startColumn":6,
                     "startLine":26
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":11,
                     "startLine":28
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":12,
                     "startLine":30
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":19,
                     "startLine":30
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":19,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test065.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":19,
                     "startLine":34
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-066.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-066.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":32,
                     "startLine":60
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":38,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":13,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":50,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":15,
                     "startLine":63
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":13,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":46,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":18,
                     "startLine":66
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":17,
                     "startLine":69
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":74,
                     "startLine":71
                   }
-                }
+                },
+                "step":23
               }
             ]
           }
@@ -247,7 +270,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":15,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":32,
                     "startLine":60
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":38,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":13,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":50,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":15,
                     "startLine":63
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":13,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":46,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":18,
                     "startLine":66
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":17,
                     "startLine":69
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":74,
                     "startLine":71
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":74,
                     "startLine":72
                   }
-                }
+                },
+                "step":24
               }
             ]
           }
@@ -465,7 +512,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":15,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":32,
                     "startLine":60
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":38,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -521,7 +575,8 @@
                     "startColumn":13,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -529,7 +584,8 @@
                     "startColumn":50,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -537,7 +593,8 @@
                     "startColumn":15,
                     "startLine":63
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -545,7 +602,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -553,7 +611,8 @@
                     "startColumn":36,
                     "startLine":63
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -561,7 +620,8 @@
                     "startColumn":13,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -569,7 +629,8 @@
                     "startColumn":46,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -577,7 +638,8 @@
                     "startColumn":18,
                     "startLine":66
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -585,7 +647,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":31,
                     "startLine":67
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":17,
                     "startLine":69
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":74,
                     "startLine":71
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":74,
                     "startLine":72
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":74,
                     "startLine":73
                   }
-                }
+                },
+                "step":25
               }
             ]
           }
@@ -691,7 +763,8 @@
                     "startColumn":18,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -699,7 +772,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -707,7 +781,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -715,7 +790,8 @@
                     "startColumn":27,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":38,
                     "startLine":83
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -739,7 +817,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -747,7 +826,8 @@
                     "startColumn":13,
                     "startLine":83
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -755,7 +835,8 @@
                     "startColumn":50,
                     "startLine":83
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":27,
                     "startLine":86
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":30,
                     "startLine":86
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":26,
                     "startLine":88
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":66,
                     "startLine":90
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -845,7 +933,8 @@
                     "startColumn":18,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -853,7 +942,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -861,7 +951,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -869,7 +960,8 @@
                     "startColumn":27,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -877,7 +969,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -885,7 +978,8 @@
                     "startColumn":38,
                     "startLine":83
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -893,7 +987,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -901,7 +996,8 @@
                     "startColumn":13,
                     "startLine":83
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -909,7 +1005,8 @@
                     "startColumn":50,
                     "startLine":83
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -917,7 +1014,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -925,7 +1023,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -933,7 +1032,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -941,7 +1041,8 @@
                     "startColumn":27,
                     "startLine":86
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -949,7 +1050,8 @@
                     "startColumn":30,
                     "startLine":86
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -957,7 +1059,8 @@
                     "startColumn":26,
                     "startLine":88
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -965,7 +1068,8 @@
                     "startColumn":66,
                     "startLine":90
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -973,7 +1077,8 @@
                     "startColumn":66,
                     "startLine":91
                   }
-                }
+                },
+                "step":17
               }
             ]
           }
@@ -1007,7 +1112,8 @@
                     "startColumn":18,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1015,7 +1121,8 @@
                     "startColumn":15,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1023,7 +1130,8 @@
                     "startColumn":17,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1031,7 +1139,8 @@
                     "startColumn":27,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1039,7 +1148,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1047,7 +1157,8 @@
                     "startColumn":38,
                     "startLine":83
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1055,7 +1166,8 @@
                     "startColumn":15,
                     "startLine":83
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1063,7 +1175,8 @@
                     "startColumn":13,
                     "startLine":83
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1071,7 +1184,8 @@
                     "startColumn":50,
                     "startLine":83
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1079,7 +1193,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1087,7 +1202,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1095,7 +1211,8 @@
                     "startColumn":36,
                     "startLine":85
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1103,7 +1220,8 @@
                     "startColumn":27,
                     "startLine":86
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1111,7 +1229,8 @@
                     "startColumn":30,
                     "startLine":86
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1119,7 +1238,8 @@
                     "startColumn":26,
                     "startLine":88
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1127,7 +1247,8 @@
                     "startColumn":66,
                     "startLine":90
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1135,7 +1256,8 @@
                     "startColumn":66,
                     "startLine":91
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test066.cpp",
@@ -1143,7 +1265,8 @@
                     "startColumn":66,
                     "startLine":92
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-067.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-067.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":28,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":9
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":26,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":40,
                     "startLine":9
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":46,
                     "startLine":9
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":26,
                     "startLine":9
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test067.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":40,
                     "startLine":9
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-070.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-070.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":10,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":13
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":14
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":15,
                     "startLine":14
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":15
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":24,
                     "startLine":18
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":24,
                     "startLine":18
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":21,
                     "startLine":21
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":22,
                     "startLine":30
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":23,
                     "startLine":31
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":14,
                     "startLine":31
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":21,
                     "startLine":21
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":17,
                     "startLine":23
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":18,
                     "startLine":24
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":23,
                     "startLine":24
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":23,
                     "startLine":24
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":17,
                     "startLine":25
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":19,
                     "startLine":27
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":15,
                     "startLine":28
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":22,
                     "startLine":30
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":23,
                     "startLine":31
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":14,
                     "startLine":31
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":21,
                     "startLine":21
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":22,
                     "startLine":30
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":23,
                     "startLine":31
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -301,7 +334,8 @@
                     "startColumn":14,
                     "startLine":31
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -309,7 +343,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -317,7 +352,8 @@
                     "startColumn":21,
                     "startLine":21
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test070.cpp",
@@ -325,7 +361,8 @@
                     "startColumn":22,
                     "startLine":30
                   }
-                }
+                },
+                "step":37
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-071.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-071.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":16,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":16
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":22,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":16,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":30
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":22,
                     "startLine":23
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":22,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":16,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":18,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":14,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":10,
                     "startLine":30
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":22,
                     "startLine":23
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":16,
                     "startLine":25
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":18,
                     "startLine":27
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -315,7 +340,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":11,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":12,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":16,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":10,
                     "startLine":44
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":12,
                     "startLine":38
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -389,7 +420,8 @@
                     "startColumn":6,
                     "startLine":48
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -397,7 +429,8 @@
                     "startColumn":9,
                     "startLine":50
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -405,7 +438,8 @@
                     "startColumn":27,
                     "startLine":50
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":24,
                     "startLine":51
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -447,7 +482,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               }
             ]
           }
@@ -481,7 +517,8 @@
                     "startColumn":6,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -489,7 +526,8 @@
                     "startColumn":15,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -497,7 +535,8 @@
                     "startColumn":16,
                     "startLine":106
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -505,7 +544,8 @@
                     "startColumn":20,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":23,
                     "startLine":110
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -555,7 +597,8 @@
                     "startColumn":6,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -563,7 +606,8 @@
                     "startColumn":15,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -571,7 +615,8 @@
                     "startColumn":16,
                     "startLine":106
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -579,7 +624,8 @@
                     "startColumn":20,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -587,7 +633,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -595,7 +642,8 @@
                     "startColumn":23,
                     "startLine":110
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -629,7 +677,8 @@
                     "startColumn":6,
                     "startLine":116
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -637,7 +686,8 @@
                     "startColumn":11,
                     "startLine":119
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -671,7 +721,8 @@
                     "startColumn":6,
                     "startLine":128
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -679,7 +730,8 @@
                     "startColumn":11,
                     "startLine":130
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -687,7 +739,8 @@
                     "startColumn":12,
                     "startLine":132
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -695,7 +748,8 @@
                     "startColumn":17,
                     "startLine":132
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -703,7 +757,8 @@
                     "startColumn":13,
                     "startLine":134
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test071.cpp",
@@ -711,7 +766,8 @@
                     "startColumn":15,
                     "startLine":136
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-072.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-072.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":36
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":38
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":24,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":24,
                     "startLine":39
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":17,
                     "startLine":40
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":17,
                     "startLine":41
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":5,
                     "startLine":44
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":20,
                     "startLine":46
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":5,
                     "startLine":46
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -169,7 +179,8 @@
                     "startColumn":5,
                     "startLine":49
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":22,
                     "startLine":51
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test072.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":5,
                     "startLine":51
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-073.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-073.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":14
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":20
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":12,
                     "startLine":21
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -169,7 +179,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":9,
                     "startLine":20
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":12,
                     "startLine":21
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -235,7 +250,8 @@
                     "startColumn":6,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":11,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":19,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":16,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":16,
                     "startLine":40
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":13,
                     "startLine":41
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -309,7 +330,8 @@
                     "startColumn":6,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -317,7 +339,8 @@
                     "startColumn":11,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -325,7 +348,8 @@
                     "startColumn":19,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":16,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":16,
                     "startLine":40
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test073.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":13,
                     "startLine":41
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-074.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-074.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":40,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":17,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":46,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":40,
                     "startLine":10
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -143,7 +153,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":20
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":15,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":16,
                     "startLine":24
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":20,
                     "startLine":24
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":25,
                     "startLine":24
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":7,
                     "startLine":25
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":30,
                     "startLine":24
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":25,
                     "startLine":24
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":7,
                     "startLine":25
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":30,
                     "startLine":24
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":25,
                     "startLine":24
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":7,
                     "startLine":25
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":30,
                     "startLine":24
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":25,
                     "startLine":24
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test074.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":7,
                     "startLine":25
                   }
-                }
+                },
+                "step":16
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-075.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-075.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":10
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":13
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":17,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":21,
                     "startLine":16
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":10,
                     "startLine":17
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -153,7 +161,8 @@
                     "startColumn":6,
                     "startLine":20
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":11,
                     "startLine":22
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":17,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":21,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":10,
                     "startLine":24
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -219,7 +232,8 @@
                     "startColumn":6,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":11,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":15,
                     "startLine":30
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":19,
                     "startLine":30
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":11,
                     "startLine":32
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -293,7 +312,8 @@
                     "startColumn":6,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -301,7 +321,8 @@
                     "startColumn":11,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -309,7 +330,8 @@
                     "startColumn":17,
                     "startLine":40
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -317,7 +339,8 @@
                     "startColumn":21,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -325,7 +348,8 @@
                     "startColumn":18,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -367,7 +392,8 @@
                     "startColumn":6,
                     "startLine":47
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test075.cpp",
@@ -375,7 +401,8 @@
                     "startColumn":13,
                     "startLine":49
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-076.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-076.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":23,
                     "startLine":6
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":32,
                     "startLine":6
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":23,
                     "startLine":6
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test076.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-077.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-077.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":1,
                     "startLine":6
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":28,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":14
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":18
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":23,
                     "startLine":20
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":11,
                     "startLine":20
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":18,
                     "startLine":22
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":13,
                     "startLine":24
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":20,
                     "startLine":26
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":20,
                     "startLine":34
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":19,
                     "startLine":40
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":18,
                     "startLine":22
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":13,
                     "startLine":24
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -301,7 +334,8 @@
                     "startColumn":20,
                     "startLine":31
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -309,7 +343,8 @@
                     "startColumn":20,
                     "startLine":34
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -317,7 +352,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -325,7 +361,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -333,7 +370,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -341,7 +379,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -349,7 +388,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -357,7 +397,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -365,7 +406,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -373,7 +415,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -381,7 +424,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -389,7 +433,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -397,7 +442,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -405,7 +451,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -413,7 +460,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -421,7 +469,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":49
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -429,7 +478,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":50
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -437,7 +487,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":51
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -445,7 +496,8 @@
                     "startColumn":19,
                     "startLine":40
                   }
-                }
+                },
+                "step":52
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -453,7 +505,8 @@
                     "startColumn":18,
                     "startLine":22
                   }
-                }
+                },
+                "step":53
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -461,7 +514,8 @@
                     "startColumn":13,
                     "startLine":24
                   }
-                }
+                },
+                "step":54
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -469,7 +523,8 @@
                     "startColumn":20,
                     "startLine":26
                   }
-                }
+                },
+                "step":55
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -477,7 +532,8 @@
                     "startColumn":20,
                     "startLine":34
                   }
-                }
+                },
+                "step":56
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -485,7 +541,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":57
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -493,7 +550,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":58
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -501,7 +559,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":59
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -509,7 +568,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":60
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -517,7 +577,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":61
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -525,7 +586,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":62
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -533,7 +595,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":63
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -541,7 +604,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":64
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -549,7 +613,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":65
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -557,7 +622,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":66
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -565,7 +631,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":67
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -573,7 +640,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":68
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -581,7 +649,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":69
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -589,7 +658,8 @@
                     "startColumn":20,
                     "startLine":38
                   }
-                }
+                },
+                "step":70
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -597,7 +667,8 @@
                     "startColumn":62,
                     "startLine":34
                   }
-                }
+                },
+                "step":71
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -605,7 +676,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":72
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -613,7 +685,8 @@
                     "startColumn":19,
                     "startLine":40
                   }
-                }
+                },
+                "step":73
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -621,7 +694,8 @@
                     "startColumn":18,
                     "startLine":22
                   }
-                }
+                },
+                "step":74
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -629,7 +703,8 @@
                     "startColumn":13,
                     "startLine":24
                   }
-                }
+                },
+                "step":75
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -637,7 +712,8 @@
                     "startColumn":20,
                     "startLine":31
                   }
-                }
+                },
+                "step":76
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -645,7 +721,8 @@
                     "startColumn":20,
                     "startLine":34
                   }
-                }
+                },
+                "step":77
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -653,7 +730,8 @@
                     "startColumn":39,
                     "startLine":34
                   }
-                }
+                },
+                "step":78
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -661,7 +739,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":79
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -669,7 +748,8 @@
                     "startColumn":23,
                     "startLine":37
                   }
-                }
+                },
+                "step":80
               }
             ]
           }
@@ -703,7 +783,8 @@
                     "startColumn":6,
                     "startLine":46
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -711,7 +792,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -719,7 +801,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -727,7 +810,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -735,7 +819,8 @@
                     "startColumn":14,
                     "startLine":51
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -743,7 +828,8 @@
                     "startColumn":20,
                     "startLine":51
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -751,7 +837,8 @@
                     "startColumn":27,
                     "startLine":51
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -759,7 +846,8 @@
                     "startColumn":18,
                     "startLine":53
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -767,7 +855,8 @@
                     "startColumn":25,
                     "startLine":53
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -775,7 +864,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -783,7 +873,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -791,7 +882,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -799,7 +891,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -807,7 +900,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -815,7 +909,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -823,7 +918,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -831,7 +927,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -839,7 +936,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -847,7 +945,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -855,7 +954,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -863,7 +963,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -871,7 +972,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -879,7 +981,8 @@
                     "startColumn":35,
                     "startLine":51
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -887,7 +990,8 @@
                     "startColumn":27,
                     "startLine":51
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -895,7 +999,8 @@
                     "startColumn":18,
                     "startLine":53
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -903,7 +1008,8 @@
                     "startColumn":25,
                     "startLine":53
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -911,7 +1017,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -919,7 +1026,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -927,7 +1035,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -935,7 +1044,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -943,7 +1053,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -951,7 +1062,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -959,7 +1071,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -967,7 +1080,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -975,7 +1089,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -983,7 +1098,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -991,7 +1107,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -999,7 +1116,8 @@
                     "startColumn":43,
                     "startLine":53
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1007,7 +1125,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1015,7 +1134,8 @@
                     "startColumn":35,
                     "startLine":51
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1023,7 +1143,8 @@
                     "startColumn":27,
                     "startLine":51
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1031,7 +1152,8 @@
                     "startColumn":18,
                     "startLine":53
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1039,7 +1161,8 @@
                     "startColumn":25,
                     "startLine":53
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1047,7 +1170,8 @@
                     "startColumn":33,
                     "startLine":53
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1055,7 +1179,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":45
               }
             ]
           }
@@ -1089,7 +1214,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1097,7 +1223,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1105,7 +1232,8 @@
                     "startColumn":13,
                     "startLine":88
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1113,7 +1241,8 @@
                     "startColumn":10,
                     "startLine":90
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1121,7 +1250,8 @@
                     "startColumn":14,
                     "startLine":90
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1129,7 +1259,8 @@
                     "startColumn":16,
                     "startLine":91
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1137,7 +1268,8 @@
                     "startColumn":14,
                     "startLine":92
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1145,7 +1277,8 @@
                     "startColumn":16,
                     "startLine":93
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1153,7 +1286,8 @@
                     "startColumn":30,
                     "startLine":93
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1161,7 +1295,8 @@
                     "startColumn":30,
                     "startLine":93
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1169,7 +1304,8 @@
                     "startColumn":17,
                     "startLine":94
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1177,7 +1313,8 @@
                     "startColumn":16,
                     "startLine":95
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test077.cpp",
@@ -1185,7 +1322,8 @@
                     "startColumn":17,
                     "startLine":94
                   }
-                }
+                },
+                "step":13
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-078.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-078.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":7,
                     "startLine":9
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":13,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":6,
                     "startLine":16
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":10,
                     "startLine":17
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -177,7 +188,8 @@
                     "startColumn":15,
                     "startLine":119
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":22,
                     "startLine":124
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":34,
                     "startLine":126
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -227,7 +241,8 @@
                     "startColumn":33,
                     "startLine":129
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":9,
                     "startLine":131
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":9,
                     "startLine":132
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":17,
                     "startLine":132
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":17,
                     "startLine":132
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":5,
                     "startLine":135
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":5,
                     "startLine":145
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -309,7 +330,8 @@
                     "startColumn":9,
                     "startLine":148
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -317,7 +339,8 @@
                     "startColumn":9,
                     "startLine":150
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -325,7 +348,8 @@
                     "startColumn":13,
                     "startLine":150
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":10,
                     "startLine":151
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":26,
                     "startLine":151
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":15,
                     "startLine":151
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":9,
                     "startLine":152
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":10,
                     "startLine":154
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":12,
                     "startLine":155
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -407,7 +437,8 @@
                     "startColumn":9,
                     "startLine":148
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":9,
                     "startLine":150
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":13,
                     "startLine":150
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":10,
                     "startLine":151
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -439,7 +473,8 @@
                     "startColumn":26,
                     "startLine":151
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -447,7 +482,8 @@
                     "startColumn":15,
                     "startLine":151
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -455,7 +491,8 @@
                     "startColumn":9,
                     "startLine":152
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -463,7 +500,8 @@
                     "startColumn":10,
                     "startLine":154
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -471,7 +509,8 @@
                     "startColumn":12,
                     "startLine":155
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -505,7 +544,8 @@
                     "startColumn":9,
                     "startLine":177
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":9,
                     "startLine":179
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":17,
                     "startLine":180
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -555,7 +597,8 @@
                     "startColumn":9,
                     "startLine":177
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -563,7 +606,8 @@
                     "startColumn":9,
                     "startLine":179
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -571,7 +615,8 @@
                     "startColumn":17,
                     "startLine":180
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -605,7 +650,8 @@
                     "startColumn":10,
                     "startLine":183
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -613,7 +659,8 @@
                     "startColumn":9,
                     "startLine":185
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -621,7 +668,8 @@
                     "startColumn":17,
                     "startLine":185
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -629,7 +677,8 @@
                     "startColumn":9,
                     "startLine":186
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -637,7 +686,8 @@
                     "startColumn":6,
                     "startLine":187
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test078.cpp",
@@ -645,7 +695,8 @@
                     "startColumn":15,
                     "startLine":188
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-079.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-079.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":21,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":11,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -121,7 +125,8 @@
                     "startColumn":6,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -163,7 +169,8 @@
                     "startColumn":20,
                     "startLine":65
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -171,7 +178,8 @@
                     "startColumn":11,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -205,7 +213,8 @@
                     "startColumn":20,
                     "startLine":65
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -213,7 +222,8 @@
                     "startColumn":11,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -247,7 +257,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -255,7 +266,8 @@
                     "startColumn":17,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -289,7 +301,8 @@
                     "startColumn":6,
                     "startLine":84
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -297,7 +310,8 @@
                     "startColumn":7,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -305,7 +319,8 @@
                     "startColumn":12,
                     "startLine":89
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -313,7 +328,8 @@
                     "startColumn":6,
                     "startLine":90
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -321,7 +337,8 @@
                     "startColumn":10,
                     "startLine":92
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -329,7 +346,8 @@
                     "startColumn":10,
                     "startLine":92
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -337,7 +355,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -345,7 +364,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -353,7 +373,8 @@
                     "startColumn":10,
                     "startLine":94
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -361,7 +382,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -369,7 +391,8 @@
                     "startColumn":8,
                     "startLine":97
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -377,7 +400,8 @@
                     "startColumn":13,
                     "startLine":98
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -385,7 +409,8 @@
                     "startColumn":13,
                     "startLine":99
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -393,7 +418,8 @@
                     "startColumn":13,
                     "startLine":100
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -401,7 +427,8 @@
                     "startColumn":13,
                     "startLine":101
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -409,7 +436,8 @@
                     "startColumn":19,
                     "startLine":103
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -417,7 +445,8 @@
                     "startColumn":19,
                     "startLine":104
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -425,7 +454,8 @@
                     "startColumn":19,
                     "startLine":105
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -433,7 +463,8 @@
                     "startColumn":19,
                     "startLine":106
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -441,7 +472,8 @@
                     "startColumn":8,
                     "startLine":107
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -449,7 +481,8 @@
                     "startColumn":19,
                     "startLine":109
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -457,7 +490,8 @@
                     "startColumn":19,
                     "startLine":110
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -465,7 +499,8 @@
                     "startColumn":19,
                     "startLine":111
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -473,7 +508,8 @@
                     "startColumn":19,
                     "startLine":112
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -481,7 +517,8 @@
                     "startColumn":8,
                     "startLine":113
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -489,7 +526,8 @@
                     "startColumn":7,
                     "startLine":115
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -497,7 +535,8 @@
                     "startColumn":10,
                     "startLine":115
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -505,7 +544,8 @@
                     "startColumn":10,
                     "startLine":116
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test079.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":9,
                     "startLine":117
                   }
-                }
+                },
+                "step":29
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-080.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-080.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":35
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":22,
                     "startLine":36
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":9,
                     "startLine":41
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":23,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":18,
                     "startLine":45
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":22,
                     "startLine":45
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":27,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":17,
                     "startLine":47
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":23,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":18,
                     "startLine":48
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -209,7 +224,8 @@
                     "startColumn":6,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":9,
                     "startLine":41
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":23,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":18,
                     "startLine":45
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":22,
                     "startLine":45
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":27,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":17,
                     "startLine":47
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":23,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":18,
                     "startLine":48
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -323,7 +349,8 @@
                     "startColumn":6,
                     "startLine":53
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":5,
                     "startLine":55
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -365,7 +393,8 @@
                     "startColumn":6,
                     "startLine":58
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":12,
                     "startLine":60
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":19,
                     "startLine":60
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -389,7 +420,8 @@
                     "startColumn":5,
                     "startLine":61
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -423,7 +455,8 @@
                     "startColumn":6,
                     "startLine":65
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -439,7 +473,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -447,7 +482,8 @@
                     "startColumn":14,
                     "startLine":68
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -455,7 +491,8 @@
                     "startColumn":11,
                     "startLine":69
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -463,7 +500,8 @@
                     "startColumn":19,
                     "startLine":70
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -497,7 +535,8 @@
                     "startColumn":6,
                     "startLine":73
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -505,7 +544,8 @@
                     "startColumn":9,
                     "startLine":75
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":9,
                     "startLine":76
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":14,
                     "startLine":76
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -529,7 +571,8 @@
                     "startColumn":9,
                     "startLine":77
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -537,7 +580,8 @@
                     "startColumn":14,
                     "startLine":77
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -545,7 +589,8 @@
                     "startColumn":11,
                     "startLine":78
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test080.cpp",
@@ -553,7 +598,8 @@
                     "startColumn":24,
                     "startLine":79
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-081.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-081.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":63
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":65
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":26,
                     "startLine":66
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":67
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":112
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":7,
                     "startLine":114
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":10,
                     "startLine":115
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":19,
                     "startLine":116
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":28,
                     "startLine":116
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":37,
                     "startLine":116
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":47,
                     "startLine":116
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":9,
                     "startLine":117
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":13,
                     "startLine":119
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":20,
                     "startLine":121
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":20,
                     "startLine":121
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":65,
                     "startLine":121
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -225,7 +242,8 @@
                     "startColumn":6,
                     "startLine":155
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":16,
                     "startLine":157
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -267,7 +286,8 @@
                     "startColumn":6,
                     "startLine":170
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test081.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":24,
                     "startLine":172
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-082.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-082.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":14,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":23,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":18,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":27,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":25,
                     "startLine":12
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":32,
                     "startLine":13
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":14,
                     "startLine":16
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":23,
                     "startLine":16
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":19,
                     "startLine":18
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":11,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":27,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":25,
                     "startLine":48
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":36,
                     "startLine":49
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":14,
                     "startLine":52
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":19,
                     "startLine":55
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":19,
                     "startLine":56
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":19,
                     "startLine":57
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":19,
                     "startLine":58
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":40,
                     "startLine":52
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":19,
                     "startLine":55
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":19,
                     "startLine":56
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":19,
                     "startLine":57
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":19,
                     "startLine":58
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":40,
                     "startLine":52
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":19,
                     "startLine":55
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":19,
                     "startLine":56
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":19,
                     "startLine":57
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":19,
                     "startLine":58
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":40,
                     "startLine":52
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":39
               }
             ]
           }
@@ -521,7 +575,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -529,7 +584,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -537,7 +593,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -545,7 +602,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -553,7 +611,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -561,7 +620,8 @@
                     "startColumn":11,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -569,7 +629,8 @@
                     "startColumn":27,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -577,7 +638,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -585,7 +647,8 @@
                     "startColumn":25,
                     "startLine":48
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":36,
                     "startLine":49
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":14,
                     "startLine":52
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -667,7 +736,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -675,7 +745,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -683,7 +754,8 @@
                     "startColumn":23,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -691,7 +763,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -699,7 +772,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -707,7 +781,8 @@
                     "startColumn":11,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -715,7 +790,8 @@
                     "startColumn":27,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":25,
                     "startLine":48
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -739,7 +817,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -747,7 +826,8 @@
                     "startColumn":36,
                     "startLine":49
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -755,7 +835,8 @@
                     "startColumn":14,
                     "startLine":52
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":18,
                     "startLine":52
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":19,
                     "startLine":55
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":19,
                     "startLine":56
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":19,
                     "startLine":57
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":19,
                     "startLine":58
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -819,7 +907,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -827,7 +916,8 @@
                     "startColumn":40,
                     "startLine":52
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -835,7 +925,8 @@
                     "startColumn":23,
                     "startLine":52
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -843,7 +934,8 @@
                     "startColumn":9,
                     "startLine":63
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test082.cpp",
@@ -851,7 +943,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":24
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-083.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-083.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test083.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":16,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test083.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-084.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-084.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":23
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":25
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":29
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":11,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":11,
                     "startLine":32
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -145,7 +152,8 @@
                     "startColumn":6,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":11,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":15,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":17,
                     "startLine":38
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test084.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-086.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-086.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":18
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":14,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":18,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":23,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":17,
                     "startLine":24
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":32,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":23,
                     "startLine":23
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":17,
                     "startLine":24
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":32,
                     "startLine":23
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":23,
                     "startLine":23
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":17,
                     "startLine":24
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":32,
                     "startLine":23
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":23,
                     "startLine":23
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":17,
                     "startLine":24
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -217,7 +233,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":14,
                     "startLine":30
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":18,
                     "startLine":30
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":23,
                     "startLine":30
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":18,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":36,
                     "startLine":30
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":23,
                     "startLine":30
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":18,
                     "startLine":31
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -307,7 +331,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":14,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":18,
                     "startLine":36
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":16,
                     "startLine":37
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":36,
                     "startLine":36
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":16,
                     "startLine":37
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":36,
                     "startLine":36
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":16,
                     "startLine":37
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":36,
                     "startLine":36
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":16,
                     "startLine":37
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -445,7 +483,8 @@
                     "startColumn":6,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -453,7 +492,8 @@
                     "startColumn":7,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -461,7 +501,8 @@
                     "startColumn":14,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -495,7 +536,8 @@
                     "startColumn":6,
                     "startLine":52
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -503,7 +545,8 @@
                     "startColumn":17,
                     "startLine":54
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -537,7 +580,8 @@
                     "startColumn":6,
                     "startLine":52
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -545,7 +589,8 @@
                     "startColumn":17,
                     "startLine":54
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -553,7 +598,8 @@
                     "startColumn":18,
                     "startLine":55
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -587,7 +633,8 @@
                     "startColumn":6,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -595,7 +642,8 @@
                     "startColumn":14,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -603,7 +651,8 @@
                     "startColumn":18,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -611,7 +660,8 @@
                     "startColumn":23,
                     "startLine":66
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -619,7 +669,8 @@
                     "startColumn":18,
                     "startLine":67
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -627,7 +678,8 @@
                     "startColumn":22,
                     "startLine":67
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -635,7 +687,8 @@
                     "startColumn":27,
                     "startLine":67
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -643,7 +696,8 @@
                     "startColumn":26,
                     "startLine":68
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -651,7 +705,8 @@
                     "startColumn":35,
                     "startLine":67
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -659,7 +714,8 @@
                     "startColumn":27,
                     "startLine":67
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -667,7 +723,8 @@
                     "startColumn":26,
                     "startLine":68
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -675,7 +732,8 @@
                     "startColumn":35,
                     "startLine":67
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -683,7 +741,8 @@
                     "startColumn":27,
                     "startLine":67
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -691,7 +750,8 @@
                     "startColumn":26,
                     "startLine":68
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -699,7 +759,8 @@
                     "startColumn":35,
                     "startLine":67
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -707,7 +768,8 @@
                     "startColumn":27,
                     "startLine":67
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -715,7 +777,8 @@
                     "startColumn":26,
                     "startLine":68
                   }
-                }
+                },
+                "step":17
               }
             ]
           }
@@ -749,7 +812,8 @@
                     "startColumn":6,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -757,7 +821,8 @@
                     "startColumn":14,
                     "startLine":74
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -765,7 +830,8 @@
                     "startColumn":18,
                     "startLine":74
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -773,7 +839,8 @@
                     "startColumn":23,
                     "startLine":74
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -781,7 +848,8 @@
                     "startColumn":19,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -789,7 +857,8 @@
                     "startColumn":29,
                     "startLine":74
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -797,7 +866,8 @@
                     "startColumn":23,
                     "startLine":74
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -805,7 +875,8 @@
                     "startColumn":19,
                     "startLine":75
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -839,7 +910,8 @@
                     "startColumn":6,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -847,7 +919,8 @@
                     "startColumn":14,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -855,7 +928,8 @@
                     "startColumn":18,
                     "startLine":81
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -863,7 +937,8 @@
                     "startColumn":23,
                     "startLine":81
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -871,7 +946,8 @@
                     "startColumn":19,
                     "startLine":82
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -879,7 +955,8 @@
                     "startColumn":30,
                     "startLine":81
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -887,7 +964,8 @@
                     "startColumn":23,
                     "startLine":81
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -895,7 +973,8 @@
                     "startColumn":19,
                     "startLine":82
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -929,7 +1008,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -937,7 +1017,8 @@
                     "startColumn":14,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -945,7 +1026,8 @@
                     "startColumn":18,
                     "startLine":88
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -953,7 +1035,8 @@
                     "startColumn":23,
                     "startLine":88
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -961,7 +1044,8 @@
                     "startColumn":21,
                     "startLine":89
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -969,7 +1053,8 @@
                     "startColumn":30,
                     "startLine":88
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -977,7 +1062,8 @@
                     "startColumn":23,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -985,7 +1071,8 @@
                     "startColumn":21,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1019,7 +1106,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -1027,7 +1115,8 @@
                     "startColumn":14,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -1035,7 +1124,8 @@
                     "startColumn":18,
                     "startLine":88
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -1043,7 +1133,8 @@
                     "startColumn":23,
                     "startLine":88
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test086.cpp",
@@ -1051,7 +1142,8 @@
                     "startColumn":21,
                     "startLine":89
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-087.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-087.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":21,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":25,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":30,
                     "startLine":12
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":20,
                     "startLine":13
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":38,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":30,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":20,
                     "startLine":13
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":38,
                     "startLine":12
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":30,
                     "startLine":12
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":20,
                     "startLine":13
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":38,
                     "startLine":12
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":30,
                     "startLine":12
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":20,
                     "startLine":13
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -183,7 +198,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":10,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":11,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -233,7 +251,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":10,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":11,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":10,
                     "startLine":29
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":11,
                     "startLine":30
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -315,7 +340,8 @@
                     "startColumn":6,
                     "startLine":39
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":9,
                     "startLine":41
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":21,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":25,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":30,
                     "startLine":43
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":20,
                     "startLine":44
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":39,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":30,
                     "startLine":43
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":20,
                     "startLine":44
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":39,
                     "startLine":43
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":30,
                     "startLine":43
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":20,
                     "startLine":44
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":39,
                     "startLine":43
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":30,
                     "startLine":43
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -427,7 +466,8 @@
                     "startColumn":20,
                     "startLine":44
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -461,7 +501,8 @@
                     "startColumn":6,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -469,7 +510,8 @@
                     "startColumn":9,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -477,7 +519,8 @@
                     "startColumn":9,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -485,7 +528,8 @@
                     "startColumn":17,
                     "startLine":74
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -493,7 +537,8 @@
                     "startColumn":21,
                     "startLine":74
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -501,7 +546,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -509,7 +555,8 @@
                     "startColumn":16,
                     "startLine":75
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -517,7 +564,8 @@
                     "startColumn":35,
                     "startLine":74
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -525,7 +573,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -533,7 +582,8 @@
                     "startColumn":16,
                     "startLine":75
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -541,7 +591,8 @@
                     "startColumn":35,
                     "startLine":74
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -549,7 +600,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -557,7 +609,8 @@
                     "startColumn":16,
                     "startLine":75
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -565,7 +618,8 @@
                     "startColumn":35,
                     "startLine":74
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -573,7 +627,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -581,7 +636,8 @@
                     "startColumn":16,
                     "startLine":75
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -615,7 +671,8 @@
                     "startColumn":6,
                     "startLine":78
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -623,7 +680,8 @@
                     "startColumn":10,
                     "startLine":80
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -631,7 +689,8 @@
                     "startColumn":12,
                     "startLine":81
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -639,7 +698,8 @@
                     "startColumn":12,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -673,7 +733,8 @@
                     "startColumn":6,
                     "startLine":104
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -681,7 +742,8 @@
                     "startColumn":10,
                     "startLine":106
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -689,7 +751,8 @@
                     "startColumn":11,
                     "startLine":107
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -697,7 +760,8 @@
                     "startColumn":11,
                     "startLine":108
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -705,7 +769,8 @@
                     "startColumn":11,
                     "startLine":109
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -713,7 +778,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -747,7 +813,8 @@
                     "startColumn":6,
                     "startLine":133
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -755,7 +822,8 @@
                     "startColumn":10,
                     "startLine":135
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -763,7 +831,8 @@
                     "startColumn":9,
                     "startLine":136
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -771,7 +840,8 @@
                     "startColumn":9,
                     "startLine":137
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -805,7 +875,8 @@
                     "startColumn":6,
                     "startLine":155
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -813,7 +884,8 @@
                     "startColumn":17,
                     "startLine":157
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -821,7 +893,8 @@
                     "startColumn":14,
                     "startLine":158
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -829,7 +902,8 @@
                     "startColumn":17,
                     "startLine":159
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -837,7 +911,8 @@
                     "startColumn":21,
                     "startLine":159
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -845,7 +920,8 @@
                     "startColumn":26,
                     "startLine":159
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -853,7 +929,8 @@
                     "startColumn":16,
                     "startLine":160
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -861,7 +938,8 @@
                     "startColumn":34,
                     "startLine":159
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -869,7 +947,8 @@
                     "startColumn":26,
                     "startLine":159
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -877,7 +956,8 @@
                     "startColumn":16,
                     "startLine":160
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -911,7 +991,8 @@
                     "startColumn":6,
                     "startLine":163
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -919,7 +1000,8 @@
                     "startColumn":10,
                     "startLine":165
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -927,7 +1009,8 @@
                     "startColumn":12,
                     "startLine":166
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -935,7 +1018,8 @@
                     "startColumn":12,
                     "startLine":167
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -969,7 +1053,8 @@
                     "startColumn":6,
                     "startLine":258
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -977,7 +1062,8 @@
                     "startColumn":10,
                     "startLine":260
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -985,7 +1071,8 @@
                     "startColumn":13,
                     "startLine":261
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -993,7 +1080,8 @@
                     "startColumn":10,
                     "startLine":262
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -1001,7 +1089,8 @@
                     "startColumn":13,
                     "startLine":263
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -1035,7 +1124,8 @@
                     "startColumn":6,
                     "startLine":276
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -1043,7 +1133,8 @@
                     "startColumn":9,
                     "startLine":278
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -1051,7 +1142,8 @@
                     "startColumn":8,
                     "startLine":279
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -1059,7 +1151,8 @@
                     "startColumn":9,
                     "startLine":280
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test087.cpp",
@@ -1067,7 +1160,8 @@
                     "startColumn":8,
                     "startLine":281
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-088.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-088.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":25
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":6,
                     "startLine":27
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":9,
                     "startLine":36
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":9,
                     "startLine":38
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -121,7 +125,8 @@
                     "startColumn":18,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":10,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":18,
                     "startLine":59
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":16,
                     "startLine":60
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":28,
                     "startLine":59
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":16,
                     "startLine":60
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":28,
                     "startLine":59
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":16,
                     "startLine":60
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":28,
                     "startLine":59
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":12,
                     "startLine":61
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":6,
                     "startLine":62
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -275,7 +295,8 @@
                     "startColumn":13,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":11,
                     "startLine":76
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":29,
                     "startLine":76
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":15,
                     "startLine":78
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":9,
                     "startLine":79
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -341,7 +366,8 @@
                     "startColumn":14,
                     "startLine":114
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":10,
                     "startLine":116
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":18,
                     "startLine":116
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":6,
                     "startLine":117
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -399,7 +428,8 @@
                     "startColumn":19,
                     "startLine":128
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -407,7 +437,8 @@
                     "startColumn":11,
                     "startLine":130
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":11,
                     "startLine":131
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":6,
                     "startLine":132
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -457,7 +490,8 @@
                     "startColumn":15,
                     "startLine":147
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test088.cpp",
@@ -465,7 +499,8 @@
                     "startColumn":13,
                     "startLine":149
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":16,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":21,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":9,
                     "startLine":16
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":16,
                     "startLine":18
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":25,
                     "startLine":19
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":36,
                     "startLine":19
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":33,
                     "startLine":23
                   }
-                }
+                },
+                "step":30
               }
             ]
           }
@@ -303,7 +333,8 @@
                     "startColumn":16,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":21,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":9,
                     "startLine":16
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":16,
                     "startLine":18
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":25,
                     "startLine":19
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -511,7 +567,8 @@
                     "startColumn":36,
                     "startLine":19
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -519,7 +576,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -527,7 +585,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -535,7 +594,8 @@
                     "startColumn":33,
                     "startLine":23
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -543,7 +603,8 @@
                     "startColumn":24,
                     "startLine":23
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -551,7 +612,8 @@
                     "startColumn":29,
                     "startLine":24
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -585,7 +647,8 @@
                     "startColumn":16,
                     "startLine":46
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":12,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":9,
                     "startLine":57
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -665,7 +737,8 @@
                     "startColumn":16,
                     "startLine":61
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -673,7 +746,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -681,7 +755,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -721,7 +800,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -755,7 +835,8 @@
                     "startColumn":16,
                     "startLine":46
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":12,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":13,
                     "startLine":52
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -819,7 +907,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -827,7 +916,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -835,7 +925,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -843,7 +934,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -851,7 +943,8 @@
                     "startColumn":9,
                     "startLine":57
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -859,7 +952,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -867,7 +961,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -875,7 +970,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -883,7 +979,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -891,7 +988,8 @@
                     "startColumn":16,
                     "startLine":61
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -899,7 +997,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -907,7 +1006,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -915,7 +1015,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -923,7 +1024,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -931,7 +1033,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -939,7 +1042,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -947,7 +1051,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -955,7 +1060,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -963,7 +1069,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -971,7 +1078,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -979,7 +1087,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -987,7 +1096,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -995,7 +1105,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1003,7 +1114,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -1037,7 +1149,8 @@
                     "startColumn":16,
                     "startLine":76
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1045,7 +1158,8 @@
                     "startColumn":12,
                     "startLine":78
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1053,7 +1167,8 @@
                     "startColumn":21,
                     "startLine":78
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1061,7 +1176,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1069,7 +1185,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1077,7 +1194,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1085,7 +1203,8 @@
                     "startColumn":13,
                     "startLine":90
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1093,7 +1212,8 @@
                     "startColumn":12,
                     "startLine":91
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1101,7 +1221,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1109,7 +1230,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1117,7 +1239,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1125,7 +1248,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1133,7 +1257,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1141,7 +1266,8 @@
                     "startColumn":15,
                     "startLine":95
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1149,7 +1275,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1157,7 +1284,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1165,7 +1293,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1173,7 +1302,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1181,7 +1311,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1189,7 +1320,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1197,7 +1329,8 @@
                     "startColumn":15,
                     "startLine":95
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1205,7 +1338,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":22
               }
             ]
           }
@@ -1239,7 +1373,8 @@
                     "startColumn":19,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1247,7 +1382,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1255,7 +1391,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1263,7 +1400,8 @@
                     "startColumn":9,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1271,7 +1409,8 @@
                     "startColumn":15,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1279,7 +1418,8 @@
                     "startColumn":9,
                     "startLine":107
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1287,7 +1427,8 @@
                     "startColumn":16,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1295,7 +1436,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1303,7 +1445,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1311,7 +1454,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1319,7 +1463,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1327,7 +1472,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1335,7 +1481,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1343,7 +1490,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1351,7 +1499,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1359,7 +1508,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1367,7 +1517,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1375,7 +1526,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1383,7 +1535,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1391,7 +1544,8 @@
                     "startColumn":21,
                     "startLine":119
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1399,7 +1553,8 @@
                     "startColumn":21,
                     "startLine":120
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1407,7 +1562,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1415,7 +1571,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1423,7 +1580,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1431,7 +1589,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1439,7 +1598,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1447,7 +1607,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1455,7 +1616,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1463,7 +1625,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1471,7 +1634,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1479,7 +1643,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1487,7 +1652,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1495,7 +1661,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1503,7 +1670,8 @@
                     "startColumn":21,
                     "startLine":123
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1511,7 +1679,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1519,7 +1688,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1527,7 +1697,8 @@
                     "startColumn":21,
                     "startLine":127
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1535,7 +1706,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1543,7 +1715,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1551,7 +1724,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1559,7 +1733,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1567,7 +1742,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1575,7 +1751,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1583,7 +1760,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1591,7 +1769,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1599,7 +1778,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1607,7 +1787,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1615,7 +1796,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":48
               }
             ]
           }
@@ -1649,7 +1831,8 @@
                     "startColumn":19,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1657,7 +1840,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1665,7 +1849,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1673,7 +1858,8 @@
                     "startColumn":9,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1681,7 +1867,8 @@
                     "startColumn":15,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1689,7 +1876,8 @@
                     "startColumn":9,
                     "startLine":107
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1697,7 +1885,8 @@
                     "startColumn":16,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1705,7 +1894,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1713,7 +1903,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1721,7 +1912,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1729,7 +1921,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1737,7 +1930,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1745,7 +1939,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1753,7 +1948,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1761,7 +1957,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1769,7 +1966,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1777,7 +1975,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1785,7 +1984,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1793,7 +1993,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1801,7 +2002,8 @@
                     "startColumn":21,
                     "startLine":119
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1809,7 +2011,8 @@
                     "startColumn":21,
                     "startLine":120
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1817,7 +2020,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1825,7 +2029,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1833,7 +2038,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1841,7 +2047,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1849,7 +2056,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1857,7 +2065,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1865,7 +2074,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1873,7 +2083,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1881,7 +2092,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1889,7 +2101,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1897,7 +2110,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1905,7 +2119,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1913,7 +2128,8 @@
                     "startColumn":21,
                     "startLine":123
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1921,7 +2137,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1929,7 +2146,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1937,7 +2155,8 @@
                     "startColumn":21,
                     "startLine":127
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1945,7 +2164,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1953,7 +2173,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1961,7 +2182,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1969,7 +2191,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1977,7 +2200,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1985,7 +2209,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1993,7 +2218,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2001,7 +2227,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2009,7 +2236,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2017,7 +2245,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2025,7 +2254,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":48
               }
             ]
           }
@@ -2059,7 +2289,8 @@
                     "startColumn":19,
                     "startLine":137
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2067,7 +2298,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2075,7 +2307,8 @@
                     "startColumn":16,
                     "startLine":139
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2083,7 +2316,8 @@
                     "startColumn":9,
                     "startLine":140
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2091,7 +2325,8 @@
                     "startColumn":15,
                     "startLine":140
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2099,7 +2334,8 @@
                     "startColumn":9,
                     "startLine":141
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2107,7 +2343,8 @@
                     "startColumn":16,
                     "startLine":141
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2115,7 +2352,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2123,7 +2361,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2131,7 +2370,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2139,7 +2379,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2147,7 +2388,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2155,7 +2397,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2163,7 +2406,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2171,7 +2415,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2179,7 +2424,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2187,7 +2433,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2195,7 +2442,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2203,7 +2451,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2211,7 +2460,8 @@
                     "startColumn":21,
                     "startLine":157
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2219,7 +2469,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2227,7 +2478,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2235,7 +2487,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2243,7 +2496,8 @@
                     "startColumn":27,
                     "startLine":162
                   }
-                }
+                },
+                "step":24
               }
             ]
           }
@@ -2277,7 +2531,8 @@
                     "startColumn":19,
                     "startLine":137
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2285,7 +2540,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2293,7 +2549,8 @@
                     "startColumn":16,
                     "startLine":139
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2301,7 +2558,8 @@
                     "startColumn":9,
                     "startLine":140
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2309,7 +2567,8 @@
                     "startColumn":15,
                     "startLine":140
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2317,7 +2576,8 @@
                     "startColumn":9,
                     "startLine":141
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2325,7 +2585,8 @@
                     "startColumn":16,
                     "startLine":141
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2333,7 +2594,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2341,7 +2603,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2349,7 +2612,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2357,7 +2621,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2365,7 +2630,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2373,7 +2639,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2381,7 +2648,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2389,7 +2657,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2397,7 +2666,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2405,7 +2675,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2413,7 +2684,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2421,7 +2693,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2429,7 +2702,8 @@
                     "startColumn":21,
                     "startLine":153
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2437,7 +2711,8 @@
                     "startColumn":21,
                     "startLine":154
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2445,7 +2720,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2453,7 +2729,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2461,7 +2738,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2469,7 +2747,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2477,7 +2756,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2485,7 +2765,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2493,7 +2774,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2501,7 +2783,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2509,7 +2792,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2517,7 +2801,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2525,7 +2810,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2533,7 +2819,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2541,7 +2828,8 @@
                     "startColumn":21,
                     "startLine":157
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2549,7 +2837,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2557,7 +2846,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2565,7 +2855,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2573,7 +2864,8 @@
                     "startColumn":27,
                     "startLine":162
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2581,7 +2873,8 @@
                     "startColumn":24,
                     "startLine":165
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2589,7 +2882,8 @@
                     "startColumn":9,
                     "startLine":168
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2597,7 +2891,8 @@
                     "startColumn":9,
                     "startLine":168
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2605,7 +2900,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2613,7 +2909,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2621,7 +2918,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2629,7 +2927,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2637,7 +2936,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2645,7 +2945,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2653,7 +2954,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2661,7 +2963,8 @@
                     "startColumn":24,
                     "startLine":165
                   }
-                }
+                },
+                "step":49
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-089.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":16,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":21,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":9,
                     "startLine":16
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":16,
                     "startLine":18
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":25,
                     "startLine":19
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":36,
                     "startLine":19
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":33,
                     "startLine":23
                   }
-                }
+                },
+                "step":30
               }
             ]
           }
@@ -303,7 +333,8 @@
                     "startColumn":16,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":21,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":21,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":27,
                     "startLine":12
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":19,
                     "startLine":13
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":32,
                     "startLine":10
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":26,
                     "startLine":10
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":9,
                     "startLine":16
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":16,
                     "startLine":18
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":21,
                     "startLine":19
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":25,
                     "startLine":19
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -511,7 +567,8 @@
                     "startColumn":36,
                     "startLine":19
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -519,7 +576,8 @@
                     "startColumn":30,
                     "startLine":19
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -527,7 +585,8 @@
                     "startColumn":31,
                     "startLine":21
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -535,7 +594,8 @@
                     "startColumn":33,
                     "startLine":23
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -543,7 +603,8 @@
                     "startColumn":24,
                     "startLine":23
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -551,7 +612,8 @@
                     "startColumn":29,
                     "startLine":24
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -585,7 +647,8 @@
                     "startColumn":16,
                     "startLine":46
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":12,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":9,
                     "startLine":57
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -665,7 +737,8 @@
                     "startColumn":16,
                     "startLine":61
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -673,7 +746,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -681,7 +755,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -721,7 +800,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -755,7 +835,8 @@
                     "startColumn":16,
                     "startLine":46
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":12,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":21,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":13,
                     "startLine":52
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -819,7 +907,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -827,7 +916,8 @@
                     "startColumn":19,
                     "startLine":54
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -835,7 +925,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -843,7 +934,8 @@
                     "startColumn":21,
                     "startLine":50
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -851,7 +943,8 @@
                     "startColumn":9,
                     "startLine":57
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -859,7 +952,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -867,7 +961,8 @@
                     "startColumn":14,
                     "startLine":57
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -875,7 +970,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -883,7 +979,8 @@
                     "startColumn":17,
                     "startLine":60
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -891,7 +988,8 @@
                     "startColumn":16,
                     "startLine":61
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -899,7 +997,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -907,7 +1006,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -915,7 +1015,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -923,7 +1024,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -931,7 +1033,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -939,7 +1042,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -947,7 +1051,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -955,7 +1060,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -963,7 +1069,8 @@
                     "startColumn":25,
                     "startLine":62
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -971,7 +1078,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -979,7 +1087,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -987,7 +1096,8 @@
                     "startColumn":28,
                     "startLine":64
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -995,7 +1105,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1003,7 +1114,8 @@
                     "startColumn":29,
                     "startLine":67
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -1037,7 +1149,8 @@
                     "startColumn":16,
                     "startLine":76
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1045,7 +1158,8 @@
                     "startColumn":12,
                     "startLine":78
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1053,7 +1167,8 @@
                     "startColumn":21,
                     "startLine":78
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1061,7 +1176,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1069,7 +1185,8 @@
                     "startColumn":21,
                     "startLine":80
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1077,7 +1194,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1085,7 +1203,8 @@
                     "startColumn":13,
                     "startLine":90
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1093,7 +1212,8 @@
                     "startColumn":12,
                     "startLine":91
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1101,7 +1221,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1109,7 +1230,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1117,7 +1239,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1125,7 +1248,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1133,7 +1257,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1141,7 +1266,8 @@
                     "startColumn":15,
                     "startLine":95
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1149,7 +1275,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1157,7 +1284,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1165,7 +1293,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1173,7 +1302,8 @@
                     "startColumn":13,
                     "startLine":94
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1181,7 +1311,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1189,7 +1320,8 @@
                     "startColumn":24,
                     "startLine":94
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1197,7 +1329,8 @@
                     "startColumn":15,
                     "startLine":95
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1205,7 +1338,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":22
               }
             ]
           }
@@ -1239,7 +1373,8 @@
                     "startColumn":19,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1247,7 +1382,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1255,7 +1391,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1263,7 +1400,8 @@
                     "startColumn":9,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1271,7 +1409,8 @@
                     "startColumn":15,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1279,7 +1418,8 @@
                     "startColumn":9,
                     "startLine":107
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1287,7 +1427,8 @@
                     "startColumn":16,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1295,7 +1436,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1303,7 +1445,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1311,7 +1454,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1319,7 +1463,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1327,7 +1472,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1335,7 +1481,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1343,7 +1490,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1351,7 +1499,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1359,7 +1508,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1367,7 +1517,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1375,7 +1526,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1383,7 +1535,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1391,7 +1544,8 @@
                     "startColumn":21,
                     "startLine":119
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1399,7 +1553,8 @@
                     "startColumn":21,
                     "startLine":120
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1407,7 +1562,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1415,7 +1571,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1423,7 +1580,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1431,7 +1589,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1439,7 +1598,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1447,7 +1607,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1455,7 +1616,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1463,7 +1625,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1471,7 +1634,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1479,7 +1643,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1487,7 +1652,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1495,7 +1661,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1503,7 +1670,8 @@
                     "startColumn":21,
                     "startLine":123
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1511,7 +1679,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1519,7 +1688,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1527,7 +1697,8 @@
                     "startColumn":21,
                     "startLine":127
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1535,7 +1706,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1543,7 +1715,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1551,7 +1724,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1559,7 +1733,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1567,7 +1742,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1575,7 +1751,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1583,7 +1760,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1591,7 +1769,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1599,7 +1778,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1607,7 +1787,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1615,7 +1796,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":48
               }
             ]
           }
@@ -1649,7 +1831,8 @@
                     "startColumn":19,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1657,7 +1840,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1665,7 +1849,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1673,7 +1858,8 @@
                     "startColumn":9,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1681,7 +1867,8 @@
                     "startColumn":15,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1689,7 +1876,8 @@
                     "startColumn":9,
                     "startLine":107
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1697,7 +1885,8 @@
                     "startColumn":16,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1705,7 +1894,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1713,7 +1903,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1721,7 +1912,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1729,7 +1921,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1737,7 +1930,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1745,7 +1939,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1753,7 +1948,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1761,7 +1957,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1769,7 +1966,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1777,7 +1975,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1785,7 +1984,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1793,7 +1993,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1801,7 +2002,8 @@
                     "startColumn":21,
                     "startLine":119
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1809,7 +2011,8 @@
                     "startColumn":21,
                     "startLine":120
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1817,7 +2020,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1825,7 +2029,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1833,7 +2038,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1841,7 +2047,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1849,7 +2056,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1857,7 +2065,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1865,7 +2074,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1873,7 +2083,8 @@
                     "startColumn":22,
                     "startLine":115
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1881,7 +2092,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1889,7 +2101,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1897,7 +2110,8 @@
                     "startColumn":31,
                     "startLine":116
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1905,7 +2119,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1913,7 +2128,8 @@
                     "startColumn":21,
                     "startLine":123
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1921,7 +2137,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1929,7 +2146,8 @@
                     "startColumn":17,
                     "startLine":126
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1937,7 +2155,8 @@
                     "startColumn":21,
                     "startLine":127
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1945,7 +2164,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1953,7 +2173,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1961,7 +2182,8 @@
                     "startColumn":9,
                     "startLine":133
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1969,7 +2191,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1977,7 +2200,8 @@
                     "startColumn":21,
                     "startLine":108
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1985,7 +2209,8 @@
                     "startColumn":13,
                     "startLine":110
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -1993,7 +2218,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2001,7 +2227,8 @@
                     "startColumn":24,
                     "startLine":110
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2009,7 +2236,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2017,7 +2245,8 @@
                     "startColumn":21,
                     "startLine":113
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2025,7 +2254,8 @@
                     "startColumn":24,
                     "startLine":130
                   }
-                }
+                },
+                "step":48
               }
             ]
           }
@@ -2059,7 +2289,8 @@
                     "startColumn":19,
                     "startLine":137
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2067,7 +2298,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2075,7 +2307,8 @@
                     "startColumn":16,
                     "startLine":139
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2083,7 +2316,8 @@
                     "startColumn":9,
                     "startLine":140
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2091,7 +2325,8 @@
                     "startColumn":15,
                     "startLine":140
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2099,7 +2334,8 @@
                     "startColumn":9,
                     "startLine":141
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2107,7 +2343,8 @@
                     "startColumn":16,
                     "startLine":141
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2115,7 +2352,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2123,7 +2361,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2131,7 +2370,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2139,7 +2379,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2147,7 +2388,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2155,7 +2397,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2163,7 +2406,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2171,7 +2415,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2179,7 +2424,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2187,7 +2433,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2195,7 +2442,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2203,7 +2451,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2211,7 +2460,8 @@
                     "startColumn":21,
                     "startLine":157
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2219,7 +2469,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2227,7 +2478,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2235,7 +2487,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2243,7 +2496,8 @@
                     "startColumn":27,
                     "startLine":162
                   }
-                }
+                },
+                "step":24
               }
             ]
           }
@@ -2277,7 +2531,8 @@
                     "startColumn":19,
                     "startLine":137
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2285,7 +2540,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2293,7 +2549,8 @@
                     "startColumn":16,
                     "startLine":139
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2301,7 +2558,8 @@
                     "startColumn":9,
                     "startLine":140
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2309,7 +2567,8 @@
                     "startColumn":15,
                     "startLine":140
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2317,7 +2576,8 @@
                     "startColumn":9,
                     "startLine":141
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2325,7 +2585,8 @@
                     "startColumn":16,
                     "startLine":141
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2333,7 +2594,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2341,7 +2603,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2349,7 +2612,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2357,7 +2621,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2365,7 +2630,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2373,7 +2639,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2381,7 +2648,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2389,7 +2657,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2397,7 +2666,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2405,7 +2675,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2413,7 +2684,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2421,7 +2693,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2429,7 +2702,8 @@
                     "startColumn":21,
                     "startLine":153
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2437,7 +2711,8 @@
                     "startColumn":21,
                     "startLine":154
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2445,7 +2720,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2453,7 +2729,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2461,7 +2738,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2469,7 +2747,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2477,7 +2756,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2485,7 +2765,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2493,7 +2774,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2501,7 +2783,8 @@
                     "startColumn":22,
                     "startLine":149
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2509,7 +2792,8 @@
                     "startColumn":21,
                     "startLine":150
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2517,7 +2801,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2525,7 +2810,8 @@
                     "startColumn":31,
                     "startLine":150
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2533,7 +2819,8 @@
                     "startColumn":21,
                     "startLine":151
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2541,7 +2828,8 @@
                     "startColumn":21,
                     "startLine":157
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2549,7 +2837,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2557,7 +2846,8 @@
                     "startColumn":17,
                     "startLine":160
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2565,7 +2855,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2573,7 +2864,8 @@
                     "startColumn":27,
                     "startLine":162
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2581,7 +2873,8 @@
                     "startColumn":24,
                     "startLine":165
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2589,7 +2882,8 @@
                     "startColumn":9,
                     "startLine":168
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2597,7 +2891,8 @@
                     "startColumn":9,
                     "startLine":168
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2605,7 +2900,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2613,7 +2909,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2621,7 +2918,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2629,7 +2927,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2637,7 +2936,8 @@
                     "startColumn":24,
                     "startLine":144
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2645,7 +2945,8 @@
                     "startColumn":15,
                     "startLine":145
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2653,7 +2954,8 @@
                     "startColumn":21,
                     "startLine":147
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test089.cpp",
@@ -2661,7 +2963,8 @@
                     "startColumn":24,
                     "startLine":165
                   }
-                }
+                },
+                "step":49
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-090.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-090.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":7,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":30
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":32
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":16,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -161,7 +170,8 @@
                     "startColumn":6,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":13,
                     "startLine":44
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":10,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -235,7 +250,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":10,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":22,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":45,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":15,
                     "startLine":75
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -317,7 +339,8 @@
                     "startColumn":6,
                     "startLine":70
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -325,7 +348,8 @@
                     "startColumn":10,
                     "startLine":72
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -333,7 +357,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":22,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":45,
                     "startLine":75
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":31,
                     "startLine":75
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":15,
                     "startLine":75
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -399,7 +428,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -407,7 +437,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":17,
                     "startLine":89
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":22,
                     "startLine":89
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":17,
                     "startLine":90
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -439,7 +473,8 @@
                     "startColumn":23,
                     "startLine":90
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -473,7 +508,8 @@
                     "startColumn":6,
                     "startLine":98
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -481,7 +517,8 @@
                     "startColumn":10,
                     "startLine":100
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -489,7 +526,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -497,7 +535,8 @@
                     "startColumn":11,
                     "startLine":102
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -505,7 +544,8 @@
                     "startColumn":28,
                     "startLine":102
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -513,7 +553,8 @@
                     "startColumn":15,
                     "startLine":102
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -521,7 +562,8 @@
                     "startColumn":10,
                     "startLine":103
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -529,7 +571,8 @@
                     "startColumn":11,
                     "startLine":105
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -563,7 +606,8 @@
                     "startColumn":6,
                     "startLine":114
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -571,7 +615,8 @@
                     "startColumn":9,
                     "startLine":116
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -579,7 +624,8 @@
                     "startColumn":16,
                     "startLine":117
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -587,7 +633,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -621,7 +668,8 @@
                     "startColumn":6,
                     "startLine":114
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -629,7 +677,8 @@
                     "startColumn":9,
                     "startLine":116
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -637,7 +686,8 @@
                     "startColumn":16,
                     "startLine":117
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -645,7 +695,8 @@
                     "startColumn":21,
                     "startLine":117
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -679,7 +730,8 @@
                     "startColumn":6,
                     "startLine":125
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -687,7 +739,8 @@
                     "startColumn":9,
                     "startLine":127
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -695,7 +748,8 @@
                     "startColumn":9,
                     "startLine":128
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -703,7 +757,8 @@
                     "startColumn":39,
                     "startLine":128
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -711,7 +766,8 @@
                     "startColumn":27,
                     "startLine":128
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -719,7 +775,8 @@
                     "startColumn":20,
                     "startLine":128
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -727,7 +784,8 @@
                     "startColumn":16,
                     "startLine":128
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -735,7 +793,8 @@
                     "startColumn":16,
                     "startLine":128
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -743,7 +802,8 @@
                     "startColumn":10,
                     "startLine":129
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -777,7 +837,8 @@
                     "startColumn":6,
                     "startLine":138
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -785,7 +846,8 @@
                     "startColumn":11,
                     "startLine":140
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -819,7 +881,8 @@
                     "startColumn":6,
                     "startLine":161
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -827,7 +890,8 @@
                     "startColumn":9,
                     "startLine":163
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -835,7 +899,8 @@
                     "startColumn":13,
                     "startLine":164
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -843,7 +908,8 @@
                     "startColumn":7,
                     "startLine":164
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -851,7 +917,8 @@
                     "startColumn":10,
                     "startLine":165
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -885,7 +952,8 @@
                     "startColumn":6,
                     "startLine":185
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -893,7 +961,8 @@
                     "startColumn":9,
                     "startLine":187
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -901,7 +970,8 @@
                     "startColumn":10,
                     "startLine":188
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -909,7 +979,8 @@
                     "startColumn":10,
                     "startLine":189
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -917,7 +988,8 @@
                     "startColumn":8,
                     "startLine":190
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -925,7 +997,8 @@
                     "startColumn":13,
                     "startLine":191
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -959,7 +1032,8 @@
                     "startColumn":6,
                     "startLine":199
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -967,7 +1041,8 @@
                     "startColumn":9,
                     "startLine":201
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -975,7 +1050,8 @@
                     "startColumn":8,
                     "startLine":202
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test090.cpp",
@@ -983,7 +1059,8 @@
                     "startColumn":19,
                     "startLine":203
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-091.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-091.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":34,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test091.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":38,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test091.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":24,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test091.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":5,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-092.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-092.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":51
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":53
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":55
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":39,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":39,
                     "startLine":55
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -207,7 +225,8 @@
                     "startColumn":6,
                     "startLine":51
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":9,
                     "startLine":53
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":18,
                     "startLine":55
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":39,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":39,
                     "startLine":55
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":17,
                     "startLine":57
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":22,
                     "startLine":57
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":14,
                     "startLine":58
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":39,
                     "startLine":55
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":28,
                     "startLine":55
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":10,
                     "startLine":60
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -401,7 +440,8 @@
                     "startColumn":6,
                     "startLine":65
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":18,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":22,
                     "startLine":69
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":39,
                     "startLine":69
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":39,
                     "startLine":69
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -521,7 +575,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -529,7 +584,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -537,7 +593,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -571,7 +628,8 @@
                     "startColumn":6,
                     "startLine":65
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -579,7 +637,8 @@
                     "startColumn":9,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -587,7 +646,8 @@
                     "startColumn":18,
                     "startLine":69
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -595,7 +655,8 @@
                     "startColumn":22,
                     "startLine":69
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -603,7 +664,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -611,7 +673,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -619,7 +682,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -627,7 +691,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -635,7 +700,8 @@
                     "startColumn":39,
                     "startLine":69
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -643,7 +709,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -651,7 +718,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -659,7 +727,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -667,7 +736,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -675,7 +745,8 @@
                     "startColumn":39,
                     "startLine":69
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -683,7 +754,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -691,7 +763,8 @@
                     "startColumn":17,
                     "startLine":71
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -699,7 +772,8 @@
                     "startColumn":22,
                     "startLine":71
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -707,7 +781,8 @@
                     "startColumn":14,
                     "startLine":72
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -715,7 +790,8 @@
                     "startColumn":39,
                     "startLine":69
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":28,
                     "startLine":69
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":10,
                     "startLine":74
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -765,7 +843,8 @@
                     "startColumn":6,
                     "startLine":78
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -773,7 +852,8 @@
                     "startColumn":9,
                     "startLine":80
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -781,7 +861,8 @@
                     "startColumn":18,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -789,7 +870,8 @@
                     "startColumn":22,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -797,7 +879,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -805,7 +888,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -813,7 +897,8 @@
                     "startColumn":39,
                     "startLine":82
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -821,7 +906,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -829,7 +915,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -837,7 +924,8 @@
                     "startColumn":39,
                     "startLine":82
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -845,7 +933,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -853,7 +942,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -887,7 +977,8 @@
                     "startColumn":6,
                     "startLine":78
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -895,7 +986,8 @@
                     "startColumn":9,
                     "startLine":80
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -903,7 +995,8 @@
                     "startColumn":18,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -911,7 +1004,8 @@
                     "startColumn":22,
                     "startLine":82
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -919,7 +1013,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -927,7 +1022,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -935,7 +1031,8 @@
                     "startColumn":39,
                     "startLine":82
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -943,7 +1040,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -951,7 +1049,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -959,7 +1058,8 @@
                     "startColumn":39,
                     "startLine":82
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -967,7 +1067,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -975,7 +1076,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -983,7 +1085,8 @@
                     "startColumn":39,
                     "startLine":82
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -991,7 +1094,8 @@
                     "startColumn":28,
                     "startLine":82
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -999,7 +1103,8 @@
                     "startColumn":10,
                     "startLine":86
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -1033,7 +1138,8 @@
                     "startColumn":6,
                     "startLine":89
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1041,7 +1147,8 @@
                     "startColumn":9,
                     "startLine":91
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1049,7 +1156,8 @@
                     "startColumn":27,
                     "startLine":93
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1057,7 +1165,8 @@
                     "startColumn":31,
                     "startLine":93
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1065,7 +1174,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1073,7 +1183,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1081,7 +1192,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1089,7 +1201,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1097,7 +1210,8 @@
                     "startColumn":48,
                     "startLine":93
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1105,7 +1219,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1113,7 +1228,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1121,7 +1237,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1129,7 +1246,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1137,7 +1255,8 @@
                     "startColumn":48,
                     "startLine":93
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1145,7 +1264,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1153,7 +1273,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1161,7 +1282,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1169,7 +1291,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -1203,7 +1326,8 @@
                     "startColumn":6,
                     "startLine":89
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1211,7 +1335,8 @@
                     "startColumn":9,
                     "startLine":91
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1219,7 +1344,8 @@
                     "startColumn":27,
                     "startLine":93
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1227,7 +1353,8 @@
                     "startColumn":31,
                     "startLine":93
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1235,7 +1362,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1243,7 +1371,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1251,7 +1380,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1259,7 +1389,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1267,7 +1398,8 @@
                     "startColumn":48,
                     "startLine":93
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1275,7 +1407,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1283,7 +1416,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1291,7 +1425,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1299,7 +1434,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1307,7 +1443,8 @@
                     "startColumn":48,
                     "startLine":93
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1315,7 +1452,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1323,7 +1461,8 @@
                     "startColumn":26,
                     "startLine":95
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1331,7 +1470,8 @@
                     "startColumn":31,
                     "startLine":95
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1339,7 +1479,8 @@
                     "startColumn":14,
                     "startLine":96
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1347,7 +1488,8 @@
                     "startColumn":48,
                     "startLine":93
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1355,7 +1497,8 @@
                     "startColumn":37,
                     "startLine":93
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1363,7 +1506,8 @@
                     "startColumn":10,
                     "startLine":98
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -1397,7 +1541,8 @@
                     "startColumn":6,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1405,7 +1550,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1413,7 +1559,8 @@
                     "startColumn":27,
                     "startLine":107
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1421,7 +1568,8 @@
                     "startColumn":31,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1429,7 +1577,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1437,7 +1586,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1445,7 +1595,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1453,7 +1604,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1461,7 +1613,8 @@
                     "startColumn":48,
                     "startLine":107
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1469,7 +1622,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1477,7 +1631,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1485,7 +1640,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1493,7 +1649,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1501,7 +1658,8 @@
                     "startColumn":48,
                     "startLine":107
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1509,7 +1667,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1517,7 +1676,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1525,7 +1685,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1533,7 +1694,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":18
               }
             ]
           }
@@ -1567,7 +1729,8 @@
                     "startColumn":6,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1575,7 +1738,8 @@
                     "startColumn":9,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1583,7 +1747,8 @@
                     "startColumn":27,
                     "startLine":107
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1591,7 +1756,8 @@
                     "startColumn":31,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1599,7 +1765,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1607,7 +1774,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1615,7 +1783,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1623,7 +1792,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1631,7 +1801,8 @@
                     "startColumn":48,
                     "startLine":107
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1639,7 +1810,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1647,7 +1819,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1655,7 +1828,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1663,7 +1837,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1671,7 +1846,8 @@
                     "startColumn":48,
                     "startLine":107
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1679,7 +1855,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1687,7 +1864,8 @@
                     "startColumn":17,
                     "startLine":109
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1695,7 +1873,8 @@
                     "startColumn":22,
                     "startLine":109
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1703,7 +1882,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1711,7 +1891,8 @@
                     "startColumn":48,
                     "startLine":107
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1719,7 +1900,8 @@
                     "startColumn":37,
                     "startLine":107
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1727,7 +1909,8 @@
                     "startColumn":10,
                     "startLine":112
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -1761,7 +1944,8 @@
                     "startColumn":6,
                     "startLine":116
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1769,7 +1953,8 @@
                     "startColumn":9,
                     "startLine":118
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1777,7 +1962,8 @@
                     "startColumn":27,
                     "startLine":120
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1785,7 +1971,8 @@
                     "startColumn":31,
                     "startLine":120
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1793,7 +1980,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1801,7 +1989,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1809,7 +1998,8 @@
                     "startColumn":48,
                     "startLine":120
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1817,7 +2007,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1825,7 +2016,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1833,7 +2025,8 @@
                     "startColumn":48,
                     "startLine":120
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1841,7 +2034,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1849,7 +2043,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -1883,7 +2078,8 @@
                     "startColumn":6,
                     "startLine":116
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1891,7 +2087,8 @@
                     "startColumn":9,
                     "startLine":118
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1899,7 +2096,8 @@
                     "startColumn":27,
                     "startLine":120
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1907,7 +2105,8 @@
                     "startColumn":31,
                     "startLine":120
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1915,7 +2114,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1923,7 +2123,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1931,7 +2132,8 @@
                     "startColumn":48,
                     "startLine":120
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1939,7 +2141,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1947,7 +2150,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1955,7 +2159,8 @@
                     "startColumn":48,
                     "startLine":120
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1963,7 +2168,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1971,7 +2177,8 @@
                     "startColumn":16,
                     "startLine":122
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1979,7 +2186,8 @@
                     "startColumn":48,
                     "startLine":120
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1987,7 +2195,8 @@
                     "startColumn":37,
                     "startLine":120
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test092.cpp",
@@ -1995,7 +2204,8 @@
                     "startColumn":10,
                     "startLine":124
                   }
-                }
+                },
+                "step":15
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-093.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-093.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":48
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":50
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":22,
                     "startLine":50
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":53
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":16,
                     "startLine":55
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test093.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":16,
                     "startLine":56
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-094.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-094.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":22,
                     "startLine":11
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":5,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":10,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":17,
                     "startLine":22
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":22,
                     "startLine":22
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":14,
                     "startLine":22
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":11,
                     "startLine":24
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":5,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":18,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":14,
                     "startLine":33
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":5,
                     "startLine":34
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -275,7 +295,8 @@
                     "startColumn":5,
                     "startLine":31
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":10,
                     "startLine":33
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":18,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":23,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":14,
                     "startLine":33
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":5,
                     "startLine":34
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -349,7 +375,8 @@
                     "startColumn":5,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":19,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":24,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":14,
                     "startLine":39
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -389,7 +420,8 @@
                     "startColumn":5,
                     "startLine":40
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -423,7 +455,8 @@
                     "startColumn":5,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -439,7 +473,8 @@
                     "startColumn":19,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -447,7 +482,8 @@
                     "startColumn":24,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -455,7 +491,8 @@
                     "startColumn":14,
                     "startLine":39
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test094.cpp",
@@ -463,7 +500,8 @@
                     "startColumn":5,
                     "startLine":40
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-095.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-095.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":17,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":13,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":17,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":13,
                     "startLine":49
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -283,7 +304,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":17,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test095.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":13,
                     "startLine":49
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-096.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-096.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":30
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":18,
                     "startLine":30
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":31
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":31
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":32,
                     "startLine":37
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":5,
                     "startLine":39
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -135,7 +144,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":32,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":12,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":16,
                     "startLine":51
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -249,7 +269,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":32,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":12,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":16,
                     "startLine":51
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -363,7 +394,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -427,7 +466,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -435,7 +475,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -443,7 +484,8 @@
                     "startColumn":32,
                     "startLine":57
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -451,7 +493,8 @@
                     "startColumn":12,
                     "startLine":57
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -459,7 +502,8 @@
                     "startColumn":16,
                     "startLine":58
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -493,7 +537,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -501,7 +546,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -509,7 +555,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -517,7 +564,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -525,7 +573,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -533,7 +582,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -541,7 +591,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -549,7 +600,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -557,7 +609,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -565,7 +618,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -573,7 +627,8 @@
                     "startColumn":32,
                     "startLine":57
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -581,7 +636,8 @@
                     "startColumn":12,
                     "startLine":57
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -589,7 +645,8 @@
                     "startColumn":16,
                     "startLine":58
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -623,7 +680,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -631,7 +689,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -639,7 +698,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -647,7 +707,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -655,7 +716,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -663,7 +725,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -671,7 +734,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -679,7 +743,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -687,7 +752,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -695,7 +761,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -703,7 +770,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -711,7 +779,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -719,7 +788,8 @@
                     "startColumn":32,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -727,7 +797,8 @@
                     "startColumn":12,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -735,7 +806,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -769,7 +841,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -777,7 +850,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -785,7 +859,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -793,7 +868,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -801,7 +877,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -809,7 +886,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -817,7 +895,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -825,7 +904,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -833,7 +913,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -841,7 +922,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -849,7 +931,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -857,7 +940,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -865,7 +949,8 @@
                     "startColumn":32,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -873,7 +958,8 @@
                     "startColumn":12,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -881,7 +967,8 @@
                     "startColumn":19,
                     "startLine":65
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -915,7 +1002,8 @@
                     "startColumn":6,
                     "startLine":71
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -923,7 +1011,8 @@
                     "startColumn":12,
                     "startLine":73
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -931,7 +1020,8 @@
                     "startColumn":22,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -939,7 +1029,8 @@
                     "startColumn":13,
                     "startLine":75
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -947,7 +1038,8 @@
                     "startColumn":17,
                     "startLine":76
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -955,7 +1047,8 @@
                     "startColumn":40,
                     "startLine":76
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -963,7 +1056,8 @@
                     "startColumn":40,
                     "startLine":76
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -971,7 +1065,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1005,7 +1100,8 @@
                     "startColumn":6,
                     "startLine":71
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1013,7 +1109,8 @@
                     "startColumn":12,
                     "startLine":73
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1021,7 +1118,8 @@
                     "startColumn":22,
                     "startLine":73
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1029,7 +1127,8 @@
                     "startColumn":13,
                     "startLine":75
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1037,7 +1136,8 @@
                     "startColumn":17,
                     "startLine":76
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1045,7 +1145,8 @@
                     "startColumn":40,
                     "startLine":76
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1053,7 +1154,8 @@
                     "startColumn":40,
                     "startLine":76
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1061,7 +1163,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1095,7 +1198,8 @@
                     "startColumn":6,
                     "startLine":81
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1103,7 +1207,8 @@
                     "startColumn":9,
                     "startLine":83
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1111,7 +1216,8 @@
                     "startColumn":13,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1119,7 +1225,8 @@
                     "startColumn":17,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1127,7 +1234,8 @@
                     "startColumn":40,
                     "startLine":86
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1135,7 +1243,8 @@
                     "startColumn":40,
                     "startLine":86
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1143,7 +1252,8 @@
                     "startColumn":20,
                     "startLine":87
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1177,7 +1287,8 @@
                     "startColumn":6,
                     "startLine":81
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1185,7 +1296,8 @@
                     "startColumn":9,
                     "startLine":83
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1193,7 +1305,8 @@
                     "startColumn":13,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1201,7 +1314,8 @@
                     "startColumn":17,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1209,7 +1323,8 @@
                     "startColumn":40,
                     "startLine":86
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1217,7 +1332,8 @@
                     "startColumn":40,
                     "startLine":86
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1225,7 +1341,8 @@
                     "startColumn":20,
                     "startLine":87
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1259,7 +1376,8 @@
                     "startColumn":6,
                     "startLine":91
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1267,7 +1385,8 @@
                     "startColumn":12,
                     "startLine":93
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1275,7 +1394,8 @@
                     "startColumn":13,
                     "startLine":95
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1283,7 +1403,8 @@
                     "startColumn":17,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1291,7 +1412,8 @@
                     "startColumn":40,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1299,7 +1421,8 @@
                     "startColumn":40,
                     "startLine":96
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1307,7 +1430,8 @@
                     "startColumn":15,
                     "startLine":97
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1341,7 +1465,8 @@
                     "startColumn":6,
                     "startLine":91
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1349,7 +1474,8 @@
                     "startColumn":12,
                     "startLine":93
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1357,7 +1483,8 @@
                     "startColumn":13,
                     "startLine":95
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1365,7 +1492,8 @@
                     "startColumn":17,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1373,7 +1501,8 @@
                     "startColumn":40,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1381,7 +1510,8 @@
                     "startColumn":40,
                     "startLine":96
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1389,7 +1519,8 @@
                     "startColumn":15,
                     "startLine":97
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1423,7 +1554,8 @@
                     "startColumn":6,
                     "startLine":101
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1431,7 +1563,8 @@
                     "startColumn":9,
                     "startLine":103
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1439,7 +1572,8 @@
                     "startColumn":13,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1447,7 +1581,8 @@
                     "startColumn":17,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1455,7 +1590,8 @@
                     "startColumn":40,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1463,7 +1599,8 @@
                     "startColumn":40,
                     "startLine":106
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1471,7 +1608,8 @@
                     "startColumn":15,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -1505,7 +1643,8 @@
                     "startColumn":6,
                     "startLine":101
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1513,7 +1652,8 @@
                     "startColumn":9,
                     "startLine":103
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1521,7 +1661,8 @@
                     "startColumn":13,
                     "startLine":105
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1529,7 +1670,8 @@
                     "startColumn":17,
                     "startLine":106
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1537,7 +1679,8 @@
                     "startColumn":40,
                     "startLine":106
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1545,7 +1688,8 @@
                     "startColumn":40,
                     "startLine":106
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test096.cpp",
@@ -1553,7 +1697,8 @@
                     "startColumn":15,
                     "startLine":107
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-097.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-097.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":32,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":12,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":16,
                     "startLine":51
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -151,7 +162,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":32,
                     "startLine":57
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":12,
                     "startLine":57
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":16,
                     "startLine":58
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -281,7 +305,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":17,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":25,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":13,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":18,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -337,7 +368,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -345,7 +377,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -353,7 +386,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -361,7 +395,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":11,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":32,
                     "startLine":64
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":12,
                     "startLine":64
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":18,
                     "startLine":65
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -427,7 +466,8 @@
                     "startColumn":6,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -435,7 +475,8 @@
                     "startColumn":12,
                     "startLine":74
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -443,7 +484,8 @@
                     "startColumn":22,
                     "startLine":74
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -451,7 +493,8 @@
                     "startColumn":13,
                     "startLine":76
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -459,7 +502,8 @@
                     "startColumn":17,
                     "startLine":77
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -467,7 +511,8 @@
                     "startColumn":40,
                     "startLine":77
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -475,7 +520,8 @@
                     "startColumn":40,
                     "startLine":77
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -483,7 +529,8 @@
                     "startColumn":20,
                     "startLine":78
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -517,7 +564,8 @@
                     "startColumn":6,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -525,7 +573,8 @@
                     "startColumn":9,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -533,7 +582,8 @@
                     "startColumn":13,
                     "startLine":86
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -541,7 +591,8 @@
                     "startColumn":17,
                     "startLine":87
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -549,7 +600,8 @@
                     "startColumn":40,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -557,7 +609,8 @@
                     "startColumn":40,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -565,7 +618,8 @@
                     "startColumn":20,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -599,7 +653,8 @@
                     "startColumn":6,
                     "startLine":92
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -607,7 +662,8 @@
                     "startColumn":12,
                     "startLine":94
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -615,7 +671,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -623,7 +680,8 @@
                     "startColumn":17,
                     "startLine":97
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -631,7 +689,8 @@
                     "startColumn":40,
                     "startLine":97
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -639,7 +698,8 @@
                     "startColumn":40,
                     "startLine":97
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -647,7 +707,8 @@
                     "startColumn":15,
                     "startLine":98
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -681,7 +742,8 @@
                     "startColumn":6,
                     "startLine":102
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -689,7 +751,8 @@
                     "startColumn":9,
                     "startLine":104
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -697,7 +760,8 @@
                     "startColumn":13,
                     "startLine":106
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -705,7 +769,8 @@
                     "startColumn":17,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -713,7 +778,8 @@
                     "startColumn":40,
                     "startLine":107
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -721,7 +787,8 @@
                     "startColumn":40,
                     "startLine":107
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test097.cpp",
@@ -729,7 +796,8 @@
                     "startColumn":15,
                     "startLine":108
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-100.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-100.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":26
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":6,
                     "startLine":29
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":11,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -121,7 +125,8 @@
                     "startColumn":5,
                     "startLine":51
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -137,7 +143,8 @@
                     "startColumn":15,
                     "startLine":54
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":10,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -179,7 +187,8 @@
                     "startColumn":5,
                     "startLine":51
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -187,7 +196,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -195,7 +205,8 @@
                     "startColumn":15,
                     "startLine":54
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -203,7 +214,8 @@
                     "startColumn":10,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -237,7 +249,8 @@
                     "startColumn":9,
                     "startLine":66
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -245,7 +258,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -279,7 +293,8 @@
                     "startColumn":9,
                     "startLine":66
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -287,7 +302,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -321,7 +337,8 @@
                     "startColumn":5,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -329,7 +346,8 @@
                     "startColumn":5,
                     "startLine":74
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -363,7 +381,8 @@
                     "startColumn":6,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -371,7 +390,8 @@
                     "startColumn":12,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -379,7 +399,8 @@
                     "startColumn":12,
                     "startLine":84
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -387,7 +408,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -395,7 +417,8 @@
                     "startColumn":13,
                     "startLine":85
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -403,7 +426,8 @@
                     "startColumn":10,
                     "startLine":86
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -411,7 +435,8 @@
                     "startColumn":17,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -419,7 +444,8 @@
                     "startColumn":19,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test100.cpp",
@@ -427,7 +453,8 @@
                     "startColumn":14,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-101.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-101.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":20,
                     "startLine":26
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":16,
                     "startLine":28
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":38,
                     "startLine":28
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":20,
                     "startLine":28
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":29
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":18,
                     "startLine":30
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":5,
                     "startLine":31
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -161,7 +170,8 @@
                     "startColumn":10,
                     "startLine":36
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":15,
                     "startLine":38
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -203,7 +214,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -211,7 +223,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -219,7 +232,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":15,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -235,7 +250,8 @@
                     "startColumn":14,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -243,7 +259,8 @@
                     "startColumn":15,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":9,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -259,7 +277,8 @@
                     "startColumn":16,
                     "startLine":50
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":9,
                     "startLine":51
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":16,
                     "startLine":54
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":25,
                     "startLine":54
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":25,
                     "startLine":54
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":9,
                     "startLine":55
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":9,
                     "startLine":58
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test101.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":12,
                     "startLine":59
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-102.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-102.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":27,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":20
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":32,
                     "startLine":20
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":20
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":36,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":32,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":17,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -153,7 +161,8 @@
                     "startColumn":36,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -161,7 +170,8 @@
                     "startColumn":13,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":32,
                     "startLine":43
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":17,
                     "startLine":43
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":9,
                     "startLine":44
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":15,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":14,
                     "startLine":47
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test102.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":5,
                     "startLine":49
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-103.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-103.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":20
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":22
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":8,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":8,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":8,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":8,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":9,
                     "startLine":24
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":10,
                     "startLine":25
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":31,
                     "startLine":25
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":26,
                     "startLine":26
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -143,7 +153,8 @@
                     "startColumn":8,
                     "startLine":30
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":8,
                     "startLine":33
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":8,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":8,
                     "startLine":33
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":8,
                     "startLine":33
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":10,
                     "startLine":34
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":10,
                     "startLine":35
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":31,
                     "startLine":35
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":26,
                     "startLine":36
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -249,7 +269,8 @@
                     "startColumn":7,
                     "startLine":40
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -291,7 +313,8 @@
                     "startColumn":7,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":8,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":9,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":22,
                     "startLine":60
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -349,7 +375,8 @@
                     "startColumn":9,
                     "startLine":69
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":23,
                     "startLine":71
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -391,7 +419,8 @@
                     "startColumn":9,
                     "startLine":92
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -399,7 +428,8 @@
                     "startColumn":8,
                     "startLine":94
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -407,7 +437,8 @@
                     "startColumn":9,
                     "startLine":95
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":10,
                     "startLine":97
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":8,
                     "startLine":98
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -465,7 +499,8 @@
                     "startColumn":16,
                     "startLine":101
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -473,7 +508,8 @@
                     "startColumn":21,
                     "startLine":103
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -507,7 +543,8 @@
                     "startColumn":20,
                     "startLine":106
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -515,7 +552,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -523,7 +561,8 @@
                     "startColumn":15,
                     "startLine":109
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -557,7 +596,8 @@
                     "startColumn":20,
                     "startLine":106
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -565,7 +605,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test103.cpp",
@@ -573,7 +614,8 @@
                     "startColumn":15,
                     "startLine":109
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-104.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-104.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":22,
                     "startLine":23
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":28,
                     "startLine":25
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":32,
                     "startLine":25
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":37,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":62,
                     "startLine":25
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":37,
                     "startLine":25
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":62,
                     "startLine":25
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":37,
                     "startLine":25
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":62,
                     "startLine":25
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":37,
                     "startLine":25
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":22
               }
             ]
           }
@@ -239,7 +261,8 @@
                     "startColumn":17,
                     "startLine":32
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":22,
                     "startLine":34
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":23,
                     "startLine":34
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":18,
                     "startLine":36
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":24,
                     "startLine":38
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":28,
                     "startLine":38
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":33,
                     "startLine":38
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":23,
                     "startLine":39
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":58,
                     "startLine":38
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":33,
                     "startLine":38
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":23,
                     "startLine":39
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":58,
                     "startLine":38
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":33,
                     "startLine":38
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":40,
                     "startLine":39
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":23,
                     "startLine":39
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":58,
                     "startLine":38
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":33,
                     "startLine":38
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":24,
                     "startLine":41
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":28,
                     "startLine":41
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":33,
                     "startLine":41
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test104.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":9,
                     "startLine":42
                   }
-                }
+                },
+                "step":33
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-106.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-106.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":11
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":13
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":7,
                     "startLine":14
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":15
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test106.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":19,
                     "startLine":17
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-107.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-107.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":60
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":61
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":61
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":27,
                     "startLine":62
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":5,
                     "startLine":71
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":5,
                     "startLine":70
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":20,
                     "startLine":75
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":20,
                     "startLine":75
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":20,
                     "startLine":76
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":20,
                     "startLine":76
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":11,
                     "startLine":78
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -175,7 +189,8 @@
                     "startColumn":6,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":60
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":14,
                     "startLine":61
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":21,
                     "startLine":61
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":27,
                     "startLine":62
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":5,
                     "startLine":71
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":5,
                     "startLine":70
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":20,
                     "startLine":75
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":20,
                     "startLine":75
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":20,
                     "startLine":76
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":20,
                     "startLine":76
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":20,
                     "startLine":77
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":11,
                     "startLine":78
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":11,
                     "startLine":79
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":12,
                     "startLine":80
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":23,
                     "startLine":80
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test107.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":11,
                     "startLine":81
                   }
-                }
+                },
+                "step":19
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-108.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-108.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":17,
                     "startLine":6
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":40,
                     "startLine":9
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":28,
                     "startLine":10
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":17,
                     "startLine":10
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test108.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":40,
                     "startLine":9
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-109.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-109.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test109.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":8,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test109.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":19,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test109.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":23,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               }
             ]
           }
@@ -327,7 +360,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -511,7 +567,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -519,7 +576,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -527,7 +585,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -535,7 +594,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -543,7 +603,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -551,7 +612,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -559,7 +621,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -567,7 +630,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -575,7 +639,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -583,7 +648,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -591,7 +657,8 @@
                     "startColumn":12,
                     "startLine":111
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -599,7 +666,8 @@
                     "startColumn":12,
                     "startLine":112
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -607,7 +675,8 @@
                     "startColumn":9,
                     "startLine":115
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -615,7 +684,8 @@
                     "startColumn":15,
                     "startLine":117
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -623,7 +693,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -631,7 +702,8 @@
                     "startColumn":14,
                     "startLine":119
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -639,7 +711,8 @@
                     "startColumn":17,
                     "startLine":120
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -647,7 +720,8 @@
                     "startColumn":13,
                     "startLine":121
                   }
-                }
+                },
+                "step":41
               }
             ]
           }
@@ -681,7 +755,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -721,7 +800,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -729,7 +809,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -737,7 +818,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -745,7 +827,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -753,7 +836,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -761,7 +845,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -769,7 +854,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -777,7 +863,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -785,7 +872,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -793,7 +881,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -801,7 +890,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -809,7 +899,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -817,7 +908,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -825,7 +917,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -833,7 +926,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -841,7 +935,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -849,7 +944,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -857,7 +953,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -865,7 +962,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -873,7 +971,8 @@
                     "startColumn":9,
                     "startLine":103
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -881,7 +980,8 @@
                     "startColumn":15,
                     "startLine":133
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -889,7 +989,8 @@
                     "startColumn":27,
                     "startLine":133
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -897,7 +998,8 @@
                     "startColumn":9,
                     "startLine":136
                   }
-                }
+                },
+                "step":28
               }
             ]
           }
@@ -931,7 +1033,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -939,7 +1042,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -947,7 +1051,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -955,7 +1060,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -963,7 +1069,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -971,7 +1078,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -979,7 +1087,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -987,7 +1096,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -995,7 +1105,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1003,7 +1114,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1011,7 +1123,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1019,7 +1132,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1027,7 +1141,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1035,7 +1150,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1043,7 +1159,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1051,7 +1168,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1059,7 +1177,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1067,7 +1186,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1075,7 +1195,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1083,7 +1204,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1091,7 +1213,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1099,7 +1222,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1107,7 +1231,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1115,7 +1240,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1123,7 +1249,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1131,7 +1258,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1139,7 +1267,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1147,7 +1276,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1155,7 +1285,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1163,7 +1294,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1171,7 +1303,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1179,7 +1312,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1187,7 +1321,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1195,7 +1330,8 @@
                     "startColumn":12,
                     "startLine":111
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1203,7 +1339,8 @@
                     "startColumn":12,
                     "startLine":112
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1211,7 +1348,8 @@
                     "startColumn":9,
                     "startLine":115
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1219,7 +1357,8 @@
                     "startColumn":15,
                     "startLine":117
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1227,7 +1366,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1235,7 +1375,8 @@
                     "startColumn":12,
                     "startLine":124
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1243,7 +1384,8 @@
                     "startColumn":15,
                     "startLine":125
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1251,7 +1393,8 @@
                     "startColumn":12,
                     "startLine":126
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1259,7 +1402,8 @@
                     "startColumn":15,
                     "startLine":133
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1267,7 +1411,8 @@
                     "startColumn":27,
                     "startLine":133
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1275,7 +1420,8 @@
                     "startColumn":9,
                     "startLine":136
                   }
-                }
+                },
+                "step":44
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-110.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               }
             ]
           }
@@ -327,7 +360,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -511,7 +567,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -519,7 +576,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -527,7 +585,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -535,7 +594,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -543,7 +603,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -551,7 +612,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -559,7 +621,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -567,7 +630,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -575,7 +639,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -583,7 +648,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -591,7 +657,8 @@
                     "startColumn":12,
                     "startLine":111
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -599,7 +666,8 @@
                     "startColumn":12,
                     "startLine":112
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -607,7 +675,8 @@
                     "startColumn":9,
                     "startLine":115
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -615,7 +684,8 @@
                     "startColumn":15,
                     "startLine":117
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -623,7 +693,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -631,7 +702,8 @@
                     "startColumn":14,
                     "startLine":119
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -639,7 +711,8 @@
                     "startColumn":17,
                     "startLine":120
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -647,7 +720,8 @@
                     "startColumn":13,
                     "startLine":121
                   }
-                }
+                },
+                "step":41
               }
             ]
           }
@@ -681,7 +755,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -721,7 +800,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -729,7 +809,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -737,7 +818,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -745,7 +827,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -753,7 +836,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -761,7 +845,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -769,7 +854,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -777,7 +863,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -785,7 +872,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -793,7 +881,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -801,7 +890,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -809,7 +899,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -817,7 +908,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -825,7 +917,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -833,7 +926,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -841,7 +935,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -849,7 +944,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -857,7 +953,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -865,7 +962,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -873,7 +971,8 @@
                     "startColumn":9,
                     "startLine":103
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -881,7 +980,8 @@
                     "startColumn":15,
                     "startLine":133
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -889,7 +989,8 @@
                     "startColumn":27,
                     "startLine":133
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -897,7 +998,8 @@
                     "startColumn":9,
                     "startLine":136
                   }
-                }
+                },
+                "step":28
               }
             ]
           }
@@ -931,7 +1033,8 @@
                     "startColumn":61,
                     "startLine":82
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -939,7 +1042,8 @@
                     "startColumn":16,
                     "startLine":84
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -947,7 +1051,8 @@
                     "startColumn":15,
                     "startLine":85
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -955,7 +1060,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -963,7 +1069,8 @@
                     "startColumn":9,
                     "startLine":87
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -971,7 +1078,8 @@
                     "startColumn":16,
                     "startLine":87
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -979,7 +1087,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -987,7 +1096,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -995,7 +1105,8 @@
                     "startColumn":9,
                     "startLine":90
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1003,7 +1114,8 @@
                     "startColumn":14,
                     "startLine":91
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1011,7 +1123,8 @@
                     "startColumn":20,
                     "startLine":92
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1019,7 +1132,8 @@
                     "startColumn":14,
                     "startLine":93
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1027,7 +1141,8 @@
                     "startColumn":10,
                     "startLine":95
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1035,7 +1150,8 @@
                     "startColumn":25,
                     "startLine":96
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1043,7 +1159,8 @@
                     "startColumn":11,
                     "startLine":96
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1051,7 +1168,8 @@
                     "startColumn":25,
                     "startLine":97
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1059,7 +1177,8 @@
                     "startColumn":11,
                     "startLine":97
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1067,7 +1186,8 @@
                     "startColumn":25,
                     "startLine":98
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1075,7 +1195,8 @@
                     "startColumn":11,
                     "startLine":98
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1083,7 +1204,8 @@
                     "startColumn":10,
                     "startLine":99
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1091,7 +1213,8 @@
                     "startColumn":25,
                     "startLine":100
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1099,7 +1222,8 @@
                     "startColumn":11,
                     "startLine":100
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1107,7 +1231,8 @@
                     "startColumn":10,
                     "startLine":101
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1115,7 +1240,8 @@
                     "startColumn":12,
                     "startLine":102
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1123,7 +1249,8 @@
                     "startColumn":26,
                     "startLine":102
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1131,7 +1258,8 @@
                     "startColumn":29,
                     "startLine":104
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1139,7 +1267,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1147,7 +1276,8 @@
                     "startColumn":8,
                     "startLine":105
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1155,7 +1285,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1163,7 +1294,8 @@
                     "startColumn":18,
                     "startLine":106
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1171,7 +1303,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1179,7 +1312,8 @@
                     "startColumn":12,
                     "startLine":109
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1187,7 +1321,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1195,7 +1330,8 @@
                     "startColumn":12,
                     "startLine":111
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1203,7 +1339,8 @@
                     "startColumn":12,
                     "startLine":112
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1211,7 +1348,8 @@
                     "startColumn":9,
                     "startLine":115
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1219,7 +1357,8 @@
                     "startColumn":15,
                     "startLine":117
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1227,7 +1366,8 @@
                     "startColumn":31,
                     "startLine":117
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1235,7 +1375,8 @@
                     "startColumn":12,
                     "startLine":124
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1243,7 +1384,8 @@
                     "startColumn":15,
                     "startLine":125
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1251,7 +1393,8 @@
                     "startColumn":12,
                     "startLine":126
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1259,7 +1402,8 @@
                     "startColumn":15,
                     "startLine":133
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1267,7 +1411,8 @@
                     "startColumn":27,
                     "startLine":133
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test110.cpp",
@@ -1275,7 +1420,8 @@
                     "startColumn":9,
                     "startLine":136
                   }
-                }
+                },
+                "step":44
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-111.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-111.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":32,
                     "startLine":120
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":16,
                     "startLine":120
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":20,
                     "startLine":121
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":32,
                     "startLine":123
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":16,
                     "startLine":123
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":36,
                     "startLine":125
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":17,
                     "startLine":127
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":16,
                     "startLine":129
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":21,
                     "startLine":130
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":25,
                     "startLine":131
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":26
               }
             ]
           }
@@ -271,7 +297,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":32,
                     "startLine":120
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":16,
                     "startLine":120
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":20,
                     "startLine":121
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":32,
                     "startLine":123
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":16,
                     "startLine":123
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":36,
                     "startLine":125
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":17,
                     "startLine":127
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":16,
                     "startLine":129
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":21,
                     "startLine":130
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":25,
                     "startLine":131
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":26
               }
             ]
           }
@@ -505,7 +557,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -521,7 +575,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -529,7 +584,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -537,7 +593,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -545,7 +602,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -553,7 +611,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -561,7 +620,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -569,7 +629,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -577,7 +638,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -585,7 +647,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -593,7 +656,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -601,7 +665,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -665,7 +737,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -673,7 +746,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -681,7 +755,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -689,7 +764,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -697,7 +773,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -705,7 +782,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -713,7 +791,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":27
               }
             ]
           }
@@ -747,7 +826,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -755,7 +835,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -819,7 +907,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -827,7 +916,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -835,7 +925,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -843,7 +934,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -851,7 +943,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -859,7 +952,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -867,7 +961,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -875,7 +970,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -883,7 +979,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -891,7 +988,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -899,7 +997,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -907,7 +1006,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -915,7 +1015,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -923,7 +1024,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -931,7 +1033,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -939,7 +1042,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -947,7 +1051,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -955,7 +1060,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -963,7 +1069,8 @@
                     "startColumn":22,
                     "startLine":164
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -971,7 +1078,8 @@
                     "startColumn":30,
                     "startLine":165
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -979,7 +1087,8 @@
                     "startColumn":23,
                     "startLine":190
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -987,7 +1096,8 @@
                     "startColumn":17,
                     "startLine":191
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -995,7 +1105,8 @@
                     "startColumn":16,
                     "startLine":192
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1003,7 +1114,8 @@
                     "startColumn":17,
                     "startLine":193
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1011,7 +1123,8 @@
                     "startColumn":22,
                     "startLine":194
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1019,7 +1132,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1027,7 +1141,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1035,7 +1150,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1043,7 +1159,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1051,7 +1168,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":39
               }
             ]
           }
@@ -1085,7 +1203,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1093,7 +1212,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1101,7 +1221,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1109,7 +1230,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1117,7 +1239,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1125,7 +1248,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1133,7 +1257,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1141,7 +1266,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1149,7 +1275,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1157,7 +1284,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1165,7 +1293,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1173,7 +1302,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1181,7 +1311,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1189,7 +1320,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1197,7 +1329,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1205,7 +1338,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1213,7 +1347,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1221,7 +1356,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1229,7 +1365,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1237,7 +1374,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1245,7 +1383,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1253,7 +1392,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1261,7 +1401,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1269,7 +1410,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1277,7 +1419,8 @@
                     "startColumn":36,
                     "startLine":147
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1285,7 +1428,8 @@
                     "startColumn":20,
                     "startLine":147
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1293,7 +1437,8 @@
                     "startColumn":24,
                     "startLine":148
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1301,7 +1446,8 @@
                     "startColumn":36,
                     "startLine":150
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1309,7 +1455,8 @@
                     "startColumn":20,
                     "startLine":150
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1317,7 +1464,8 @@
                     "startColumn":40,
                     "startLine":152
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1325,7 +1473,8 @@
                     "startColumn":21,
                     "startLine":154
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1333,7 +1482,8 @@
                     "startColumn":20,
                     "startLine":156
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1341,7 +1491,8 @@
                     "startColumn":25,
                     "startLine":157
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1349,7 +1500,8 @@
                     "startColumn":29,
                     "startLine":158
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1357,7 +1509,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1365,7 +1518,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1373,7 +1527,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1381,7 +1536,8 @@
                     "startColumn":22,
                     "startLine":164
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1389,7 +1545,8 @@
                     "startColumn":30,
                     "startLine":165
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1397,7 +1554,8 @@
                     "startColumn":23,
                     "startLine":190
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1405,7 +1563,8 @@
                     "startColumn":17,
                     "startLine":191
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1413,7 +1572,8 @@
                     "startColumn":16,
                     "startLine":192
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1421,7 +1581,8 @@
                     "startColumn":17,
                     "startLine":193
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1429,7 +1590,8 @@
                     "startColumn":22,
                     "startLine":194
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1437,7 +1599,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1445,7 +1608,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1453,7 +1617,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1461,7 +1626,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1469,7 +1635,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":49
               }
             ]
           }
@@ -1503,7 +1670,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1511,7 +1679,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1519,7 +1688,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1527,7 +1697,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1535,7 +1706,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1543,7 +1715,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1551,7 +1724,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1559,7 +1733,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1567,7 +1742,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1575,7 +1751,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1583,7 +1760,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1591,7 +1769,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1599,7 +1778,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1607,7 +1787,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1615,7 +1796,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1623,7 +1805,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1631,7 +1814,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1639,7 +1823,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1647,7 +1832,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1655,7 +1841,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1663,7 +1850,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1671,7 +1859,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1679,7 +1868,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1687,7 +1877,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1695,7 +1886,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1703,7 +1895,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1711,7 +1904,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":27
               }
             ]
           }
@@ -1745,7 +1939,8 @@
                     "startColumn":7,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1753,7 +1948,8 @@
                     "startColumn":9,
                     "startLine":108
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1761,7 +1957,8 @@
                     "startColumn":14,
                     "startLine":108
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1769,7 +1966,8 @@
                     "startColumn":13,
                     "startLine":109
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1777,7 +1975,8 @@
                     "startColumn":11,
                     "startLine":110
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1785,7 +1984,8 @@
                     "startColumn":10,
                     "startLine":111
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1793,7 +1993,8 @@
                     "startColumn":22,
                     "startLine":111
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1801,7 +2002,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1809,7 +2011,8 @@
                     "startColumn":13,
                     "startLine":112
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1817,7 +2020,8 @@
                     "startColumn":22,
                     "startLine":113
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1825,7 +2029,8 @@
                     "startColumn":26,
                     "startLine":114
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1833,7 +2038,8 @@
                     "startColumn":31,
                     "startLine":115
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1841,7 +2047,8 @@
                     "startColumn":11,
                     "startLine":115
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1849,7 +2056,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1857,7 +2065,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1865,7 +2074,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1873,7 +2083,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1881,7 +2092,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1889,7 +2101,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1897,7 +2110,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1905,7 +2119,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1913,7 +2128,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1921,7 +2137,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1929,7 +2146,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1937,7 +2155,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1945,7 +2164,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1953,7 +2173,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1961,7 +2182,8 @@
                     "startColumn":22,
                     "startLine":164
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1969,7 +2191,8 @@
                     "startColumn":30,
                     "startLine":165
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1977,7 +2200,8 @@
                     "startColumn":23,
                     "startLine":190
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1985,7 +2209,8 @@
                     "startColumn":17,
                     "startLine":191
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -1993,7 +2218,8 @@
                     "startColumn":16,
                     "startLine":192
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2001,7 +2227,8 @@
                     "startColumn":17,
                     "startLine":193
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2009,7 +2236,8 @@
                     "startColumn":22,
                     "startLine":194
                   }
-                }
+                },
+                "step":34
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2017,7 +2245,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":35
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2025,7 +2254,8 @@
                     "startColumn":19,
                     "startLine":196
                   }
-                }
+                },
+                "step":36
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2033,7 +2263,8 @@
                     "startColumn":35,
                     "startLine":199
                   }
-                }
+                },
+                "step":37
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2041,7 +2272,8 @@
                     "startColumn":15,
                     "startLine":199
                   }
-                }
+                },
+                "step":38
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2049,7 +2281,8 @@
                     "startColumn":21,
                     "startLine":116
                   }
-                }
+                },
+                "step":39
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2057,7 +2290,8 @@
                     "startColumn":28,
                     "startLine":118
                   }
-                }
+                },
+                "step":40
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2065,7 +2299,8 @@
                     "startColumn":24,
                     "startLine":133
                   }
-                }
+                },
+                "step":41
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2073,7 +2308,8 @@
                     "startColumn":18,
                     "startLine":133
                   }
-                }
+                },
+                "step":42
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2081,7 +2317,8 @@
                     "startColumn":13,
                     "startLine":135
                   }
-                }
+                },
+                "step":43
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2089,7 +2326,8 @@
                     "startColumn":18,
                     "startLine":137
                   }
-                }
+                },
+                "step":44
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2097,7 +2335,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":45
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2105,7 +2344,8 @@
                     "startColumn":12,
                     "startLine":139
                   }
-                }
+                },
+                "step":46
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2113,7 +2353,8 @@
                     "startColumn":18,
                     "startLine":140
                   }
-                }
+                },
+                "step":47
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2121,7 +2362,8 @@
                     "startColumn":20,
                     "startLine":143
                   }
-                }
+                },
+                "step":48
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2129,7 +2371,8 @@
                     "startColumn":20,
                     "startLine":145
                   }
-                }
+                },
+                "step":49
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2137,7 +2380,8 @@
                     "startColumn":21,
                     "startLine":161
                   }
-                }
+                },
+                "step":50
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2145,7 +2389,8 @@
                     "startColumn":16,
                     "startLine":161
                   }
-                }
+                },
+                "step":51
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test111.cpp",
@@ -2153,7 +2398,8 @@
                     "startColumn":17,
                     "startLine":163
                   }
-                }
+                },
+                "step":52
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-112.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-112.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":29
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":32
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":34
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":35
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":18,
                     "startLine":40
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":16,
                     "startLine":41
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":19,
                     "startLine":42
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":12,
                     "startLine":44
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test112.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":34,
                     "startLine":46
                   }
-                }
+                },
+                "step":14
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-113.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-113.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":26
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":28
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":37,
                     "startLine":29
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":5,
                     "startLine":29
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":9,
                     "startLine":56
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":11,
                     "startLine":58
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":19,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":13,
                     "startLine":60
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":30,
                     "startLine":60
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":12,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":9,
                     "startLine":63
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":9,
                     "startLine":88
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":11,
                     "startLine":90
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":19,
                     "startLine":91
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":23,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":21,
                     "startLine":92
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":25,
                     "startLine":92
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":13,
                     "startLine":93
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":9,
                     "startLine":95
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -275,7 +295,8 @@
                     "startColumn":9,
                     "startLine":104
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":11,
                     "startLine":106
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":19,
                     "startLine":107
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":23,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":12,
                     "startLine":108
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":16,
                     "startLine":108
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":10,
                     "startLine":109
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":9,
                     "startLine":111
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -365,7 +393,8 @@
                     "startColumn":6,
                     "startLine":135
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":9,
                     "startLine":137
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -381,7 +411,8 @@
                     "startColumn":9,
                     "startLine":138
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -389,7 +420,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -397,7 +429,8 @@
                     "startColumn":13,
                     "startLine":141
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -405,7 +438,8 @@
                     "startColumn":10,
                     "startLine":143
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":16,
                     "startLine":144
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -421,7 +456,8 @@
                     "startColumn":8,
                     "startLine":144
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -429,7 +465,8 @@
                     "startColumn":12,
                     "startLine":145
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -437,7 +474,8 @@
                     "startColumn":13,
                     "startLine":146
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -471,7 +509,8 @@
                     "startColumn":6,
                     "startLine":135
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -479,7 +518,8 @@
                     "startColumn":9,
                     "startLine":137
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -487,7 +527,8 @@
                     "startColumn":9,
                     "startLine":138
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -495,7 +536,8 @@
                     "startColumn":9,
                     "startLine":139
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -503,7 +545,8 @@
                     "startColumn":13,
                     "startLine":141
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -511,7 +554,8 @@
                     "startColumn":10,
                     "startLine":143
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -519,7 +563,8 @@
                     "startColumn":16,
                     "startLine":144
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -527,7 +572,8 @@
                     "startColumn":8,
                     "startLine":144
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -535,7 +581,8 @@
                     "startColumn":12,
                     "startLine":145
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test113.cpp",
@@ -543,7 +590,8 @@
                     "startColumn":19,
                     "startLine":147
                   }
-                }
+                },
+                "step":10
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-116.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-116.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":1
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":3
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":4
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":4
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":14,
                     "startLine":8
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":16,
                     "startLine":10
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test116.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":12,
                     "startLine":12
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-117.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-117.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":7,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":19
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":20
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":11,
                     "startLine":20
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":23,
                     "startLine":31
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -151,7 +162,8 @@
                     "startColumn":8,
                     "startLine":90
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":12,
                     "startLine":92
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":19,
                     "startLine":92
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":5,
                     "startLine":94
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":11,
                     "startLine":108
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":20,
                     "startLine":108
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":20,
                     "startLine":108
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":9,
                     "startLine":109
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":15,
                     "startLine":111
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":19,
                     "startLine":111
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":18,
                     "startLine":113
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":11,
                     "startLine":114
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":9,
                     "startLine":116
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":25,
                     "startLine":133
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -289,7 +314,8 @@
                     "startColumn":6,
                     "startLine":143
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":9,
                     "startLine":145
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -305,7 +332,8 @@
                     "startColumn":17,
                     "startLine":145
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -313,7 +341,8 @@
                     "startColumn":25,
                     "startLine":145
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -321,7 +350,8 @@
                     "startColumn":5,
                     "startLine":147
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -329,7 +359,8 @@
                     "startColumn":5,
                     "startLine":158
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -337,7 +368,8 @@
                     "startColumn":23,
                     "startLine":163
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -371,7 +403,8 @@
                     "startColumn":6,
                     "startLine":143
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":9,
                     "startLine":145
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":17,
                     "startLine":145
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":25,
                     "startLine":145
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":5,
                     "startLine":147
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":5,
                     "startLine":158
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":5,
                     "startLine":169
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test117.cpp",
@@ -427,7 +466,8 @@
                     "startColumn":22,
                     "startLine":173
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-121.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-121.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":10,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":39
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":41
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":44
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":18,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -127,7 +135,8 @@
                     "startColumn":14,
                     "startLine":59
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":14,
                     "startLine":62
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":14,
                     "startLine":62
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":24,
                     "startLine":62
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":24,
                     "startLine":62
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":14,
                     "startLine":62
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":14,
                     "startLine":62
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":5,
                     "startLine":64
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -217,7 +233,8 @@
                     "startColumn":10,
                     "startLine":90
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":15,
                     "startLine":92
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":25,
                     "startLine":92
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":17,
                     "startLine":93
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test121.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":45,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-122.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-122.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":11,
                     "startLine":50
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":52
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":53
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":57
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":58
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":12,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":26,
                     "startLine":62
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":37,
                     "startLine":61
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":19,
                     "startLine":61
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":26,
                     "startLine":62
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -159,7 +171,8 @@
                     "startColumn":12,
                     "startLine":67
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":19,
                     "startLine":69
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":8,
                     "startLine":71
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":12,
                     "startLine":73
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":38,
                     "startLine":73
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":19,
                     "startLine":73
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test122.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":26,
                     "startLine":74
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-123.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-123.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":19
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":7,
                     "startLine":21
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":24
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":16,
                     "startLine":26
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":16,
                     "startLine":27
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":16,
                     "startLine":28
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":16,
                     "startLine":29
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":16,
                     "startLine":30
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":12,
                     "startLine":32
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test123.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":16,
                     "startLine":34
                   }
-                }
+                },
+                "step":13
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-126.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-126.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test126.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test126.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":19
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test126.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":13,
                     "startLine":21
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test126.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":5,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-127.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-127.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":6
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":10,
                     "startLine":30
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":19,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -137,7 +143,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -145,7 +152,8 @@
                     "startColumn":10,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -153,7 +161,8 @@
                     "startColumn":19,
                     "startLine":37
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -187,7 +196,8 @@
                     "startColumn":6,
                     "startLine":47
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -195,7 +205,8 @@
                     "startColumn":10,
                     "startLine":54
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -203,7 +214,8 @@
                     "startColumn":10,
                     "startLine":55
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -211,7 +223,8 @@
                     "startColumn":13,
                     "startLine":57
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -219,7 +232,8 @@
                     "startColumn":23,
                     "startLine":59
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -227,7 +241,8 @@
                     "startColumn":22,
                     "startLine":60
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -261,7 +276,8 @@
                     "startColumn":6,
                     "startLine":76
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -269,7 +285,8 @@
                     "startColumn":10,
                     "startLine":78
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -277,7 +294,8 @@
                     "startColumn":20,
                     "startLine":79
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -285,7 +303,8 @@
                     "startColumn":25,
                     "startLine":79
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -293,7 +312,8 @@
                     "startColumn":20,
                     "startLine":80
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -301,7 +321,8 @@
                     "startColumn":25,
                     "startLine":80
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -335,7 +356,8 @@
                     "startColumn":6,
                     "startLine":104
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -343,7 +365,8 @@
                     "startColumn":11,
                     "startLine":111
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -351,7 +374,8 @@
                     "startColumn":16,
                     "startLine":111
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -359,7 +383,8 @@
                     "startColumn":9,
                     "startLine":112
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -367,7 +392,8 @@
                     "startColumn":15,
                     "startLine":112
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -375,7 +401,8 @@
                     "startColumn":13,
                     "startLine":113
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -383,7 +410,8 @@
                     "startColumn":18,
                     "startLine":120
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -391,7 +419,8 @@
                     "startColumn":22,
                     "startLine":120
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -399,7 +428,8 @@
                     "startColumn":27,
                     "startLine":120
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -407,7 +437,8 @@
                     "startColumn":16,
                     "startLine":121
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":34,
                     "startLine":120
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":27,
                     "startLine":120
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -431,7 +464,8 @@
                     "startColumn":16,
                     "startLine":121
                   }
-                }
+                },
+                "step":13
               }
             ]
           }
@@ -465,7 +499,8 @@
                     "startColumn":6,
                     "startLine":128
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -473,7 +508,8 @@
                     "startColumn":11,
                     "startLine":130
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -507,7 +543,8 @@
                     "startColumn":6,
                     "startLine":133
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -515,7 +552,8 @@
                     "startColumn":11,
                     "startLine":137
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -523,7 +561,8 @@
                     "startColumn":13,
                     "startLine":138
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -531,7 +570,8 @@
                     "startColumn":21,
                     "startLine":140
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -539,7 +579,8 @@
                     "startColumn":21,
                     "startLine":142
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -547,7 +588,8 @@
                     "startColumn":21,
                     "startLine":144
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -581,7 +623,8 @@
                     "startColumn":6,
                     "startLine":147
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -589,7 +632,8 @@
                     "startColumn":11,
                     "startLine":151
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -597,7 +641,8 @@
                     "startColumn":13,
                     "startLine":152
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -605,7 +650,8 @@
                     "startColumn":19,
                     "startLine":154
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -613,7 +659,8 @@
                     "startColumn":19,
                     "startLine":156
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test127.cpp",
@@ -621,7 +668,8 @@
                     "startColumn":19,
                     "startLine":158
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-128.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-128.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":58
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":17,
                     "startLine":65
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":67
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":22,
                     "startLine":70
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":71
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":20,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":11,
                     "startLine":73
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":33,
                     "startLine":74
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -127,7 +135,8 @@
                     "startColumn":6,
                     "startLine":58
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":17,
                     "startLine":65
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":18,
                     "startLine":67
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":22,
                     "startLine":70
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":19,
                     "startLine":71
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":20,
                     "startLine":72
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":11,
                     "startLine":73
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":33,
                     "startLine":74
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test128.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":5,
                     "startLine":76
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-129.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-129.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":26,
                     "startLine":32
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":26,
                     "startLine":32
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":5,
                     "startLine":33
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":36
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":10,
                     "startLine":40
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":19,
                     "startLine":40
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":11,
                     "startLine":41
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":5,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -169,7 +179,8 @@
                     "startColumn":7,
                     "startLine":45
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":21,
                     "startLine":51
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":12,
                     "startLine":51
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test129.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":30,
                     "startLine":52
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-130.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-130.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":90
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":92
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":18,
                     "startLine":93
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":94
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":13,
                     "startLine":97
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":15,
                     "startLine":98
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":18,
                     "startLine":99
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":20,
                     "startLine":100
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":7,
                     "startLine":102
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":13,
                     "startLine":103
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -175,7 +189,8 @@
                     "startColumn":6,
                     "startLine":86
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":13,
                     "startLine":90
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":13,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":15,
                     "startLine":92
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":18,
                     "startLine":93
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":18,
                     "startLine":94
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":13,
                     "startLine":96
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":13,
                     "startLine":97
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":15,
                     "startLine":98
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":18,
                     "startLine":99
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":20,
                     "startLine":100
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":7,
                     "startLine":102
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":13,
                     "startLine":103
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":7,
                     "startLine":105
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":9,
                     "startLine":106
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test130.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":21,
                     "startLine":106
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-131.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-131.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":15
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":17
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":17
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":18
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":16,
                     "startLine":18
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":5,
                     "startLine":20
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":5,
                     "startLine":22
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test131.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":5,
                     "startLine":24
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-132.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-132.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":14
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":16
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":17
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":30,
                     "startLine":17
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":30,
                     "startLine":17
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":18
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":45
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":11,
                     "startLine":47
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":18,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":30,
                     "startLine":48
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":14,
                     "startLine":49
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":6,
                     "startLine":103
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":19,
                     "startLine":105
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":11,
                     "startLine":106
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":18,
                     "startLine":107
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":27,
                     "startLine":107
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":11,
                     "startLine":109
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":28,
                     "startLine":110
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":17,
                     "startLine":111
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":35,
                     "startLine":111
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":24,
                     "startLine":111
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test132.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":19,
                     "startLine":112
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-134.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-134.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":37
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":41
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":9,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":9,
                     "startLine":37
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test134.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":14,
                     "startLine":41
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-136.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-136.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":81
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":47,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":8,
                     "startLine":91
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":37,
                     "startLine":98
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":81
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":11,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":47,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":8,
                     "startLine":91
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":37,
                     "startLine":98
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":50,
                     "startLine":99
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":22,
                     "startLine":101
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -217,7 +233,8 @@
                     "startColumn":6,
                     "startLine":81
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":11,
                     "startLine":88
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":9,
                     "startLine":89
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":47,
                     "startLine":91
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":8,
                     "startLine":91
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":10,
                     "startLine":93
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":37,
                     "startLine":98
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":50,
                     "startLine":99
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":22,
                     "startLine":101
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":21,
                     "startLine":102
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -297,7 +323,8 @@
                     "startColumn":34,
                     "startLine":103
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -331,7 +358,8 @@
                     "startColumn":6,
                     "startLine":145
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":20,
                     "startLine":147
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":18,
                     "startLine":148
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":25,
                     "startLine":148
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":12,
                     "startLine":150
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":9,
                     "startLine":151
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":18,
                     "startLine":153
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":13,
                     "startLine":155
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":12,
                     "startLine":158
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":9,
                     "startLine":159
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":17,
                     "startLine":161
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test136.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":17,
                     "startLine":162
                   }
-                }
+                },
+                "step":12
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-137.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-137.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":49,
                     "startLine":48
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":48
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":25,
                     "startLine":49
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":52
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":50,
                     "startLine":57
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":11,
                     "startLine":57
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test137.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":25,
                     "startLine":58
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-138.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-138.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":14,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":23,
                     "startLine":15
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test138.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":20,
                     "startLine":18
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-139.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-139.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":5,
                     "startLine":14
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":16
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":19,
                     "startLine":16
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":19,
                     "startLine":18
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":19,
                     "startLine":18
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":5,
                     "startLine":20
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":23
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":23,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":31,
                     "startLine":27
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":23,
                     "startLine":28
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":35,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -185,7 +197,8 @@
                     "startColumn":6,
                     "startLine":48
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":10,
                     "startLine":50
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":11,
                     "startLine":51
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":38,
                     "startLine":51
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":20,
                     "startLine":51
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":9,
                     "startLine":53
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":13,
                     "startLine":55
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":23,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test139.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":24,
                     "startLine":62
                   }
-                }
+                },
+                "step":9
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-140.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-140.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":28,
                     "startLine":53
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -319,7 +351,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -367,7 +405,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -375,7 +414,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -383,7 +423,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -391,7 +432,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -399,7 +441,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -407,7 +450,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -415,7 +459,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -423,7 +468,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -431,7 +477,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -439,7 +486,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -447,7 +495,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -455,7 +504,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -463,7 +513,8 @@
                     "startColumn":24,
                     "startLine":57
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -471,7 +522,8 @@
                     "startColumn":15,
                     "startLine":57
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -479,7 +531,8 @@
                     "startColumn":28,
                     "startLine":58
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -487,7 +540,8 @@
                     "startColumn":15,
                     "startLine":58
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -495,7 +549,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -503,7 +558,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -511,7 +567,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -519,7 +576,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -527,7 +585,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -535,7 +594,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -543,7 +603,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -551,7 +612,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -559,7 +621,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -567,7 +630,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -601,7 +665,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -609,7 +674,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -617,7 +683,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -625,7 +692,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -633,7 +701,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -641,7 +710,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -649,7 +719,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -657,7 +728,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -665,7 +737,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -673,7 +746,8 @@
                     "startColumn":18,
                     "startLine":62
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -681,7 +755,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -715,7 +790,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -739,7 +817,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -747,7 +826,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -755,7 +835,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -763,7 +844,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -771,7 +853,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -779,7 +862,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -787,7 +871,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -795,7 +880,8 @@
                     "startColumn":24,
                     "startLine":52
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -803,7 +889,8 @@
                     "startColumn":15,
                     "startLine":52
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -811,7 +898,8 @@
                     "startColumn":28,
                     "startLine":53
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -819,7 +907,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -827,7 +916,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -835,7 +925,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -843,7 +934,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -851,7 +943,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -859,7 +952,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -867,7 +961,8 @@
                     "startColumn":18,
                     "startLine":62
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -875,7 +970,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":21
               }
             ]
           }
@@ -909,7 +1005,8 @@
                     "startColumn":10,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -917,7 +1014,8 @@
                     "startColumn":9,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -925,7 +1023,8 @@
                     "startColumn":13,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -933,7 +1032,8 @@
                     "startColumn":9,
                     "startLine":46
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -941,7 +1041,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -949,7 +1050,8 @@
                     "startColumn":25,
                     "startLine":46
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -957,7 +1059,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -965,7 +1068,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -973,7 +1077,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -981,7 +1086,8 @@
                     "startColumn":17,
                     "startLine":50
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -989,7 +1095,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -997,7 +1104,8 @@
                     "startColumn":17,
                     "startLine":55
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1005,7 +1113,8 @@
                     "startColumn":24,
                     "startLine":57
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1013,7 +1122,8 @@
                     "startColumn":15,
                     "startLine":57
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1021,7 +1131,8 @@
                     "startColumn":28,
                     "startLine":58
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1029,7 +1140,8 @@
                     "startColumn":15,
                     "startLine":58
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1037,7 +1149,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1045,7 +1158,8 @@
                     "startColumn":16,
                     "startLine":48
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1053,7 +1167,8 @@
                     "startColumn":11,
                     "startLine":61
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1061,7 +1176,8 @@
                     "startColumn":18,
                     "startLine":62
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test140.cpp",
@@ -1069,7 +1185,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":21
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":19,
                     "startLine":47
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":30,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":52
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":19,
                     "startLine":53
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":30,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":20,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":9,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":11,
                     "startLine":83
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":26,
                     "startLine":85
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":16,
                     "startLine":86
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":14,
                     "startLine":87
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":28,
                     "startLine":99
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":9,
                     "startLine":101
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":11,
                     "startLine":102
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":24,
                     "startLine":104
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":14,
                     "startLine":106
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-141.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":47
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":49
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":30,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":52
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":19,
                     "startLine":53
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":55
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":79
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":20,
                     "startLine":81
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":9,
                     "startLine":82
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":11,
                     "startLine":83
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":26,
                     "startLine":85
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":16,
                     "startLine":86
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":14,
                     "startLine":87
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":6,
                     "startLine":99
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":9,
                     "startLine":101
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":11,
                     "startLine":102
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":24,
                     "startLine":104
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":16,
                     "startLine":105
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test141.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":14,
                     "startLine":106
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-146.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-146.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":157
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":159
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":160
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":161
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":7,
                     "startLine":161
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":14,
                     "startLine":162
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":165
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":9,
                     "startLine":167
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":16,
                     "startLine":168
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":11,
                     "startLine":169
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":14,
                     "startLine":170
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -177,7 +188,8 @@
                     "startColumn":6,
                     "startLine":173
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":9,
                     "startLine":175
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":16,
                     "startLine":176
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":20,
                     "startLine":176
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":11,
                     "startLine":177
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":7,
                     "startLine":178
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":14,
                     "startLine":179
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -259,7 +277,8 @@
                     "startColumn":6,
                     "startLine":225
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -267,7 +286,8 @@
                     "startColumn":9,
                     "startLine":227
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -275,7 +295,8 @@
                     "startColumn":20,
                     "startLine":227
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -283,7 +304,8 @@
                     "startColumn":20,
                     "startLine":227
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -291,7 +313,8 @@
                     "startColumn":8,
                     "startLine":228
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -299,7 +322,8 @@
                     "startColumn":5,
                     "startLine":229
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -333,7 +357,8 @@
                     "startColumn":6,
                     "startLine":225
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -341,7 +366,8 @@
                     "startColumn":9,
                     "startLine":227
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -349,7 +375,8 @@
                     "startColumn":20,
                     "startLine":227
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -357,7 +384,8 @@
                     "startColumn":20,
                     "startLine":227
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -365,7 +393,8 @@
                     "startColumn":8,
                     "startLine":228
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test146.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":5,
                     "startLine":229
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-150.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-150.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":18
                   }
-                }
+                },
+                "step":1
               }
             ]
           }
@@ -71,7 +72,8 @@
                     "startColumn":5,
                     "startLine":23
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test150.cpp",
@@ -79,7 +81,8 @@
                     "startColumn":5,
                     "startLine":25
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -113,7 +116,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test150.cpp",
@@ -121,7 +125,8 @@
                     "startColumn":9,
                     "startLine":30
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test150.cpp",
@@ -129,7 +134,8 @@
                     "startColumn":19,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -163,7 +169,8 @@
                     "startColumn":6,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test150.cpp",
@@ -171,7 +178,8 @@
                     "startColumn":5,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-152.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-152.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test152.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":27
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test152.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":19,
                     "startLine":27
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test152.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":5,
                     "startLine":28
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-155.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-155.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":44
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":46
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":47
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":47
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":48
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":51
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":10,
                     "startLine":53
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":11,
                     "startLine":54
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":17,
                     "startLine":54
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":16,
                     "startLine":55
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":56
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":10,
                     "startLine":57
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -193,7 +206,8 @@
                     "startColumn":6,
                     "startLine":61
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":10,
                     "startLine":63
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":11,
                     "startLine":64
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":17,
                     "startLine":64
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":11,
                     "startLine":65
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":15,
                     "startLine":65
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test155.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":10,
                     "startLine":66
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-156.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-156.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":22,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":10,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":16,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":22,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":10,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":10,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":10,
                     "startLine":15
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -201,7 +215,8 @@
                     "startColumn":6,
                     "startLine":27
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":25,
                     "startLine":29
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -243,7 +259,8 @@
                     "startColumn":6,
                     "startLine":42
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -251,7 +268,8 @@
                     "startColumn":25,
                     "startLine":44
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -285,7 +303,8 @@
                     "startColumn":6,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -293,7 +312,8 @@
                     "startColumn":25,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -327,7 +347,8 @@
                     "startColumn":6,
                     "startLine":92
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -335,7 +356,8 @@
                     "startColumn":47,
                     "startLine":94
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -343,7 +365,8 @@
                     "startColumn":22,
                     "startLine":94
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -351,7 +374,8 @@
                     "startColumn":22,
                     "startLine":95
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -359,7 +383,8 @@
                     "startColumn":29,
                     "startLine":96
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test156.cpp",
@@ -367,7 +392,8 @@
                     "startColumn":25,
                     "startLine":99
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-157.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-157.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":34
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":36
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":37
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":21,
                     "startLine":37
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":17,
                     "startLine":39
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":31,
                     "startLine":40
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":43
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":14,
                     "startLine":45
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":17,
                     "startLine":46
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test157.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":27,
                     "startLine":47
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-160.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-160.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":28
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":14,
                     "startLine":30
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":31
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":35
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -119,7 +126,8 @@
                     "startColumn":6,
                     "startLine":50
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":20,
                     "startLine":52
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":9,
                     "startLine":53
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":11,
                     "startLine":55
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":11,
                     "startLine":56
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":13,
                     "startLine":57
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":15,
                     "startLine":59
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":15,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":19,
                     "startLine":64
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":15,
                     "startLine":67
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":15,
                     "startLine":68
                   }
-                }
+                },
+                "step":11
               }
             ]
           }
@@ -233,7 +251,8 @@
                     "startColumn":6,
                     "startLine":72
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":14,
                     "startLine":74
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":9,
                     "startLine":75
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":11,
                     "startLine":77
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":13,
                     "startLine":78
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":15,
                     "startLine":80
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -281,7 +305,8 @@
                     "startColumn":11,
                     "startLine":83
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -289,7 +314,8 @@
                     "startColumn":15,
                     "startLine":84
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -323,7 +349,8 @@
                     "startColumn":6,
                     "startLine":94
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":22,
                     "startLine":96
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":9,
                     "startLine":97
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":13,
                     "startLine":99
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":15,
                     "startLine":101
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":11,
                     "startLine":104
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":15,
                     "startLine":105
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -405,7 +438,8 @@
                     "startColumn":6,
                     "startLine":108
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -413,7 +447,8 @@
                     "startColumn":14,
                     "startLine":110
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -421,7 +456,8 @@
                     "startColumn":9,
                     "startLine":111
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -429,7 +465,8 @@
                     "startColumn":15,
                     "startLine":113
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -437,7 +474,8 @@
                     "startColumn":15,
                     "startLine":115
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -445,7 +483,8 @@
                     "startColumn":11,
                     "startLine":118
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -453,7 +492,8 @@
                     "startColumn":15,
                     "startLine":119
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -487,7 +527,8 @@
                     "startColumn":6,
                     "startLine":147
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -495,7 +536,8 @@
                     "startColumn":14,
                     "startLine":149
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -503,7 +545,8 @@
                     "startColumn":9,
                     "startLine":150
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -511,7 +554,8 @@
                     "startColumn":14,
                     "startLine":152
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -519,7 +563,8 @@
                     "startColumn":15,
                     "startLine":154
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -527,7 +572,8 @@
                     "startColumn":11,
                     "startLine":157
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -535,7 +581,8 @@
                     "startColumn":15,
                     "startLine":158
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -569,7 +616,8 @@
                     "startColumn":6,
                     "startLine":161
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -577,7 +625,8 @@
                     "startColumn":14,
                     "startLine":163
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -585,7 +634,8 @@
                     "startColumn":9,
                     "startLine":164
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -593,7 +643,8 @@
                     "startColumn":16,
                     "startLine":166
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -601,7 +652,8 @@
                     "startColumn":15,
                     "startLine":168
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -609,7 +661,8 @@
                     "startColumn":11,
                     "startLine":171
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -617,7 +670,8 @@
                     "startColumn":15,
                     "startLine":172
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -651,7 +705,8 @@
                     "startColumn":6,
                     "startLine":186
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -659,7 +714,8 @@
                     "startColumn":17,
                     "startLine":188
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -667,7 +723,8 @@
                     "startColumn":9,
                     "startLine":189
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -675,7 +732,8 @@
                     "startColumn":13,
                     "startLine":191
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -683,7 +741,8 @@
                     "startColumn":15,
                     "startLine":193
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -691,7 +750,8 @@
                     "startColumn":11,
                     "startLine":196
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test160.cpp",
@@ -699,7 +759,8 @@
                     "startColumn":15,
                     "startLine":197
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-162.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-162.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":10,
                     "startLine":22
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test162.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":24
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test162.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":26,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test162.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test162.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":26,
                     "startLine":26
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-163.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-163.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":26,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":37,
                     "startLine":29
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":20,
                     "startLine":29
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":19
               }
             ]
           }
@@ -215,7 +234,8 @@
                     "startColumn":26,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":13,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":18,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -335,7 +369,8 @@
                     "startColumn":37,
                     "startLine":29
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -343,7 +378,8 @@
                     "startColumn":20,
                     "startLine":29
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -351,7 +387,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -359,7 +396,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":19
               }
             ]
           }
@@ -393,7 +431,8 @@
                     "startColumn":26,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":13,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":18,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -449,7 +494,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -457,7 +503,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -465,7 +512,8 @@
                     "startColumn":37,
                     "startLine":29
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -473,7 +521,8 @@
                     "startColumn":20,
                     "startLine":29
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -481,7 +530,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -489,7 +539,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -497,7 +548,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -505,7 +557,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -513,7 +566,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -521,7 +575,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":17
               }
             ]
           }
@@ -555,7 +610,8 @@
                     "startColumn":26,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -563,7 +619,8 @@
                     "startColumn":13,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -571,7 +628,8 @@
                     "startColumn":18,
                     "startLine":19
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -579,7 +637,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -587,7 +646,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -595,7 +655,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -603,7 +664,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -611,7 +673,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -619,7 +682,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -627,7 +691,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -635,7 +700,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -643,7 +709,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -651,7 +718,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -659,7 +727,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -667,7 +736,8 @@
                     "startColumn":25,
                     "startLine":27
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -675,7 +745,8 @@
                     "startColumn":37,
                     "startLine":29
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -683,7 +754,8 @@
                     "startColumn":20,
                     "startLine":29
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -691,7 +763,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -699,7 +772,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -707,7 +781,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -715,7 +790,8 @@
                     "startColumn":18,
                     "startLine":25
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -723,7 +799,8 @@
                     "startColumn":17,
                     "startLine":21
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test163.cpp",
@@ -731,7 +808,8 @@
                     "startColumn":29,
                     "startLine":23
                   }
-                }
+                },
+                "step":23
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-166.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-166.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":17
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test166.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":19
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test166.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":21
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test166.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":22
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-167.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-167.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":15,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":10
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":18,
                     "startLine":11
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":14
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test167.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":24,
                     "startLine":15
                   }
-                }
+                },
+                "step":7
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-168.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-168.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":9
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":11
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":11,
                     "startLine":12
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":14,
                     "startLine":14
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":15
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":11,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":6,
                     "startLine":20
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":9,
                     "startLine":22
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":11,
                     "startLine":23
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":14,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":9,
                     "startLine":26
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test168.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":11,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-169.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-169.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test169.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":5,
                     "startLine":21
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":9,
                     "startLine":25
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test169.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":5,
                     "startLine":27
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-170.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-170.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":47
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":49
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":50
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":10,
                     "startLine":52
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":10,
                     "startLine":53
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":54
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":13,
                     "startLine":56
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":17,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":32,
                     "startLine":61
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":21,
                     "startLine":61
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test170.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":8,
                     "startLine":62
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-171.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-171.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":8
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":20,
                     "startLine":10
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":18,
                     "startLine":11
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":13,
                     "startLine":12
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":13,
                     "startLine":13
                   }
-                }
+                },
+                "step":5
               }
             ]
           }
@@ -103,7 +108,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":20,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":18,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":17,
                     "startLine":25
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":13,
                     "startLine":26
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":13,
                     "startLine":27
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -177,7 +188,8 @@
                     "startColumn":6,
                     "startLine":37
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":20,
                     "startLine":39
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":18,
                     "startLine":40
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":12,
                     "startLine":42
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":14,
                     "startLine":44
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":12,
                     "startLine":50
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":13,
                     "startLine":52
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test171.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":13,
                     "startLine":53
                   }
-                }
+                },
+                "step":8
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-172.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-172.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":14,
                     "startLine":132
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test172.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":18,
                     "startLine":136
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test172.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":27,
                     "startLine":136
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test172.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":138
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test172.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":141
                   }
-                }
+                },
+                "step":5
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-173.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-173.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":7,
                     "startLine":6
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":15,
                     "startLine":8
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":23,
                     "startLine":8
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":11
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":24,
                     "startLine":11
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":12
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":12
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":16,
                     "startLine":14
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":28,
                     "startLine":14
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":28,
                     "startLine":14
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test173.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-178.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-178.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":21
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":17,
                     "startLine":23
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":24
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":11,
                     "startLine":26
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":27
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":13,
                     "startLine":28
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":15,
                     "startLine":30
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":15,
                     "startLine":32
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":19,
                     "startLine":35
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":15,
                     "startLine":38
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test178.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":15,
                     "startLine":39
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-179.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-179.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":44
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test179.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":42,
                     "startLine":46
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test179.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":95,
                     "startLine":46
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test179.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":48
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test179.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":15,
                     "startLine":48
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test179.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":51
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-180.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-180.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":26
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":24,
                     "startLine":31
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":23,
                     "startLine":32
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":33
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":51,
                     "startLine":33
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":31,
                     "startLine":33
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":24,
                     "startLine":35
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":14,
                     "startLine":36
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":18,
                     "startLine":36
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":28,
                     "startLine":37
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":28,
                     "startLine":38
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":22,
                     "startLine":39
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":28,
                     "startLine":40
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":30,
                     "startLine":36
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":28,
                     "startLine":37
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":28,
                     "startLine":38
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":22,
                     "startLine":39
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":28,
                     "startLine":40
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":30,
                     "startLine":36
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":28,
                     "startLine":37
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":28,
                     "startLine":38
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":22,
                     "startLine":39
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":28,
                     "startLine":40
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":30,
                     "startLine":36
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":23,
                     "startLine":36
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test180.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":23,
                     "startLine":42
                   }
-                }
+                },
+                "step":29
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-181.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-181.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":3,
                     "startLine":152
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/utility",
@@ -45,7 +46,8 @@
                     "startColumn":32,
                     "startLine":155
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/utility",
@@ -53,7 +55,8 @@
                     "startColumn":32,
                     "startLine":155
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/utility",
@@ -61,7 +64,8 @@
                     "startColumn":32,
                     "startLine":156
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-182.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-182.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":7
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test182.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":9
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test182.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":20,
                     "startLine":9
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test182.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":20,
                     "startLine":9
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test182.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":14
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test182.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":17
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-185.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-185.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":20
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":22
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":14,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":15,
                     "startLine":23
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -95,7 +99,8 @@
                     "startColumn":6,
                     "startLine":53
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":10,
                     "startLine":55
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":14,
                     "startLine":55
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test185.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":15,
                     "startLine":56
                   }
-                }
+                },
+                "step":4
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-186.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-186.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":20,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":10,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":20,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":20,
                     "startLine":11
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":20,
                     "startLine":11
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":12,
                     "startLine":9
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":20,
                     "startLine":11
                   }
-                }
+                },
+                "step":12
               }
             ]
           }
@@ -159,7 +171,8 @@
                     "startColumn":6,
                     "startLine":15
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":12,
                     "startLine":17
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":20,
                     "startLine":17
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":10,
                     "startLine":18
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":24,
                     "startLine":23
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":16,
                     "startLine":21
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test186.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":24,
                     "startLine":23
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-188.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-188.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":3
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":12,
                     "startLine":5
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":22,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":6
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":18,
                     "startLine":6
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":10,
                     "startLine":7
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":18,
                     "startLine":7
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":18,
                     "startLine":7
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":11,
                     "startLine":8
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":16,
                     "startLine":9
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":27,
                     "startLine":9
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":20,
                     "startLine":10
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":12,
                     "startLine":16
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":11,
                     "startLine":8
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":16,
                     "startLine":9
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":27,
                     "startLine":9
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":20,
                     "startLine":10
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -181,7 +199,8 @@
                     "startColumn":19,
                     "startLine":12
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -189,7 +208,8 @@
                     "startColumn":17,
                     "startLine":12
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -197,7 +217,8 @@
                     "startColumn":21,
                     "startLine":13
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -205,7 +226,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -213,7 +235,8 @@
                     "startColumn":12,
                     "startLine":16
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -221,7 +244,8 @@
                     "startColumn":11,
                     "startLine":8
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -229,7 +253,8 @@
                     "startColumn":16,
                     "startLine":9
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -237,7 +262,8 @@
                     "startColumn":27,
                     "startLine":9
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -245,7 +271,8 @@
                     "startColumn":20,
                     "startLine":10
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -253,7 +280,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -261,7 +289,8 @@
                     "startColumn":12,
                     "startLine":16
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -269,7 +298,8 @@
                     "startColumn":11,
                     "startLine":8
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -277,7 +307,8 @@
                     "startColumn":16,
                     "startLine":9
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -285,7 +316,8 @@
                     "startColumn":27,
                     "startLine":9
                   }
-                }
+                },
+                "step":32
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -293,7 +325,8 @@
                     "startColumn":20,
                     "startLine":10
                   }
-                }
+                },
+                "step":33
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test188.cpp",
@@ -301,7 +334,8 @@
                     "startColumn":18,
                     "startLine":15
                   }
-                }
+                },
+                "step":34
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-192.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-192.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":1,
                     "startLine":109
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/stralign.h",
@@ -45,7 +46,8 @@
                     "startColumn":18,
                     "startLine":120
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/stralign.h",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":120
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":203,
                     "startLine":725
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/tchar.h",
@@ -95,7 +99,8 @@
                     "startColumn":12,
                     "startLine":731
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/tchar.h",
@@ -103,7 +108,8 @@
                     "startColumn":46,
                     "startLine":731
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/tchar.h",
@@ -111,7 +117,8 @@
                     "startColumn":29,
                     "startLine":731
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -145,7 +152,8 @@
                     "startColumn":29,
                     "startLine":770
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/tchar.h",
@@ -153,7 +161,8 @@
                     "startColumn":19,
                     "startLine":781
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -187,7 +196,8 @@
                     "startColumn":1,
                     "startLine":1459
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -195,7 +205,8 @@
                     "startColumn":13,
                     "startLine":1467
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -203,7 +214,8 @@
                     "startColumn":12,
                     "startLine":1468
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -211,7 +223,8 @@
                     "startColumn":29,
                     "startLine":1468
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -219,7 +232,8 @@
                     "startColumn":31,
                     "startLine":1470
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -227,7 +241,8 @@
                     "startColumn":8,
                     "startLine":1470
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -235,7 +250,8 @@
                     "startColumn":26,
                     "startLine":1472
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -243,7 +259,8 @@
                     "startColumn":24,
                     "startLine":1474
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -251,7 +268,8 @@
                     "startColumn":37,
                     "startLine":1474
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -259,7 +277,8 @@
                     "startColumn":16,
                     "startLine":1475
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -267,7 +286,8 @@
                     "startColumn":31,
                     "startLine":1475
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -275,7 +295,8 @@
                     "startColumn":34,
                     "startLine":1477
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -283,7 +304,8 @@
                     "startColumn":12,
                     "startLine":1477
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -291,7 +313,8 @@
                     "startColumn":30,
                     "startLine":1479
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -299,7 +322,8 @@
                     "startColumn":25,
                     "startLine":1481
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -307,7 +331,8 @@
                     "startColumn":20,
                     "startLine":1483
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -315,7 +340,8 @@
                     "startColumn":21,
                     "startLine":1485
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -323,7 +349,8 @@
                     "startColumn":30,
                     "startLine":1543
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -331,7 +358,8 @@
                     "startColumn":22,
                     "startLine":1544
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -339,7 +367,8 @@
                     "startColumn":30,
                     "startLine":1556
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -347,7 +376,8 @@
                     "startColumn":43,
                     "startLine":1556
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -355,7 +385,8 @@
                     "startColumn":5,
                     "startLine":1575
                   }
-                }
+                },
+                "step":22
               }
             ]
           }
@@ -389,7 +420,8 @@
                     "startColumn":1,
                     "startLine":2571
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -397,7 +429,8 @@
                     "startColumn":13,
                     "startLine":2580
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -405,7 +438,8 @@
                     "startColumn":12,
                     "startLine":2581
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -413,7 +447,8 @@
                     "startColumn":29,
                     "startLine":2581
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -421,7 +456,8 @@
                     "startColumn":31,
                     "startLine":2583
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -429,7 +465,8 @@
                     "startColumn":8,
                     "startLine":2583
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -437,7 +474,8 @@
                     "startColumn":26,
                     "startLine":2585
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -445,7 +483,8 @@
                     "startColumn":24,
                     "startLine":2587
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -453,7 +492,8 @@
                     "startColumn":37,
                     "startLine":2587
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -461,7 +501,8 @@
                     "startColumn":16,
                     "startLine":2588
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -469,7 +510,8 @@
                     "startColumn":31,
                     "startLine":2588
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -477,7 +519,8 @@
                     "startColumn":16,
                     "startLine":2589
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -485,7 +528,8 @@
                     "startColumn":37,
                     "startLine":2589
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -493,7 +537,8 @@
                     "startColumn":34,
                     "startLine":2591
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -527,7 +572,8 @@
                     "startColumn":1,
                     "startLine":4631
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -535,7 +581,8 @@
                     "startColumn":13,
                     "startLine":4640
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -543,7 +590,8 @@
                     "startColumn":12,
                     "startLine":4641
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -551,7 +599,8 @@
                     "startColumn":29,
                     "startLine":4641
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -559,7 +608,8 @@
                     "startColumn":12,
                     "startLine":4642
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -567,7 +617,8 @@
                     "startColumn":40,
                     "startLine":4644
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -575,7 +626,8 @@
                     "startColumn":8,
                     "startLine":4644
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -583,7 +635,8 @@
                     "startColumn":26,
                     "startLine":4650
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -591,7 +644,8 @@
                     "startColumn":24,
                     "startLine":4652
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -599,7 +653,8 @@
                     "startColumn":45,
                     "startLine":4652
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -607,7 +662,8 @@
                     "startColumn":16,
                     "startLine":4653
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -615,7 +671,8 @@
                     "startColumn":39,
                     "startLine":4653
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -623,7 +680,8 @@
                     "startColumn":16,
                     "startLine":4654
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -631,7 +689,8 @@
                     "startColumn":41,
                     "startLine":4654
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -639,7 +698,8 @@
                     "startColumn":34,
                     "startLine":4656
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -673,7 +733,8 @@
                     "startColumn":1,
                     "startLine":6791
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -681,7 +742,8 @@
                     "startColumn":13,
                     "startLine":6800
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -689,7 +751,8 @@
                     "startColumn":12,
                     "startLine":6801
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -697,7 +760,8 @@
                     "startColumn":29,
                     "startLine":6801
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -705,7 +769,8 @@
                     "startColumn":31,
                     "startLine":6803
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -713,7 +778,8 @@
                     "startColumn":8,
                     "startLine":6803
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -721,7 +787,8 @@
                     "startColumn":26,
                     "startLine":6805
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -729,7 +796,8 @@
                     "startColumn":24,
                     "startLine":6807
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -737,7 +805,8 @@
                     "startColumn":37,
                     "startLine":6807
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -745,7 +814,8 @@
                     "startColumn":16,
                     "startLine":6808
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -753,7 +823,8 @@
                     "startColumn":31,
                     "startLine":6808
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -761,7 +832,8 @@
                     "startColumn":34,
                     "startLine":6810
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -769,7 +841,8 @@
                     "startColumn":12,
                     "startLine":6810
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -777,7 +850,8 @@
                     "startColumn":30,
                     "startLine":6812
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -785,7 +859,8 @@
                     "startColumn":25,
                     "startLine":6814
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -793,7 +868,8 @@
                     "startColumn":20,
                     "startLine":6816
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -801,7 +877,8 @@
                     "startColumn":21,
                     "startLine":6818
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -809,7 +886,8 @@
                     "startColumn":30,
                     "startLine":6881
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -817,7 +895,8 @@
                     "startColumn":22,
                     "startLine":6882
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -825,7 +904,8 @@
                     "startColumn":30,
                     "startLine":6894
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -833,7 +913,8 @@
                     "startColumn":43,
                     "startLine":6894
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -841,7 +922,8 @@
                     "startColumn":5,
                     "startLine":6913
                   }
-                }
+                },
+                "step":22
               }
             ]
           }
@@ -875,7 +957,8 @@
                     "startColumn":1,
                     "startLine":9374
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -883,7 +966,8 @@
                     "startColumn":13,
                     "startLine":9381
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -891,7 +975,8 @@
                     "startColumn":12,
                     "startLine":9382
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -899,7 +984,8 @@
                     "startColumn":29,
                     "startLine":9382
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -907,7 +993,8 @@
                     "startColumn":31,
                     "startLine":9384
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -915,7 +1002,8 @@
                     "startColumn":8,
                     "startLine":9384
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -923,7 +1011,8 @@
                     "startColumn":26,
                     "startLine":9386
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -931,7 +1020,8 @@
                     "startColumn":24,
                     "startLine":9388
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -939,7 +1029,8 @@
                     "startColumn":37,
                     "startLine":9388
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -947,7 +1038,8 @@
                     "startColumn":16,
                     "startLine":9389
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -955,7 +1047,8 @@
                     "startColumn":31,
                     "startLine":9389
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -963,7 +1056,8 @@
                     "startColumn":21,
                     "startLine":9391
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -971,7 +1065,8 @@
                     "startColumn":16,
                     "startLine":9393
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -979,7 +1074,8 @@
                     "startColumn":17,
                     "startLine":9395
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -987,7 +1083,8 @@
                     "startColumn":30,
                     "startLine":9432
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -995,7 +1092,8 @@
                     "startColumn":22,
                     "startLine":9433
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1003,7 +1101,8 @@
                     "startColumn":30,
                     "startLine":9445
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1011,7 +1110,8 @@
                     "startColumn":17,
                     "startLine":9446
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1019,7 +1119,8 @@
                     "startColumn":17,
                     "startLine":9447
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1027,7 +1128,8 @@
                     "startColumn":5,
                     "startLine":9466
                   }
-                }
+                },
+                "step":20
               }
             ]
           }
@@ -1061,7 +1163,8 @@
                     "startColumn":1,
                     "startLine":9552
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1069,7 +1172,8 @@
                     "startColumn":13,
                     "startLine":9557
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1077,7 +1181,8 @@
                     "startColumn":10,
                     "startLine":9559
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1085,7 +1190,8 @@
                     "startColumn":31,
                     "startLine":9559
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1093,7 +1199,8 @@
                     "startColumn":33,
                     "startLine":9565
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1101,7 +1208,8 @@
                     "startColumn":12,
                     "startLine":9565
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1109,7 +1217,8 @@
                     "startColumn":26,
                     "startLine":9568
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1117,7 +1226,8 @@
                     "startColumn":5,
                     "startLine":9573
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1151,7 +1261,8 @@
                     "startColumn":1,
                     "startLine":9584
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1159,7 +1270,8 @@
                     "startColumn":13,
                     "startLine":9589
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1167,7 +1279,8 @@
                     "startColumn":10,
                     "startLine":9591
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1175,7 +1288,8 @@
                     "startColumn":31,
                     "startLine":9591
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1183,7 +1297,8 @@
                     "startColumn":33,
                     "startLine":9597
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1191,7 +1306,8 @@
                     "startColumn":12,
                     "startLine":9597
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1199,7 +1315,8 @@
                     "startColumn":26,
                     "startLine":9600
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1207,7 +1324,8 @@
                     "startColumn":5,
                     "startLine":9605
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1241,7 +1359,8 @@
                     "startColumn":1,
                     "startLine":10240
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1249,7 +1368,8 @@
                     "startColumn":13,
                     "startLine":10246
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1257,7 +1377,8 @@
                     "startColumn":29,
                     "startLine":10248
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1265,7 +1386,8 @@
                     "startColumn":8,
                     "startLine":10248
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1273,7 +1395,8 @@
                     "startColumn":26,
                     "startLine":10250
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1281,7 +1404,8 @@
                     "startColumn":33,
                     "startLine":10252
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1289,7 +1413,8 @@
                     "startColumn":12,
                     "startLine":10252
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1297,7 +1422,8 @@
                     "startColumn":5,
                     "startLine":10259
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1331,7 +1457,8 @@
                     "startColumn":1,
                     "startLine":10296
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1339,7 +1466,8 @@
                     "startColumn":13,
                     "startLine":10302
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1347,7 +1475,8 @@
                     "startColumn":29,
                     "startLine":10304
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1355,7 +1484,8 @@
                     "startColumn":8,
                     "startLine":10304
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1363,7 +1493,8 @@
                     "startColumn":26,
                     "startLine":10306
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1371,7 +1502,8 @@
                     "startColumn":33,
                     "startLine":10308
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1379,7 +1511,8 @@
                     "startColumn":12,
                     "startLine":10308
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1387,7 +1520,8 @@
                     "startColumn":5,
                     "startLine":10315
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1421,7 +1555,8 @@
                     "startColumn":1,
                     "startLine":11010
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1429,7 +1564,8 @@
                     "startColumn":12,
                     "startLine":11018
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1437,7 +1573,8 @@
                     "startColumn":29,
                     "startLine":11018
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1445,7 +1582,8 @@
                     "startColumn":22,
                     "startLine":11020
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1453,7 +1591,8 @@
                     "startColumn":18,
                     "startLine":11022
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1461,7 +1600,8 @@
                     "startColumn":35,
                     "startLine":11022
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1469,7 +1609,8 @@
                     "startColumn":17,
                     "startLine":11035
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1477,7 +1618,8 @@
                     "startColumn":18,
                     "startLine":11059
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1485,7 +1627,8 @@
                     "startColumn":35,
                     "startLine":11059
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1493,7 +1636,8 @@
                     "startColumn":5,
                     "startLine":11068
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -1527,7 +1671,8 @@
                     "startColumn":1,
                     "startLine":11079
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1535,7 +1680,8 @@
                     "startColumn":12,
                     "startLine":11087
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1543,7 +1689,8 @@
                     "startColumn":29,
                     "startLine":11087
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1551,7 +1698,8 @@
                     "startColumn":22,
                     "startLine":11089
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1559,7 +1707,8 @@
                     "startColumn":18,
                     "startLine":11091
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1567,7 +1716,8 @@
                     "startColumn":17,
                     "startLine":11104
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1575,7 +1725,8 @@
                     "startColumn":18,
                     "startLine":11128
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/strsafe.h",
@@ -1583,7 +1734,8 @@
                     "startColumn":5,
                     "startLine":11137
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -1617,7 +1769,8 @@
                     "startColumn":24,
                     "startLine":326
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1625,7 +1778,8 @@
                     "startColumn":19,
                     "startLine":329
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1659,7 +1813,8 @@
                     "startColumn":24,
                     "startLine":340
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1667,7 +1822,8 @@
                     "startColumn":13,
                     "startLine":345
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1701,7 +1857,8 @@
                     "startColumn":24,
                     "startLine":340
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1709,7 +1866,8 @@
                     "startColumn":13,
                     "startLine":345
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1743,7 +1901,8 @@
                     "startColumn":24,
                     "startLine":364
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1751,7 +1910,8 @@
                     "startColumn":15,
                     "startLine":369
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1785,7 +1945,8 @@
                     "startColumn":24,
                     "startLine":364
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1793,7 +1954,8 @@
                     "startColumn":15,
                     "startLine":369
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1827,7 +1989,8 @@
                     "startColumn":24,
                     "startLine":441
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1835,7 +1998,8 @@
                     "startColumn":19,
                     "startLine":444
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1869,7 +2033,8 @@
                     "startColumn":24,
                     "startLine":455
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1877,7 +2042,8 @@
                     "startColumn":13,
                     "startLine":460
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1911,7 +2077,8 @@
                     "startColumn":24,
                     "startLine":455
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1919,7 +2086,8 @@
                     "startColumn":13,
                     "startLine":460
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1953,7 +2121,8 @@
                     "startColumn":24,
                     "startLine":479
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -1961,7 +2130,8 @@
                     "startColumn":14,
                     "startLine":484
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -1995,7 +2165,8 @@
                     "startColumn":24,
                     "startLine":479
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/iosfwd",
@@ -2003,7 +2174,8 @@
                     "startColumn":14,
                     "startLine":484
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -2037,7 +2209,8 @@
                     "startColumn":19,
                     "startLine":605
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2045,7 +2218,8 @@
                     "startColumn":9,
                     "startLine":608
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2053,7 +2227,8 @@
                     "startColumn":17,
                     "startLine":608
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2061,7 +2236,8 @@
                     "startColumn":9,
                     "startLine":609
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2069,7 +2245,8 @@
                     "startColumn":14,
                     "startLine":610
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2077,7 +2254,8 @@
                     "startColumn":6,
                     "startLine":611
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2085,7 +2263,8 @@
                     "startColumn":10,
                     "startLine":612
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2093,7 +2272,8 @@
                     "startColumn":12,
                     "startLine":613
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2101,7 +2281,8 @@
                     "startColumn":22,
                     "startLine":613
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2109,7 +2290,8 @@
                     "startColumn":20,
                     "startLine":615
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -2143,7 +2325,8 @@
                     "startColumn":18,
                     "startLine":872
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2151,7 +2334,8 @@
                     "startColumn":9,
                     "startLine":878
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2159,7 +2343,8 @@
                     "startColumn":18,
                     "startLine":878
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2167,7 +2352,8 @@
                     "startColumn":10,
                     "startLine":879
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2175,7 +2361,8 @@
                     "startColumn":23,
                     "startLine":879
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2183,7 +2370,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2191,7 +2379,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2199,7 +2388,8 @@
                     "startColumn":7,
                     "startLine":880
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2207,7 +2397,8 @@
                     "startColumn":16,
                     "startLine":882
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2215,7 +2406,8 @@
                     "startColumn":35,
                     "startLine":882
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2223,7 +2415,8 @@
                     "startColumn":29,
                     "startLine":883
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2231,7 +2424,8 @@
                     "startColumn":19,
                     "startLine":883
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2239,7 +2433,8 @@
                     "startColumn":4,
                     "startLine":883
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2247,7 +2442,8 @@
                     "startColumn":16,
                     "startLine":899
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2255,7 +2451,8 @@
                     "startColumn":11,
                     "startLine":901
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2263,7 +2460,8 @@
                     "startColumn":5,
                     "startLine":902
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2271,7 +2469,8 @@
                     "startColumn":10,
                     "startLine":903
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2279,7 +2478,8 @@
                     "startColumn":16,
                     "startLine":882
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2287,7 +2487,8 @@
                     "startColumn":35,
                     "startLine":882
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2295,7 +2496,8 @@
                     "startColumn":29,
                     "startLine":883
                   }
-                }
+                },
+                "step":20
               }
             ]
           }
@@ -2329,7 +2531,8 @@
                     "startColumn":18,
                     "startLine":872
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2337,7 +2540,8 @@
                     "startColumn":9,
                     "startLine":878
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2345,7 +2549,8 @@
                     "startColumn":18,
                     "startLine":878
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2353,7 +2558,8 @@
                     "startColumn":10,
                     "startLine":879
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2361,7 +2567,8 @@
                     "startColumn":23,
                     "startLine":879
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2369,7 +2576,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2377,7 +2585,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2385,7 +2594,8 @@
                     "startColumn":7,
                     "startLine":880
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2393,7 +2603,8 @@
                     "startColumn":16,
                     "startLine":882
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2401,7 +2612,8 @@
                     "startColumn":35,
                     "startLine":882
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2409,7 +2621,8 @@
                     "startColumn":29,
                     "startLine":883
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2417,7 +2630,8 @@
                     "startColumn":19,
                     "startLine":883
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2425,7 +2639,8 @@
                     "startColumn":4,
                     "startLine":883
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2433,7 +2648,8 @@
                     "startColumn":9,
                     "startLine":894
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2441,7 +2657,8 @@
                     "startColumn":28,
                     "startLine":895
                   }
-                }
+                },
+                "step":15
               }
             ]
           }
@@ -2475,7 +2692,8 @@
                     "startColumn":18,
                     "startLine":872
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2483,7 +2701,8 @@
                     "startColumn":9,
                     "startLine":878
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2491,7 +2710,8 @@
                     "startColumn":18,
                     "startLine":878
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2499,7 +2719,8 @@
                     "startColumn":10,
                     "startLine":879
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2507,7 +2728,8 @@
                     "startColumn":23,
                     "startLine":879
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2515,7 +2737,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2523,7 +2746,8 @@
                     "startColumn":33,
                     "startLine":879
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2531,7 +2755,8 @@
                     "startColumn":7,
                     "startLine":880
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2539,7 +2764,8 @@
                     "startColumn":16,
                     "startLine":882
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2547,7 +2773,8 @@
                     "startColumn":35,
                     "startLine":882
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2555,7 +2782,8 @@
                     "startColumn":29,
                     "startLine":883
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2563,7 +2791,8 @@
                     "startColumn":19,
                     "startLine":883
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2571,7 +2800,8 @@
                     "startColumn":4,
                     "startLine":883
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2579,7 +2809,8 @@
                     "startColumn":9,
                     "startLine":894
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2587,7 +2818,8 @@
                     "startColumn":28,
                     "startLine":895
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2595,7 +2827,8 @@
                     "startColumn":13,
                     "startLine":895
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2603,7 +2836,8 @@
                     "startColumn":16,
                     "startLine":899
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2611,7 +2845,8 @@
                     "startColumn":11,
                     "startLine":901
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2619,7 +2854,8 @@
                     "startColumn":5,
                     "startLine":902
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2627,7 +2863,8 @@
                     "startColumn":10,
                     "startLine":903
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2635,7 +2872,8 @@
                     "startColumn":16,
                     "startLine":882
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2643,7 +2881,8 @@
                     "startColumn":35,
                     "startLine":882
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2651,7 +2890,8 @@
                     "startColumn":29,
                     "startLine":883
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2659,7 +2899,8 @@
                     "startColumn":19,
                     "startLine":883
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2667,7 +2908,8 @@
                     "startColumn":4,
                     "startLine":883
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2675,7 +2917,8 @@
                     "startColumn":9,
                     "startLine":894
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2683,7 +2926,8 @@
                     "startColumn":28,
                     "startLine":895
                   }
-                }
+                },
+                "step":27
               }
             ]
           }
@@ -2717,7 +2961,8 @@
                     "startColumn":18,
                     "startLine":908
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2725,7 +2970,8 @@
                     "startColumn":9,
                     "startLine":914
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2733,7 +2979,8 @@
                     "startColumn":18,
                     "startLine":914
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2741,7 +2988,8 @@
                     "startColumn":10,
                     "startLine":915
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2749,7 +2997,8 @@
                     "startColumn":23,
                     "startLine":915
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2757,7 +3006,8 @@
                     "startColumn":33,
                     "startLine":915
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2765,7 +3015,8 @@
                     "startColumn":33,
                     "startLine":915
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2773,7 +3024,8 @@
                     "startColumn":7,
                     "startLine":916
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2781,7 +3033,8 @@
                     "startColumn":16,
                     "startLine":918
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2789,7 +3042,8 @@
                     "startColumn":35,
                     "startLine":918
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2797,7 +3051,8 @@
                     "startColumn":26,
                     "startLine":919
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2805,7 +3060,8 @@
                     "startColumn":29,
                     "startLine":919
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2813,7 +3069,8 @@
                     "startColumn":27,
                     "startLine":920
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2821,7 +3078,8 @@
                     "startColumn":17,
                     "startLine":920
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2829,7 +3087,8 @@
                     "startColumn":23,
                     "startLine":921
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2837,7 +3096,8 @@
                     "startColumn":6,
                     "startLine":924
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2845,7 +3105,8 @@
                     "startColumn":13,
                     "startLine":924
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2853,7 +3114,8 @@
                     "startColumn":11,
                     "startLine":924
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2861,7 +3123,8 @@
                     "startColumn":16,
                     "startLine":918
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2869,7 +3132,8 @@
                     "startColumn":35,
                     "startLine":918
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2877,7 +3141,8 @@
                     "startColumn":26,
                     "startLine":919
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2885,7 +3150,8 @@
                     "startColumn":29,
                     "startLine":919
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2893,7 +3159,8 @@
                     "startColumn":27,
                     "startLine":920
                   }
-                }
+                },
+                "step":23
               }
             ]
           }
@@ -2927,7 +3194,8 @@
                     "startColumn":18,
                     "startLine":908
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2935,7 +3203,8 @@
                     "startColumn":9,
                     "startLine":914
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2943,7 +3212,8 @@
                     "startColumn":18,
                     "startLine":914
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2951,7 +3221,8 @@
                     "startColumn":10,
                     "startLine":915
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2959,7 +3230,8 @@
                     "startColumn":23,
                     "startLine":915
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2967,7 +3239,8 @@
                     "startColumn":33,
                     "startLine":915
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2975,7 +3248,8 @@
                     "startColumn":33,
                     "startLine":915
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2983,7 +3257,8 @@
                     "startColumn":7,
                     "startLine":916
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2991,7 +3266,8 @@
                     "startColumn":16,
                     "startLine":918
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -2999,7 +3275,8 @@
                     "startColumn":35,
                     "startLine":918
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3007,7 +3284,8 @@
                     "startColumn":26,
                     "startLine":919
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3015,7 +3293,8 @@
                     "startColumn":29,
                     "startLine":919
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3023,7 +3302,8 @@
                     "startColumn":27,
                     "startLine":920
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3031,7 +3311,8 @@
                     "startColumn":17,
                     "startLine":920
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3039,7 +3320,8 @@
                     "startColumn":23,
                     "startLine":921
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3047,7 +3329,8 @@
                     "startColumn":6,
                     "startLine":924
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3055,7 +3338,8 @@
                     "startColumn":13,
                     "startLine":924
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3063,7 +3347,8 @@
                     "startColumn":11,
                     "startLine":924
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3071,7 +3356,8 @@
                     "startColumn":16,
                     "startLine":918
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3079,7 +3365,8 @@
                     "startColumn":35,
                     "startLine":918
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3087,7 +3374,8 @@
                     "startColumn":26,
                     "startLine":919
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3095,7 +3383,8 @@
                     "startColumn":29,
                     "startLine":919
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3103,7 +3392,8 @@
                     "startColumn":27,
                     "startLine":920
                   }
-                }
+                },
+                "step":23
               }
             ]
           }
@@ -3137,7 +3427,8 @@
                     "startColumn":15,
                     "startLine":972
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3145,7 +3436,8 @@
                     "startColumn":7,
                     "startLine":976
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3153,7 +3445,8 @@
                     "startColumn":16,
                     "startLine":977
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3161,7 +3454,8 @@
                     "startColumn":12,
                     "startLine":978
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3169,7 +3463,8 @@
                     "startColumn":23,
                     "startLine":978
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3177,7 +3472,8 @@
                     "startColumn":16,
                     "startLine":980
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3185,7 +3481,8 @@
                     "startColumn":19,
                     "startLine":980
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3193,7 +3490,8 @@
                     "startColumn":20,
                     "startLine":981
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3201,7 +3499,8 @@
                     "startColumn":38,
                     "startLine":981
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3209,7 +3508,8 @@
                     "startColumn":8,
                     "startLine":983
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3217,7 +3517,8 @@
                     "startColumn":10,
                     "startLine":984
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3225,7 +3526,8 @@
                     "startColumn":29,
                     "startLine":986
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3233,7 +3535,8 @@
                     "startColumn":19,
                     "startLine":986
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3241,7 +3544,8 @@
                     "startColumn":4,
                     "startLine":986
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3249,7 +3553,8 @@
                     "startColumn":9,
                     "startLine":996
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3257,7 +3562,8 @@
                     "startColumn":28,
                     "startLine":997
                   }
-                }
+                },
+                "step":16
               }
             ]
           }
@@ -3291,7 +3597,8 @@
                     "startColumn":15,
                     "startLine":972
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3299,7 +3606,8 @@
                     "startColumn":7,
                     "startLine":976
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3307,7 +3615,8 @@
                     "startColumn":16,
                     "startLine":977
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3315,7 +3624,8 @@
                     "startColumn":12,
                     "startLine":978
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3323,7 +3633,8 @@
                     "startColumn":23,
                     "startLine":978
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3331,7 +3642,8 @@
                     "startColumn":16,
                     "startLine":980
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3339,7 +3651,8 @@
                     "startColumn":19,
                     "startLine":980
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3347,7 +3660,8 @@
                     "startColumn":20,
                     "startLine":981
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3355,7 +3669,8 @@
                     "startColumn":38,
                     "startLine":981
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3363,7 +3678,8 @@
                     "startColumn":8,
                     "startLine":983
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3371,7 +3687,8 @@
                     "startColumn":10,
                     "startLine":984
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3379,7 +3696,8 @@
                     "startColumn":29,
                     "startLine":986
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3387,7 +3705,8 @@
                     "startColumn":19,
                     "startLine":986
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3395,7 +3714,8 @@
                     "startColumn":4,
                     "startLine":986
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3403,7 +3723,8 @@
                     "startColumn":9,
                     "startLine":996
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3411,7 +3732,8 @@
                     "startColumn":28,
                     "startLine":997
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3419,7 +3741,8 @@
                     "startColumn":13,
                     "startLine":997
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3427,7 +3750,8 @@
                     "startColumn":16,
                     "startLine":1001
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3435,7 +3759,8 @@
                     "startColumn":11,
                     "startLine":1003
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3443,7 +3768,8 @@
                     "startColumn":5,
                     "startLine":1004
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3451,7 +3777,8 @@
                     "startColumn":20,
                     "startLine":981
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3459,7 +3786,8 @@
                     "startColumn":38,
                     "startLine":981
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3467,7 +3795,8 @@
                     "startColumn":8,
                     "startLine":983
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3475,7 +3804,8 @@
                     "startColumn":10,
                     "startLine":984
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3483,7 +3813,8 @@
                     "startColumn":29,
                     "startLine":986
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3491,7 +3822,8 @@
                     "startColumn":19,
                     "startLine":986
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3499,7 +3831,8 @@
                     "startColumn":4,
                     "startLine":986
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3507,7 +3840,8 @@
                     "startColumn":9,
                     "startLine":996
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3515,7 +3849,8 @@
                     "startColumn":28,
                     "startLine":997
                   }
-                }
+                },
+                "step":29
               }
             ]
           }
@@ -3549,7 +3884,8 @@
                     "startColumn":24,
                     "startLine":1520
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3557,7 +3893,8 @@
                     "startColumn":2,
                     "startLine":1524
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3565,7 +3902,8 @@
                     "startColumn":29,
                     "startLine":1525
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3573,7 +3911,8 @@
                     "startColumn":12,
                     "startLine":1525
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3581,7 +3920,8 @@
                     "startColumn":12,
                     "startLine":1524
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3589,7 +3929,8 @@
                     "startColumn":2,
                     "startLine":1524
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3597,7 +3938,8 @@
                     "startColumn":29,
                     "startLine":1525
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -3631,7 +3973,8 @@
                     "startColumn":24,
                     "startLine":1534
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3639,7 +3982,8 @@
                     "startColumn":2,
                     "startLine":1538
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3647,7 +3991,8 @@
                     "startColumn":29,
                     "startLine":1539
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3655,7 +4000,8 @@
                     "startColumn":12,
                     "startLine":1539
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3663,7 +4009,8 @@
                     "startColumn":12,
                     "startLine":1538
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3671,7 +4018,8 @@
                     "startColumn":2,
                     "startLine":1538
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3679,7 +4027,8 @@
                     "startColumn":29,
                     "startLine":1539
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -3713,7 +4062,8 @@
                     "startColumn":16,
                     "startLine":1557
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3721,7 +4071,8 @@
                     "startColumn":22,
                     "startLine":1562
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3729,7 +4080,8 @@
                     "startColumn":13,
                     "startLine":1563
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -3763,7 +4115,8 @@
                     "startColumn":16,
                     "startLine":1581
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3771,7 +4124,8 @@
                     "startColumn":22,
                     "startLine":1586
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3779,7 +4133,8 @@
                     "startColumn":13,
                     "startLine":1587
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -3813,7 +4168,8 @@
                     "startColumn":24,
                     "startLine":1756
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3821,7 +4177,8 @@
                     "startColumn":2,
                     "startLine":1760
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3829,7 +4186,8 @@
                     "startColumn":17,
                     "startLine":1760
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3837,7 +4195,8 @@
                     "startColumn":17,
                     "startLine":1760
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3845,7 +4204,8 @@
                     "startColumn":38,
                     "startLine":1760
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3853,7 +4213,8 @@
                     "startColumn":2,
                     "startLine":1760
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3861,7 +4222,8 @@
                     "startColumn":17,
                     "startLine":1760
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -3895,7 +4257,8 @@
                     "startColumn":24,
                     "startLine":1765
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3903,7 +4266,8 @@
                     "startColumn":2,
                     "startLine":1769
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3911,7 +4275,8 @@
                     "startColumn":16,
                     "startLine":1769
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3919,7 +4284,8 @@
                     "startColumn":16,
                     "startLine":1769
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3927,7 +4293,8 @@
                     "startColumn":37,
                     "startLine":1769
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3935,7 +4302,8 @@
                     "startColumn":2,
                     "startLine":1769
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3943,7 +4311,8 @@
                     "startColumn":16,
                     "startLine":1769
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -3977,7 +4346,8 @@
                     "startColumn":24,
                     "startLine":1779
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3985,7 +4355,8 @@
                     "startColumn":2,
                     "startLine":1783
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -3993,7 +4364,8 @@
                     "startColumn":23,
                     "startLine":1784
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4001,7 +4373,8 @@
                     "startColumn":12,
                     "startLine":1784
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4009,7 +4382,8 @@
                     "startColumn":12,
                     "startLine":1783
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4017,7 +4391,8 @@
                     "startColumn":2,
                     "startLine":1783
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4025,7 +4400,8 @@
                     "startColumn":23,
                     "startLine":1784
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -4059,7 +4435,8 @@
                     "startColumn":24,
                     "startLine":1793
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4067,7 +4444,8 @@
                     "startColumn":2,
                     "startLine":1797
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4075,7 +4453,8 @@
                     "startColumn":23,
                     "startLine":1798
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4083,7 +4462,8 @@
                     "startColumn":12,
                     "startLine":1798
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4091,7 +4471,8 @@
                     "startColumn":12,
                     "startLine":1797
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4099,7 +4480,8 @@
                     "startColumn":2,
                     "startLine":1797
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4107,7 +4489,8 @@
                     "startColumn":23,
                     "startLine":1798
                   }
-                }
+                },
+                "step":7
               }
             ]
           }
@@ -4141,7 +4524,8 @@
                     "startColumn":15,
                     "startLine":1824
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4149,7 +4533,8 @@
                     "startColumn":22,
                     "startLine":1829
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4157,7 +4542,8 @@
                     "startColumn":2,
                     "startLine":1830
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4165,7 +4551,8 @@
                     "startColumn":21,
                     "startLine":1831
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4173,7 +4560,8 @@
                     "startColumn":11,
                     "startLine":1831
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4181,7 +4569,8 @@
                     "startColumn":12,
                     "startLine":1830
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4189,7 +4578,8 @@
                     "startColumn":7,
                     "startLine":1830
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4197,7 +4587,8 @@
                     "startColumn":2,
                     "startLine":1830
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4205,7 +4596,8 @@
                     "startColumn":21,
                     "startLine":1831
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -4239,7 +4631,8 @@
                     "startColumn":15,
                     "startLine":1824
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4247,7 +4640,8 @@
                     "startColumn":22,
                     "startLine":1829
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4255,7 +4649,8 @@
                     "startColumn":2,
                     "startLine":1830
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4263,7 +4658,8 @@
                     "startColumn":21,
                     "startLine":1831
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4271,7 +4667,8 @@
                     "startColumn":11,
                     "startLine":1831
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4279,7 +4676,8 @@
                     "startColumn":12,
                     "startLine":1830
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4287,7 +4685,8 @@
                     "startColumn":7,
                     "startLine":1830
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4295,7 +4694,8 @@
                     "startColumn":2,
                     "startLine":1830
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4303,7 +4703,8 @@
                     "startColumn":21,
                     "startLine":1831
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4311,7 +4712,8 @@
                     "startColumn":11,
                     "startLine":1831
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -4345,7 +4747,8 @@
                     "startColumn":16,
                     "startLine":1857
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4353,7 +4756,8 @@
                     "startColumn":22,
                     "startLine":1862
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4361,7 +4765,8 @@
                     "startColumn":2,
                     "startLine":1863
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4369,7 +4774,8 @@
                     "startColumn":22,
                     "startLine":1864
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4377,7 +4783,8 @@
                     "startColumn":11,
                     "startLine":1864
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4385,7 +4792,8 @@
                     "startColumn":12,
                     "startLine":1863
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4393,7 +4801,8 @@
                     "startColumn":7,
                     "startLine":1863
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4401,7 +4810,8 @@
                     "startColumn":2,
                     "startLine":1863
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4409,7 +4819,8 @@
                     "startColumn":22,
                     "startLine":1864
                   }
-                }
+                },
+                "step":9
               }
             ]
           }
@@ -4443,7 +4854,8 @@
                     "startColumn":16,
                     "startLine":1857
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4451,7 +4863,8 @@
                     "startColumn":22,
                     "startLine":1862
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4459,7 +4872,8 @@
                     "startColumn":2,
                     "startLine":1863
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4467,7 +4881,8 @@
                     "startColumn":22,
                     "startLine":1864
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4475,7 +4890,8 @@
                     "startColumn":11,
                     "startLine":1864
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4483,7 +4899,8 @@
                     "startColumn":12,
                     "startLine":1863
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4491,7 +4908,8 @@
                     "startColumn":7,
                     "startLine":1863
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4499,7 +4917,8 @@
                     "startColumn":2,
                     "startLine":1863
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4507,7 +4926,8 @@
                     "startColumn":22,
                     "startLine":1864
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/xlocale",
@@ -4515,7 +4935,8 @@
                     "startColumn":11,
                     "startLine":1864
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -4549,7 +4970,8 @@
                     "startColumn":13,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4557,7 +4979,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4565,7 +4988,8 @@
                     "startColumn":25,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4573,7 +4997,8 @@
                     "startColumn":49,
                     "startLine":59
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4581,7 +5006,8 @@
                     "startColumn":11,
                     "startLine":60
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4589,7 +5015,8 @@
                     "startColumn":18,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4597,7 +5024,8 @@
                     "startColumn":23,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4605,7 +5033,8 @@
                     "startColumn":30,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4613,7 +5042,8 @@
                     "startColumn":17,
                     "startLine":62
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4621,7 +5051,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4629,7 +5060,8 @@
                     "startColumn":13,
                     "startLine":68
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4637,7 +5069,8 @@
                     "startColumn":10,
                     "startLine":70
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4645,7 +5078,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4653,7 +5087,8 @@
                     "startColumn":10,
                     "startLine":78
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4661,7 +5096,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4669,7 +5105,8 @@
                     "startColumn":14,
                     "startLine":85
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4677,7 +5114,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4685,7 +5123,8 @@
                     "startColumn":21,
                     "startLine":91
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4693,7 +5132,8 @@
                     "startColumn":21,
                     "startLine":91
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4701,7 +5141,8 @@
                     "startColumn":15,
                     "startLine":98
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4709,7 +5150,8 @@
                     "startColumn":18,
                     "startLine":99
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4717,7 +5159,8 @@
                     "startColumn":53,
                     "startLine":99
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4725,7 +5168,8 @@
                     "startColumn":31,
                     "startLine":103
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4733,7 +5177,8 @@
                     "startColumn":25,
                     "startLine":103
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4741,7 +5186,8 @@
                     "startColumn":28,
                     "startLine":104
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4749,7 +5195,8 @@
                     "startColumn":23,
                     "startLine":108
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4757,7 +5204,8 @@
                     "startColumn":15,
                     "startLine":108
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4765,7 +5213,8 @@
                     "startColumn":9,
                     "startLine":109
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4773,7 +5222,8 @@
                     "startColumn":31,
                     "startLine":113
                   }
-                }
+                },
+                "step":29
               }
             ]
           }
@@ -4807,7 +5257,8 @@
                     "startColumn":13,
                     "startLine":57
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4815,7 +5266,8 @@
                     "startColumn":17,
                     "startLine":59
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4823,7 +5275,8 @@
                     "startColumn":25,
                     "startLine":59
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4831,7 +5284,8 @@
                     "startColumn":49,
                     "startLine":59
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4839,7 +5293,8 @@
                     "startColumn":11,
                     "startLine":60
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4847,7 +5302,8 @@
                     "startColumn":18,
                     "startLine":61
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4855,7 +5311,8 @@
                     "startColumn":23,
                     "startLine":61
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4863,7 +5320,8 @@
                     "startColumn":30,
                     "startLine":61
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4871,7 +5329,8 @@
                     "startColumn":17,
                     "startLine":62
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4879,7 +5338,8 @@
                     "startColumn":10,
                     "startLine":64
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4887,7 +5347,8 @@
                     "startColumn":13,
                     "startLine":68
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4895,7 +5356,8 @@
                     "startColumn":10,
                     "startLine":70
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4903,7 +5365,8 @@
                     "startColumn":14,
                     "startLine":73
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4911,7 +5374,8 @@
                     "startColumn":10,
                     "startLine":78
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4919,7 +5383,8 @@
                     "startColumn":23,
                     "startLine":85
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4927,7 +5392,8 @@
                     "startColumn":14,
                     "startLine":85
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4935,7 +5401,8 @@
                     "startColumn":14,
                     "startLine":86
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4943,7 +5410,8 @@
                     "startColumn":21,
                     "startLine":91
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4951,7 +5419,8 @@
                     "startColumn":21,
                     "startLine":91
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4959,7 +5428,8 @@
                     "startColumn":15,
                     "startLine":98
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4967,7 +5437,8 @@
                     "startColumn":18,
                     "startLine":99
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4975,7 +5446,8 @@
                     "startColumn":53,
                     "startLine":99
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4983,7 +5455,8 @@
                     "startColumn":31,
                     "startLine":103
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4991,7 +5464,8 @@
                     "startColumn":25,
                     "startLine":103
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -4999,7 +5473,8 @@
                     "startColumn":28,
                     "startLine":104
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5007,7 +5482,8 @@
                     "startColumn":23,
                     "startLine":108
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5015,7 +5491,8 @@
                     "startColumn":15,
                     "startLine":108
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5023,7 +5500,8 @@
                     "startColumn":9,
                     "startLine":109
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5031,7 +5509,8 @@
                     "startColumn":31,
                     "startLine":113
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5039,7 +5518,8 @@
                     "startColumn":25,
                     "startLine":113
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5047,7 +5527,8 @@
                     "startColumn":13,
                     "startLine":115
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/dev/win8/drivers/tablet/recognition/ink/core/inferno/src/loadtdnnbin.cpp",
@@ -5055,7 +5536,8 @@
                     "startColumn":17,
                     "startLine":116
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -5089,7 +5571,8 @@
                     "startColumn":14,
                     "startLine":324
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5097,7 +5580,8 @@
                     "startColumn":12,
                     "startLine":327
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5105,7 +5589,8 @@
                     "startColumn":14,
                     "startLine":328
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5113,7 +5598,8 @@
                     "startColumn":28,
                     "startLine":328
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5121,7 +5607,8 @@
                     "startColumn":3,
                     "startLine":328
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5129,7 +5616,8 @@
                     "startColumn":16,
                     "startLine":330
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5137,7 +5625,8 @@
                     "startColumn":2,
                     "startLine":330
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5145,7 +5634,8 @@
                     "startColumn":36,
                     "startLine":331
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5153,7 +5643,8 @@
                     "startColumn":26,
                     "startLine":331
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5161,7 +5652,8 @@
                     "startColumn":10,
                     "startLine":331
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5169,7 +5661,8 @@
                     "startColumn":63,
                     "startLine":342
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5177,7 +5670,8 @@
                     "startColumn":56,
                     "startLine":342
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5185,7 +5679,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5193,7 +5688,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5201,7 +5697,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5209,7 +5706,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5217,7 +5715,8 @@
                     "startColumn":36,
                     "startLine":346
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5225,7 +5724,8 @@
                     "startColumn":13,
                     "startLine":346
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5233,7 +5733,8 @@
                     "startColumn":5,
                     "startLine":347
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5241,7 +5742,8 @@
                     "startColumn":5,
                     "startLine":348
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5249,7 +5751,8 @@
                     "startColumn":2,
                     "startLine":330
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5257,7 +5760,8 @@
                     "startColumn":36,
                     "startLine":331
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5265,7 +5769,8 @@
                     "startColumn":26,
                     "startLine":331
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5273,7 +5778,8 @@
                     "startColumn":10,
                     "startLine":331
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5281,7 +5787,8 @@
                     "startColumn":63,
                     "startLine":342
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5289,7 +5796,8 @@
                     "startColumn":56,
                     "startLine":342
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5297,7 +5805,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5305,7 +5814,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5313,7 +5823,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5321,7 +5832,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5329,7 +5841,8 @@
                     "startColumn":36,
                     "startLine":346
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5337,7 +5850,8 @@
                     "startColumn":13,
                     "startLine":346
                   }
-                }
+                },
+                "step":32
               }
             ]
           }
@@ -5371,7 +5885,8 @@
                     "startColumn":14,
                     "startLine":324
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5379,7 +5894,8 @@
                     "startColumn":12,
                     "startLine":327
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5387,7 +5903,8 @@
                     "startColumn":14,
                     "startLine":328
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5395,7 +5912,8 @@
                     "startColumn":28,
                     "startLine":328
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5403,7 +5921,8 @@
                     "startColumn":3,
                     "startLine":328
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5411,7 +5930,8 @@
                     "startColumn":16,
                     "startLine":330
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5419,7 +5939,8 @@
                     "startColumn":2,
                     "startLine":330
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5427,7 +5948,8 @@
                     "startColumn":36,
                     "startLine":331
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5435,7 +5957,8 @@
                     "startColumn":26,
                     "startLine":331
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5443,7 +5966,8 @@
                     "startColumn":10,
                     "startLine":331
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5451,7 +5975,8 @@
                     "startColumn":63,
                     "startLine":342
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5459,7 +5984,8 @@
                     "startColumn":56,
                     "startLine":342
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5467,7 +5993,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5475,7 +6002,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5483,7 +6011,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5491,7 +6020,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5499,7 +6029,8 @@
                     "startColumn":36,
                     "startLine":346
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5507,7 +6038,8 @@
                     "startColumn":13,
                     "startLine":346
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5515,7 +6047,8 @@
                     "startColumn":5,
                     "startLine":347
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5523,7 +6056,8 @@
                     "startColumn":5,
                     "startLine":348
                   }
-                }
+                },
+                "step":20
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5531,7 +6065,8 @@
                     "startColumn":2,
                     "startLine":330
                   }
-                }
+                },
+                "step":21
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5539,7 +6074,8 @@
                     "startColumn":36,
                     "startLine":331
                   }
-                }
+                },
+                "step":22
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5547,7 +6083,8 @@
                     "startColumn":26,
                     "startLine":331
                   }
-                }
+                },
+                "step":23
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5555,7 +6092,8 @@
                     "startColumn":10,
                     "startLine":331
                   }
-                }
+                },
+                "step":24
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5563,7 +6101,8 @@
                     "startColumn":63,
                     "startLine":342
                   }
-                }
+                },
+                "step":25
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5571,7 +6110,8 @@
                     "startColumn":56,
                     "startLine":342
                   }
-                }
+                },
+                "step":26
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5579,7 +6119,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":27
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5587,7 +6128,8 @@
                     "startColumn":46,
                     "startLine":342
                   }
-                }
+                },
+                "step":28
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5595,7 +6137,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":29
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5603,7 +6146,8 @@
                     "startColumn":33,
                     "startLine":342
                   }
-                }
+                },
+                "step":30
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5611,7 +6155,8 @@
                     "startColumn":36,
                     "startLine":346
                   }
-                }
+                },
+                "step":31
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/crt/stl70/streambuf",
@@ -5619,7 +6164,8 @@
                     "startColumn":13,
                     "startLine":346
                   }
-                }
+                },
+                "step":32
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-193.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-193.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":1,
                     "startLine":13
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":17
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":12,
                     "startLine":18
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":12,
                     "startLine":19
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":12,
                     "startLine":20
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":12,
                     "startLine":21
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":12,
                     "startLine":22
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":12,
                     "startLine":23
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":11,
                     "startLine":25
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":14,
                     "startLine":26
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":12,
                     "startLine":28
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":15,
                     "startLine":29
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":11,
                     "startLine":31
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":18,
                     "startLine":33
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":39,
                     "startLine":33
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":19,
                     "startLine":40
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test193.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":15,
                     "startLine":41
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-194.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-194.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":4
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test194.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":10,
                     "startLine":6
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test194.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":10,
                     "startLine":7
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test194.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":8,
                     "startLine":9
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test194.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":6,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test194.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":8,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":17,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":21
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":9,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":15,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -161,7 +170,8 @@
                     "startColumn":9,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":15,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":11,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":16,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":9,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":31,
                     "startLine":49
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -299,7 +322,8 @@
                     "startColumn":9,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":15,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":11,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":16,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":9,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":31,
                     "startLine":49
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":16,
                     "startLine":51
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":9,
                     "startLine":52
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -427,7 +466,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-197.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":16
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":21
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":22
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -87,7 +90,8 @@
                     "startColumn":6,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -95,7 +99,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -103,7 +108,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -111,7 +117,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -161,7 +170,8 @@
                     "startColumn":6,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -169,7 +179,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -177,7 +188,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -185,7 +197,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -193,7 +206,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -201,7 +215,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -209,7 +224,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -217,7 +233,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":11,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":16,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":9,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":31,
                     "startLine":49
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -299,7 +322,8 @@
                     "startColumn":6,
                     "startLine":35
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -307,7 +331,8 @@
                     "startColumn":12,
                     "startLine":37
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":11,
                     "startLine":38
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":15,
                     "startLine":40
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":17,
                     "startLine":42
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -339,7 +367,8 @@
                     "startColumn":21,
                     "startLine":42
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -347,7 +376,8 @@
                     "startColumn":9,
                     "startLine":43
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -355,7 +385,8 @@
                     "startColumn":18,
                     "startLine":43
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -363,7 +394,8 @@
                     "startColumn":11,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -371,7 +403,8 @@
                     "startColumn":11,
                     "startLine":46
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -379,7 +412,8 @@
                     "startColumn":16,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -387,7 +421,8 @@
                     "startColumn":9,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -395,7 +430,8 @@
                     "startColumn":11,
                     "startLine":49
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -403,7 +439,8 @@
                     "startColumn":31,
                     "startLine":49
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -411,7 +448,8 @@
                     "startColumn":16,
                     "startLine":51
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -419,7 +457,8 @@
                     "startColumn":9,
                     "startLine":52
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test197.cpp",
@@ -427,7 +466,8 @@
                     "startColumn":15,
                     "startLine":53
                   }
-                }
+                },
+                "step":17
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":10,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":28,
                     "startLine":51
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -175,7 +189,8 @@
                     "startColumn":10,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":16,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":15,
                     "startLine":57
                   }
-                }
+                },
+                "step":20
               }
             ]
           }
@@ -361,7 +395,8 @@
                     "startColumn":12,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":11,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":15,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":12,
                     "startLine":68
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":34,
                     "startLine":68
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":38,
                     "startLine":68
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":34,
                     "startLine":68
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":12,
                     "startLine":71
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":34,
                     "startLine":71
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":38,
                     "startLine":71
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":34,
                     "startLine":71
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-198.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":6,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":16,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":25,
                     "startLine":50
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":28,
                     "startLine":51
                   }
-                }
+                },
+                "step":14
               }
             ]
           }
@@ -175,7 +189,8 @@
                     "startColumn":6,
                     "startLine":41
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":19,
                     "startLine":43
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -191,7 +207,8 @@
                     "startColumn":16,
                     "startLine":45
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -199,7 +216,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -207,7 +225,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -215,7 +234,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -223,7 +243,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -231,7 +252,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -239,7 +261,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -247,7 +270,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -255,7 +279,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -263,7 +288,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -271,7 +297,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -279,7 +306,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -287,7 +315,8 @@
                     "startColumn":28,
                     "startLine":47
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -295,7 +324,8 @@
                     "startColumn":22,
                     "startLine":47
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -303,7 +333,8 @@
                     "startColumn":26,
                     "startLine":48
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -311,7 +342,8 @@
                     "startColumn":39,
                     "startLine":45
                   }
-                }
+                },
+                "step":18
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -319,7 +351,8 @@
                     "startColumn":28,
                     "startLine":45
                   }
-                }
+                },
+                "step":19
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -327,7 +360,8 @@
                     "startColumn":15,
                     "startLine":57
                   }
-                }
+                },
+                "step":20
               }
             ]
           }
@@ -361,7 +395,8 @@
                     "startColumn":7,
                     "startLine":64
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -369,7 +404,8 @@
                     "startColumn":11,
                     "startLine":66
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -377,7 +413,8 @@
                     "startColumn":15,
                     "startLine":66
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -385,7 +422,8 @@
                     "startColumn":12,
                     "startLine":68
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -393,7 +431,8 @@
                     "startColumn":34,
                     "startLine":68
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -401,7 +440,8 @@
                     "startColumn":38,
                     "startLine":68
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -409,7 +449,8 @@
                     "startColumn":34,
                     "startLine":68
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -417,7 +458,8 @@
                     "startColumn":12,
                     "startLine":71
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -425,7 +467,8 @@
                     "startColumn":34,
                     "startLine":71
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -433,7 +476,8 @@
                     "startColumn":38,
                     "startLine":71
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test198.cpp",
@@ -441,7 +485,8 @@
                     "startColumn":34,
                     "startLine":71
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":42,
                     "startLine":62
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":69
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":23,
                     "startLine":74
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":41,
                     "startLine":74
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":10,
                     "startLine":140
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":7,
                     "startLine":142
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":15,
                     "startLine":143
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":23,
                     "startLine":146
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":11,
                     "startLine":146
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":7,
                     "startLine":147
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":16,
                     "startLine":150
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":32,
                     "startLine":150
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":151
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -217,7 +233,8 @@
                     "startColumn":10,
                     "startLine":140
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":7,
                     "startLine":142
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":15,
                     "startLine":143
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":23,
                     "startLine":146
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":11,
                     "startLine":146
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":7,
                     "startLine":147
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":4,
                     "startLine":148
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -307,7 +331,8 @@
                     "startColumn":18,
                     "startLine":158
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":24,
                     "startLine":162
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":36,
                     "startLine":162
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":5,
                     "startLine":163
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -365,7 +393,8 @@
                     "startColumn":11,
                     "startLine":185
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":15,
                     "startLine":188
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -407,7 +437,8 @@
                     "startColumn":10,
                     "startLine":265
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":25,
                     "startLine":271
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":5,
                     "startLine":272
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -457,7 +490,8 @@
                     "startColumn":10,
                     "startLine":265
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -465,7 +499,8 @@
                     "startColumn":25,
                     "startLine":271
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -473,7 +508,8 @@
                     "startColumn":5,
                     "startLine":272
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-199.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":42,
                     "startLine":62
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":11,
                     "startLine":67
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":68
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":9,
                     "startLine":69
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":23,
                     "startLine":74
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":41,
                     "startLine":74
                   }
-                }
+                },
+                "step":6
               }
             ]
           }
@@ -111,7 +117,8 @@
                     "startColumn":10,
                     "startLine":140
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -119,7 +126,8 @@
                     "startColumn":7,
                     "startLine":142
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -127,7 +135,8 @@
                     "startColumn":15,
                     "startLine":143
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -135,7 +144,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -143,7 +153,8 @@
                     "startColumn":23,
                     "startLine":146
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -151,7 +162,8 @@
                     "startColumn":11,
                     "startLine":146
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -159,7 +171,8 @@
                     "startColumn":7,
                     "startLine":147
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -167,7 +180,8 @@
                     "startColumn":16,
                     "startLine":150
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -175,7 +189,8 @@
                     "startColumn":32,
                     "startLine":150
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -183,7 +198,8 @@
                     "startColumn":14,
                     "startLine":151
                   }
-                }
+                },
+                "step":10
               }
             ]
           }
@@ -217,7 +233,8 @@
                     "startColumn":10,
                     "startLine":140
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -225,7 +242,8 @@
                     "startColumn":7,
                     "startLine":142
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -233,7 +251,8 @@
                     "startColumn":15,
                     "startLine":143
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -241,7 +260,8 @@
                     "startColumn":13,
                     "startLine":144
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -249,7 +269,8 @@
                     "startColumn":23,
                     "startLine":146
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -257,7 +278,8 @@
                     "startColumn":11,
                     "startLine":146
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -265,7 +287,8 @@
                     "startColumn":7,
                     "startLine":147
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -273,7 +296,8 @@
                     "startColumn":4,
                     "startLine":148
                   }
-                }
+                },
+                "step":8
               }
             ]
           }
@@ -307,7 +331,8 @@
                     "startColumn":18,
                     "startLine":158
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -315,7 +340,8 @@
                     "startColumn":24,
                     "startLine":162
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -323,7 +349,8 @@
                     "startColumn":36,
                     "startLine":162
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -331,7 +358,8 @@
                     "startColumn":5,
                     "startLine":163
                   }
-                }
+                },
+                "step":4
               }
             ]
           }
@@ -365,7 +393,8 @@
                     "startColumn":11,
                     "startLine":185
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -373,7 +402,8 @@
                     "startColumn":15,
                     "startLine":188
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -407,7 +437,8 @@
                     "startColumn":10,
                     "startLine":265
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -415,7 +446,8 @@
                     "startColumn":25,
                     "startLine":271
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -423,7 +455,8 @@
                     "startColumn":5,
                     "startLine":272
                   }
-                }
+                },
+                "step":3
               }
             ]
           }
@@ -457,7 +490,8 @@
                     "startColumn":10,
                     "startLine":265
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -465,7 +499,8 @@
                     "startColumn":25,
                     "startLine":271
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test199.cpp",
@@ -473,7 +508,8 @@
                     "startColumn":5,
                     "startLine":272
                   }
-                }
+                },
+                "step":3
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-201.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-201.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test201.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":14
                   }
-                }
+                },
+                "step":2
               }
             ]
           }
@@ -79,7 +81,8 @@
                     "startColumn":9,
                     "startLine":38
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test201.cpp",
@@ -87,7 +90,8 @@
                     "startColumn":9,
                     "startLine":40
                   }
-                }
+                },
+                "step":2
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-203.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-203.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":19,
                     "startLine":1
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":9,
                     "startLine":3
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":17,
                     "startLine":5
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":11,
                     "startLine":7
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":9,
                     "startLine":8
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":11,
                     "startLine":13
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":14
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":11,
                     "startLine":19
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":15,
                     "startLine":20
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test203.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":14,
                     "startLine":22
                   }
-                }
+                },
+                "step":11
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":8
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":5,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":19,
                     "startLine":12
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":9,
                     "startLine":15
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":15,
                     "startLine":15
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":15,
                     "startLine":15
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":15,
                     "startLine":15
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":15,
                     "startLine":15
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":13,
                     "startLine":16
                   }
-                }
+                },
+                "step":15
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -157,7 +172,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":16
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -165,7 +181,8 @@
                     "startColumn":16,
                     "startLine":20
                   }
-                }
+                },
+                "step":17
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -173,7 +190,8 @@
                     "startColumn":13,
                     "startLine":22
                   }
-                }
+                },
+                "step":18
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/Expected-205.xml.sarif
@@ -37,7 +37,8 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":1
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -45,7 +46,8 @@
                     "startColumn":13,
                     "startLine":7
                   }
-                }
+                },
+                "step":2
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -53,7 +55,8 @@
                     "startColumn":5,
                     "startLine":8
                   }
-                }
+                },
+                "step":3
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -61,7 +64,8 @@
                     "startColumn":5,
                     "startLine":8
                   }
-                }
+                },
+                "step":4
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -69,7 +73,8 @@
                     "startColumn":9,
                     "startLine":10
                   }
-                }
+                },
+                "step":5
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -77,7 +82,8 @@
                     "startColumn":15,
                     "startLine":11
                   }
-                }
+                },
+                "step":6
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -85,7 +91,8 @@
                     "startColumn":22,
                     "startLine":11
                   }
-                }
+                },
+                "step":7
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -93,7 +100,8 @@
                     "startColumn":9,
                     "startLine":12
                   }
-                }
+                },
+                "step":8
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -101,7 +109,8 @@
                     "startColumn":19,
                     "startLine":12
                   }
-                }
+                },
+                "step":9
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -109,7 +118,8 @@
                     "startColumn":9,
                     "startLine":15
                   }
-                }
+                },
+                "step":10
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -117,7 +127,8 @@
                     "startColumn":15,
                     "startLine":15
                   }
-                }
+                },
+                "step":11
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -125,7 +136,8 @@
                     "startColumn":13,
                     "startLine":16
                   }
-                }
+                },
+                "step":12
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -133,7 +145,8 @@
                     "startColumn":9,
                     "startLine":19
                   }
-                }
+                },
+                "step":13
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -141,7 +154,8 @@
                     "startColumn":16,
                     "startLine":20
                   }
-                }
+                },
+                "step":14
               },{
                 "physicalLocation":{
                   "uri":"file:///c:/somepath/test205.cpp",
@@ -149,7 +163,8 @@
                     "startColumn":13,
                     "startLine":22
                   }
-                }
+                },
+                "step":15
               }
             ]
           }

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/LongConditions.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/LongConditions.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":7
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'simpleVar' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":10
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '<branch condition>' is false)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":16
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'simpleVar' is used, but may not have been initialized",
                 "importance":"essential"
@@ -109,7 +118,10 @@
                     "startLine":21
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'simpleVar' is not initialized",
                 "importance":"essential"
@@ -121,7 +133,10 @@
                     "startLine":23
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!isInitializzedd' is false)"
               },{
@@ -132,7 +147,10 @@
                     "startLine":28
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'simpleVar' is used, but may not have been initialized",
                 "importance":"essential"
@@ -175,7 +193,10 @@
                     "startLine":33
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'simpleVar' is not initialized",
                 "importance":"essential"
@@ -187,7 +208,10 @@
                     "startLine":35
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '!isDefined' is false)"
               },{
@@ -198,7 +222,10 @@
                     "startLine":40
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'simpleVar' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/LongMacro.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/LongMacro.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":5
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'simpleVar' is not initialized",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":7
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume '(((int)(hrLongVar)))>4' is false)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":12
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'simpleVar' is used, but may not have been initialized",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/RelevantKeyEvents2.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/RelevantKeyEvents2.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":12
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"branch",
                 "message":"'pNodeFree' may be NULL (Enter this branch)"
               },{
@@ -53,7 +56,9 @@
                     "startColumn":14,
                     "startLine":14
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents2.cpp",
@@ -61,7 +66,9 @@
                     "startColumn":18,
                     "startLine":16
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents2.cpp",
@@ -70,7 +77,10 @@
                     "startLine":16
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this loop, (assume 'i>=0' is false)"
               },{
@@ -81,7 +91,10 @@
                     "startLine":23
                   }
                 },
-                "step":2,
+                "step":5,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"alias",
                 "message":"(alias) 'pNode' receives the value of 'pNodeFree' (which may be NULL)",
                 "importance":"essential"
@@ -93,7 +106,10 @@
                     "startLine":24
                   }
                 },
-                "step":3,
+                "step":6,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"'pNode' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/RelevantkeyEvents.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/RelevantkeyEvents.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":3
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'a' is an array of 5 elements (5 bytes)",
                 "importance":"essential"
@@ -54,7 +57,9 @@
                     "startColumn":13,
                     "startLine":4
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -62,7 +67,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -70,7 +77,9 @@
                     "startColumn":33,
                     "startLine":4
                   }
-                }
+                },
+                "step":4,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -78,7 +87,9 @@
                     "startColumn":24,
                     "startLine":4
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -86,7 +97,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":6,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -94,7 +107,9 @@
                     "startColumn":33,
                     "startLine":4
                   }
-                }
+                },
+                "step":7,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -102,7 +117,9 @@
                     "startColumn":24,
                     "startLine":4
                   }
-                }
+                },
+                "step":8,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -110,7 +127,9 @@
                     "startColumn":19,
                     "startLine":4
                   }
-                }
+                },
+                "step":9,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -118,7 +137,9 @@
                     "startColumn":9,
                     "startLine":5
                   }
-                }
+                },
+                "step":10,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/relevantkeyevents/relevantkeyevents.cpp",
@@ -127,7 +148,10 @@
                     "startLine":6
                   }
                 },
-                "step":1,
+                "step":11,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'i<=5')"
               },{
@@ -138,7 +162,10 @@
                     "startLine":8
                   }
                 },
-                "step":2,
+                "step":12,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'a[5]', (readable range is 0 to 4)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS260613.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS260613.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":9,
                     "startLine":6
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs260613.cpp",
@@ -50,7 +52,9 @@
                     "startColumn":9,
                     "startLine":7
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs260613.cpp",
@@ -59,7 +63,10 @@
                     "startLine":9
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'offset' is a byte quantity",
                 "importance":"essential"
@@ -71,7 +78,10 @@
                     "startLine":10
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -113,7 +123,9 @@
                     "startColumn":9,
                     "startLine":17
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs260613.cpp",
@@ -121,7 +133,9 @@
                     "startColumn":9,
                     "startLine":18
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs260613.cpp",
@@ -130,7 +144,10 @@
                     "startLine":20
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS348783.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS348783.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":9
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'buffer' is an array of 10 elements (20 bytes)",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":10
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'buffer' is an Output from 'wcscpy_s' (declared at c:\\program files (x86)\\microsoft visual studio 11.0\\vc\\wpsdk\\wp80\\include\\string.h:285)"
               },{
@@ -66,7 +72,10 @@
                     "startLine":10
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'buffer[19]', (writable range is 0 to 9)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS370524.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS370524.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":8,
                     "startLine":11
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs370524.cpp",
@@ -51,7 +53,10 @@
                     "startLine":12
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'target' may be NULL",
                 "importance":"essential"
@@ -63,7 +68,10 @@
                     "startLine":13
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'target' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -105,7 +113,9 @@
                     "startColumn":8,
                     "startLine":21
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs370524.cpp",
@@ -114,7 +124,10 @@
                     "startLine":22
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'target' may be NULL",
                 "importance":"essential"
@@ -126,7 +139,10 @@
                     "startLine":23
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'target' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -169,7 +185,10 @@
                     "startLine":31
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'target' may be NULL",
                 "importance":"essential"
@@ -180,7 +199,9 @@
                     "startColumn":10,
                     "startLine":32
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs370524.cpp",
@@ -189,7 +210,10 @@
                     "startLine":33
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"'target' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS372959.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS372959.cpp.xml.sarif
@@ -42,7 +42,9 @@
                     "startColumn":7,
                     "startLine":10
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -50,7 +52,9 @@
                     "startColumn":5,
                     "startLine":11
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -59,7 +63,10 @@
                     "startLine":13
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -71,7 +78,10 @@
                     "startLine":15
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -113,7 +123,9 @@
                     "startColumn":5,
                     "startLine":22
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -121,7 +133,9 @@
                     "startColumn":7,
                     "startLine":23
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -130,7 +144,10 @@
                     "startLine":25
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'this->j' may equal 8",
                 "importance":"essential"
@@ -142,7 +159,10 @@
                     "startLine":27
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -184,7 +204,9 @@
                     "startColumn":7,
                     "startLine":34
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -192,7 +214,9 @@
                     "startColumn":5,
                     "startLine":35
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -201,7 +225,10 @@
                     "startLine":37
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'i' is a byte quantity",
                 "importance":"essential"
@@ -213,7 +240,10 @@
                     "startLine":39
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -255,7 +285,9 @@
                     "startColumn":5,
                     "startLine":46
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -263,7 +295,9 @@
                     "startColumn":7,
                     "startLine":47
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -272,7 +306,10 @@
                     "startLine":49
                   }
                 },
-                "step":0,
+                "step":3,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'this->j' may equal 14",
                 "importance":"essential"
@@ -284,7 +321,10 @@
                     "startLine":51
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -326,7 +366,9 @@
                     "startColumn":7,
                     "startLine":58
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -335,7 +377,10 @@
                     "startLine":59
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'j2' is a byte quantity",
                 "importance":"essential"
@@ -347,7 +392,10 @@
                     "startLine":61
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'i' receives the value of 'j2' (which is in bytes)",
                 "importance":"essential"
@@ -359,7 +407,10 @@
                     "startLine":63
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -401,7 +452,9 @@
                     "startColumn":7,
                     "startLine":70
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -410,7 +463,10 @@
                     "startLine":71
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'j2' is a byte quantity",
                 "importance":"essential"
@@ -422,7 +478,10 @@
                     "startLine":73
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"alias",
                 "message":"(alias) 'i' receives a byte quantity from 'j2'",
                 "importance":"essential"
@@ -434,7 +493,10 @@
                     "startLine":75
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -476,7 +538,9 @@
                     "startColumn":7,
                     "startLine":85
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -485,7 +549,10 @@
                     "startLine":86
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'this->cb' may equal 4",
                 "importance":"essential"
@@ -497,7 +564,10 @@
                     "startLine":88
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"
@@ -539,7 +609,9 @@
                     "startColumn":7,
                     "startLine":94
                   }
-                }
+                },
+                "step":1,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs372959.cpp",
@@ -548,7 +620,10 @@
                     "startLine":95
                   }
                 },
-                "step":0,
+                "step":2,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'cb2' is a byte quantity",
                 "importance":"essential"
@@ -560,7 +635,10 @@
                     "startLine":97
                   }
                 },
-                "step":1,
+                "step":3,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Expression mixes element counts and byte quantities",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS373273.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS373273.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":10
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'n' is equal to 5",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":11
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 5 elements (20 bytes)",
                 "importance":"essential"
@@ -66,7 +72,9 @@
                     "startColumn":10,
                     "startLine":12
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs373273.cpp",
@@ -75,7 +83,10 @@
                     "startLine":14
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"declaration",
                 "message":"'n' is an In\/Out argument to 'new[]' (declared at d:\\src\\sarif-sdk\\src\\sarif.functionaltests\\convertertestdata\\prefast\\predefined c++ types (compiler internal):38)"
               },{
@@ -86,7 +97,10 @@
                     "startLine":16
                   }
                 },
-                "step":3,
+                "step":5,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[5]', (readable range is 0 to 4)",
                 "importance":"essential"
@@ -129,7 +143,10 @@
                     "startLine":36
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'n' is equal to 5",
                 "importance":"essential"
@@ -141,7 +158,10 @@
                     "startLine":37
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"declaration",
                 "message":"'data' is an array of 5 elements (20 bytes)",
                 "importance":"essential"
@@ -152,7 +172,9 @@
                     "startColumn":10,
                     "startLine":38
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs373273.cpp",
@@ -161,7 +183,10 @@
                     "startLine":40
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'n' is an Input to 'SampleClass::{ctor}' (declared on line 28)"
               },{
@@ -172,7 +197,10 @@
                     "startLine":42
                   }
                 },
-                "step":3,
+                "step":5,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"usage",
                 "message":"Invalid read from 'data[5]', (readable range is 0 to 4)",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS375867.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS375867.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":8
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":9
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'SUCCEEDED(hr)')"
               },{
@@ -66,7 +72,10 @@
                     "startLine":11
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -109,7 +118,10 @@
                     "startLine":17
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -121,7 +133,10 @@
                     "startLine":18
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'SUCCEEDED(hr)&&b' is false)"
               },{
@@ -132,7 +147,10 @@
                     "startLine":24
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -175,7 +193,10 @@
                     "startLine":30
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -187,7 +208,10 @@
                     "startLine":31
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '((SUCCEEDED(hr)||b))&&c')"
               },{
@@ -198,7 +222,10 @@
                     "startLine":33
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -241,7 +268,10 @@
                     "startLine":39
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -253,7 +283,10 @@
                     "startLine":40
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!SUCCEEDED(_hResult)')"
               },{
@@ -264,7 +297,10 @@
                     "startLine":42
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -307,7 +343,10 @@
                     "startLine":48
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -319,7 +358,10 @@
                     "startLine":49
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'FAILED(hr)')"
               },{
@@ -330,7 +372,10 @@
                     "startLine":51
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -373,7 +418,10 @@
                     "startLine":57
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -385,7 +433,10 @@
                     "startLine":58
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Skip this branch, (assume 'FAILED(hr)&&b||SUCCEEDED(hr)' is false)"
               },{
@@ -396,7 +447,10 @@
                     "startLine":64
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -439,7 +493,10 @@
                     "startLine":70
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -451,7 +508,10 @@
                     "startLine":71
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '((FAILED(Hr_2)||b))&&c')"
               },{
@@ -462,7 +522,10 @@
                     "startLine":73
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -505,7 +568,10 @@
                     "startLine":79
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -517,7 +583,10 @@
                     "startLine":80
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '!FAILED(hr)')"
               },{
@@ -528,7 +597,10 @@
                     "startLine":82
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -571,7 +643,10 @@
                     "startLine":88
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -583,7 +658,10 @@
                     "startLine":89
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'hr==S_FALSE')"
               },{
@@ -594,7 +672,10 @@
                     "startLine":91
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -637,7 +718,10 @@
                     "startLine":97
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -649,7 +733,10 @@
                     "startLine":98
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'b&&((c||S_FALSE==hr))')"
               },{
@@ -660,7 +747,10 @@
                     "startLine":100
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -703,7 +793,10 @@
                     "startLine":106
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -715,7 +808,10 @@
                     "startLine":107
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume 'S_OK==hr')"
               },{
@@ -726,7 +822,10 @@
                     "startLine":109
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"
@@ -769,7 +868,10 @@
                     "startLine":115
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'data' is NULL",
                 "importance":"essential"
@@ -781,7 +883,10 @@
                     "startLine":116
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this branch, (assume '((S_FALSE+S_OK))==hr')"
               },{
@@ -792,7 +897,10 @@
                     "startLine":118
                   }
                 },
-                "step":2,
+                "step":3,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"'data' is dereferenced, but may still be NULL",
                 "importance":"essential"

--- a/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS378661.cpp.xml.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/PREfast/TFS378661.cpp.xml.sarif
@@ -43,7 +43,10 @@
                     "startLine":6
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'seq' is an array of 5 elements (20 bytes)",
                 "importance":"essential"
@@ -55,7 +58,10 @@
                     "startLine":10
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'seq[5]', (writable range is 0 to 4)",
                 "importance":"essential"
@@ -98,7 +104,10 @@
                     "startLine":13
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'seq' is an array of 4 elements (16 bytes)",
                 "importance":"essential"
@@ -110,7 +119,10 @@
                     "startLine":17
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'seq[4]', (writable range is 0 to 3)",
                 "importance":"essential"
@@ -153,7 +165,10 @@
                     "startLine":20
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'seq' is an array of 1 elements (4 bytes)",
                 "importance":"essential"
@@ -164,7 +179,9 @@
                     "startColumn":6,
                     "startLine":24
                   }
-                }
+                },
+                "step":2,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs378661.cpp",
@@ -172,7 +189,9 @@
                     "startColumn":8,
                     "startLine":25
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs378661.cpp",
@@ -181,7 +200,10 @@
                     "startLine":25
                   }
                 },
-                "step":1,
+                "step":4,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"Enter this loop, (assume 'i<size')"
               },{
@@ -191,7 +213,9 @@
                     "startColumn":10,
                     "startLine":27
                   }
-                }
+                },
+                "step":5,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs378661.cpp",
@@ -200,7 +224,10 @@
                     "startLine":25
                   }
                 },
-                "step":2,
+                "step":6,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"declaration",
                 "message":"'i' may equal 1",
                 "importance":"essential"
@@ -212,7 +239,10 @@
                     "startLine":25
                   }
                 },
-                "step":3,
+                "step":7,
+                "properties":{
+                  "keyEventId":"4"
+                },
                 "kind":"branch",
                 "message":"Exit this loop, ('i<size' is false)"
               },{
@@ -223,7 +253,10 @@
                     "startLine":29
                   }
                 },
-                "step":4,
+                "step":8,
+                "properties":{
+                  "keyEventId":"5"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'seq[1]', (writable range is 0 to 0)",
                 "importance":"essential"
@@ -266,7 +299,10 @@
                     "startLine":32
                   }
                 },
-                "step":0,
+                "step":1,
+                "properties":{
+                  "keyEventId":"1"
+                },
                 "kind":"declaration",
                 "message":"'seq' is an array of 4 elements (16 bytes)",
                 "importance":"essential"
@@ -278,7 +314,10 @@
                     "startLine":36
                   }
                 },
-                "step":1,
+                "step":2,
+                "properties":{
+                  "keyEventId":"2"
+                },
                 "kind":"branch",
                 "message":"'size' may equal 4 (Enter this branch)"
               },{
@@ -288,7 +327,9 @@
                     "startColumn":10,
                     "startLine":38
                   }
-                }
+                },
+                "step":3,
+                "importance":"unimportant"
               },{
                 "physicalLocation":{
                   "uri":"file:///d:/src/sarif-sdk/src/sarif.functionaltests/convertertestdata/prefast/src/fixedbugs/tfs378661.cpp",
@@ -297,7 +338,10 @@
                     "startLine":40
                   }
                 },
-                "step":2,
+                "step":4,
+                "properties":{
+                  "keyEventId":"3"
+                },
                 "kind":"usage",
                 "message":"Invalid write to 'seq[4]', (writable range is 0 to 3)",
                 "importance":"essential"


### PR DESCRIPTION
This work was partially done in June (commits f200c04e and ca4144cb). But:

1. The converter didn't actually emit the `step` property for `SFA`s without a `KEYEVENT`.
2. It didn't emit the `keyEventId` property into the property bag the way PREfast does during direct production.
3. It used a 0-based `step` property.
4. It didn't set `"importance":"unimportant"` for `SFA`s without a `KEYEVENT`.
5. It didn't check to see if the checker actually used `KEYEVENT`s.

Note: The implementation differs from the direct production implementation in PREfast in that the converter doesn't bother to emit the default value `"importance": "important"` in those cases where it would be appropriate. We should talk about whether to change PREfast to do the same.