### PR TITLE
Fix #504: Schema allows additional properties on "notification" object

### DIFF
--- a/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
@@ -254,7 +254,7 @@
           "ruleId": "C2152",
           "level": "error",
           "message": "Exception evaluating rule \"C2152\". Rule disabled; run continues.",
-          "analysisTarget": {
+          "physicalLocation": {
             "uri": "file:///home/buildAgent/src/crypto/hash.cpp"
           },
           "threadId": 52,

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -530,6 +530,7 @@
     "notification": {
       "type": "object",
       "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "additionalProperties": false,
       "properties": {
 
         "id": {


### PR DESCRIPTION
The schema did not specify "additionalProperties": false on the notification object. As a result, the validation tests did not detect an error in the Comprehensive.sarif sample file, where a toolNotification incorrectly had an analysisTarget property instead of a physicalLocation property.

Fixed the schema and the sample.

@michaelcfanning FYI. I'm going to merge this.