### PR TITLE
Fix #507: Add IAnalyzeOptions .NoConsoleOutput

### DIFF
--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -26,6 +26,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 TargetFileSpecifiers = new string[0]
             };
 
+            analyzeOptions.NoConsoleOutput = true;
+
             var command = new TestAnalyzeCommand();
 
             Assembly[] plugInAssemblies = null;
@@ -440,6 +442,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     TargetFileSpecifiers = new string[] { fileName },
                     Verbose = true,
                     Statistics = true,
+                    NoConsoleOutput = true,
                     ComputeTargetsHash = true,
                     ConfigurationFilePath = TestAnalyzeCommand.DEFAULT_POLICY_NAME,
                     Recurse = true,

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 TargetFileSpecifiers = new string[0]
             };
 
-            analyzeOptions.NoConsoleOutput = true;
+            analyzeOptions.Quiet = true;
 
             var command = new TestAnalyzeCommand();
 
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     TargetFileSpecifiers = new string[] { fileName },
                     Verbose = true,
                     Statistics = true,
-                    NoConsoleOutput = true,
+                    Quiet = true,
                     ComputeTargetsHash = true,
                     ConfigurationFilePath = TestAnalyzeCommand.DEFAULT_POLICY_NAME,
                     Recurse = true,

--- a/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public bool Recurse { get; set; }
 
+        public bool NoConsoleOutput { get; set; }
+
         public bool Statistics { get; set; }
 
         public IEnumerable<string> TargetFileSpecifiers { get; set; }

--- a/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
+++ b/src/Sarif.Driver.UnitTests/TestAnalyzeOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public bool Recurse { get; set; }
 
-        public bool NoConsoleOutput { get; set; }
+        public bool Quiet { get; set; }
 
         public bool Statistics { get; set; }
 

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -161,7 +161,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         internal AggregatingLogger InitializeLogger(IAnalyzeOptions analyzeOptions)
         {
             var logger = new AggregatingLogger();
-            logger.Loggers.Add(new ConsoleLogger(analyzeOptions.Verbose));
+
+            if (!analyzeOptions.NoConsoleOutput)
+            {
+                logger.Loggers.Add(new ConsoleLogger(analyzeOptions.Verbose));
+            }
 
             if (analyzeOptions.Statistics)
             {

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             var logger = new AggregatingLogger();
 
-            if (!analyzeOptions.NoConsoleOutput)
+            if (!analyzeOptions.Quiet)
             {
                 logger.Loggers.Add(new ConsoleLogger(analyzeOptions.Verbose));
             }

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -39,10 +39,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public string ConfigurationFilePath { get; set; }
 
         [Option(
-            'n',
-            "no-console-output",
+            'q',
+            "quiet",
             HelpText = "Do not log results to the console.")]
-        public bool NoConsoleOutput { get; set; }
+        public bool Quiet { get; set; }
 
         [Option(
             's',

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -39,6 +39,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         public string ConfigurationFilePath { get; set; }
 
         [Option(
+            'n',
+            "no-console-output",
+            HelpText = "Do not log results to the console.")]
+        public bool NoConsoleOutput { get; set; }
+
+        [Option(
             's',
             "statistics",
             HelpText = "Generate timing and other statistics for analysis session.")]

--- a/src/Sarif/IAnalyzeOptions.cs
+++ b/src/Sarif/IAnalyzeOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         string ConfigurationFilePath { get; }
 
-        bool NoConsoleOutput { get; }
+        bool Quiet { get; }
 
         bool Statistics { get; }
 

--- a/src/Sarif/IAnalyzeOptions.cs
+++ b/src/Sarif/IAnalyzeOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         string ConfigurationFilePath { get; }
 
+        bool NoConsoleOutput { get; }
+
         bool Statistics { get; }
 
         bool ComputeTargetsHash { get; }


### PR DESCRIPTION
Add a Boolean property `NoConsoleOutput` to `IAnalyzeOptions` and `AnalyzeOptionsBase`. When set, it will prevent the `AggregatingLogger` from including a `ConsoleLogger` (in the same way -- but with the opposite logical sense -- that the `Statistics` property causes the `AggregatingLogger` to include a `StatisticsLogger`).

The reason for doing this is that functional tests can set this property on the options object, so the console output from the tests will be clean instead of including the (expected) error output.

With this change, the output from the functional tests looks like this:

```
xUnit.net Console Runner (32-bit .NET 4.0.30319.42000)
  Discovering: Sarif.Driver.UnitTests
  Discovered:  Sarif.Driver.UnitTests
  Starting:    Sarif.Driver.UnitTests

# valid targets: 1
# invalid targets: 0
Time elapsed: 00:00:00.0258590
  Finished:    Sarif.Driver.UnitTests
```

(The remaining console output is from the statistics logger.)

NOTE: My motivation for doing this is that the SarifCli.FunctionalTests were also producing console output which I didn't want to see. If you really want to keep seeing the console output from the Sarif.Driver unit tests, I can revert the changes to AnalyzeCommandTests, but keep the rest of the changes. That will let me suppress the console output from my SarifCli.FunctionalTests. But I do think that that test output should be clean.