### PR TITLE
Add AnalyzeCommandBase.LogToolNotification

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 
@@ -479,7 +480,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             return skimmers;
         }
 
-
         public virtual void ConfigureFromOptions(TContext context, TOptions analyzeOptions)
         {
             PropertiesDictionary configuration = null;
@@ -495,6 +495,34 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 }
             }
             context.Policy = configuration;
-        }       
+        }
+
+        protected static void LogToolNotification(
+            IAnalysisLogger logger,
+            string message,
+            NotificationLevel level = NotificationLevel.Note,
+            Exception ex = null)
+        {
+            ExceptionData exceptionData = null;
+            if (ex != null)
+            {
+                exceptionData = new ExceptionData
+                {
+                    Kind = ex.GetType().FullName,
+                    Message = ex.Message,
+                    Stack = Stack.CreateStacks(ex).FirstOrDefault()
+                };
+            }
+
+            TextWriter writer = level == NotificationLevel.Error ? Console.Error : Console.Out;
+            writer.WriteLine(message);
+
+            logger.LogToolNotification(new Notification
+            {
+                Level = level,
+                Message = message,
+                Exception = exceptionData
+            });
+        }
     }
 }


### PR DESCRIPTION
This was originally in SarifCli, but it's generally useful. After we publish a new version of the driver with this change, we'll upgrade SarifCli to use it (in a separate commit), and remove SarifCli's copy of the method.

NOTE: There are other two seemingly-generally-useful methods in SarifCli's derived `AnalyzeCommand` class: `LogResult` and `LogResults`. But they're SARIF-specific, so they don't belong in the framework. With a little more work they could be refactored so the common parts could be put into the framework, but I won't do that now.