### PR TITLE
Fix #506, Fix #521

### DIFF
--- a/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
+++ b/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Sdk\FormatForVisualStudioTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SarifHelpers.cs" />
+    <Compile Include="Sdk\RuleUtilitiesTests.cs" />
     <Compile Include="Sdk\SarifLoggerTests.cs" />
     <Compile Include="TestAnalysisContext.cs" />
     <Compile Include="TestAnalyzeCommand.cs" />

--- a/src/Sarif.Driver.UnitTests/Sdk/RuleUtilitiesTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/RuleUtilitiesTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Driver;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Driver.Sdk
+{
+    public class RuleUtilitiesTests
+    {
+        [Fact]
+        public void BuildResult_BuildsExpectedResult()
+        {
+            // Arrange
+            const string FormatId = "Default";
+            const string RuleId = "TST0001";
+            string[] Arguments = new string[] { "42", "54" };
+
+            var context = new TestAnalysisContext
+            {
+                TargetUri = new System.Uri("file:///c:/src/file.c"),
+                Rule = new Rule
+                {
+                    Id = RuleId,
+                    MessageFormats = new Dictionary<string, string>
+                    {
+                        [FormatId] = "Expected {0} but got {1}."
+                    }
+                }
+            };
+
+            var region = new Region
+            {
+                StartLine = 42
+            };
+
+            // Act.
+            Result result = RuleUtilities.BuildResult(
+                ResultLevel.Error,
+                context,
+                region,
+                FormatId,
+                Arguments);
+
+            // Assert.
+            result.RuleId.Should().Be(RuleId);
+
+            result.FormattedRuleMessage.FormatId.Should().Be(FormatId);
+
+            result.FormattedRuleMessage.Arguments.Count.Should().Be(Arguments.Length);
+            result.FormattedRuleMessage.Arguments[0].Should().Be(Arguments[0]);
+            result.FormattedRuleMessage.Arguments[1].Should().Be(Arguments[1]);
+
+            result.Locations.Count.Should().Be(1);
+            result.Locations[0].AnalysisTarget.Region.ValueEquals(region).Should().BeTrue();
+        }
+    }
+}

--- a/src/Sarif/RuleUtilities.cs
+++ b/src/Sarif/RuleUtilities.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Resources;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -24,33 +22,22 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(arguments));
             }
 
-            string[] messageArguments = arguments;
-
             formatId = RuleUtilities.NormalizeFormatId(context.Rule.Id, formatId);
 
-            string targetPath = context.TargetUri?.LocalPath;
-
-            Result result = new Result();
-
-            result.RuleId = context.Rule.Id;
-
-            if (!string.IsNullOrEmpty(targetPath))
+            Result result = new Result
             {
-                // In the event of an analysis target, we always provide
-                // the local path to this item as the 0th argument
-                messageArguments = new string[arguments.Length + 1];
-                messageArguments[0] = Path.GetFileName(targetPath);
-                arguments.CopyTo(messageArguments, 1);
-            }
+                RuleId = context.Rule.Id,
 
-            result.FormattedRuleMessage = new FormattedRuleMessage()
-            {
-                FormatId = formatId,
-                Arguments = messageArguments
+                FormattedRuleMessage = new FormattedRuleMessage()
+                {
+                    FormatId = formatId,
+                    Arguments = arguments
+                },
+
+                Level = level
             };
 
-            result.Level = level;
-
+            string targetPath = context.TargetUri?.LocalPath;
             if (targetPath != null)
             {
                 result.Locations = new List<Location> {

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An exception was raised analyzing &apos;{0}&apos; for check &apos;{1}&apos; (which has been disabled). The exception may have resulted from a problem related to parsing image metadata and not specific to the rule, however..
+        ///   Looks up a localized string similar to An exception was raised analyzing &apos;{0}&apos; for check &apos;{1}&apos; (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target, and not specific to the rule, however..
         /// </summary>
         internal static string ERR998_ExceptionInAnalyze {
             get {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -166,7 +166,7 @@
     <value>Could not create output file '{0}'.</value>
   </data>
   <data name="ERR998_ExceptionInAnalyze" xml:space="preserve">
-    <value>An exception was raised analyzing '{0}' for check '{1}' (which has been disabled). The exception may have resulted from a problem related to parsing image metadata and not specific to the rule, however.</value>
+    <value>An exception was raised analyzing '{0}' for check '{1}' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target, and not specific to the rule, however.</value>
   </data>
   <data name="ERR998_ExceptionInCanAnalyze" xml:space="preserve">
     <value>An exception was raised attempting to determine whether '{0}' is a valid analysis target for check '{1}' (which has been disabled). The exception may have resulted from a problem related to parsing the analysis target and not specific to the rule, however.</value>


### PR DESCRIPTION
506: Driver framework produces binary analysis-specific message
521: Framework insists on repeating file name in {0} of formatted messages

521: The framework was implemented this way for the sake of BinSkim, which really does want to mention the name of the binary at the start of each message, for example:

    Foo.dll is not marked with DYNAMICBASE.

But for other tools, it doesn't always make sense. Remove the SDK code that automatically prepends the file name as `{0}`. When BinSkim upgrades to a version of the SDK with this change, it will have to be updated to explicitly specify the file name in each list of formatted message arguments.