### PR TITLE
SarifCli: Let the framework catch unhandled exceptions

### DIFF
--- a/src/Sarif/Writers/MimeType.cs
+++ b/src/Sarif/Writers/MimeType.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         /// <summary>The MIME type used for CSharp files.</summary>
         public static readonly string CSharp = "text/x-csharp";
         /// <summary>The MIME type for SARIF files.</summary>
-        public static readonly string Sarif = "text/x-sarif";
+        public static readonly string Sarif = "application/sarif-json";
 
         private static bool HasExtension(string fileName, string extension)
         {

--- a/src/SarifCli/AnalyzeCommand.cs
+++ b/src/SarifCli/AnalyzeCommand.cs
@@ -115,16 +115,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Cli
             {
                 ReportInvalidSchemaErrors(ex, schemaFilePath, logger);
             }
-            catch (Exception ex)
-            {
-                LogToolNotification(logger, ex.Message, NotificationLevel.Error, ex);
-
-                // Don't try to run the skimmers if something unexpected happened.
-                // Sure, if it were something schema-validation-specific, like "can't
-                // find schema file," then we could successfully run the skimmers,
-                // but I don't think it's worth trying to be that clever.
-                ok = false;
-            }
+            // The framework will catch all other, unexpected exceptions, and it will
+            // cause the tool to exit with a non-0 exit code.
 
             return ok;
         }

--- a/src/SarifCli/SarifValidationContext.cs
+++ b/src/SarifCli/SarifValidationContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Cli
 
         public string MimeType
         {
-            get { return "text/x-sarif"; }
+            get { return "application/sarif-json"; }
             set { throw new InvalidOperationException(); }
         }
 


### PR DESCRIPTION
Also:
* Set SARIF MIME type to `application/sarif+json`.

NOTE: We can't yet DRY out SarifCli's usage of that literal string -- that is, we can't have SarifCli refer to the new value of `MimeType.Sarif` -- until the next time we upgrade SarifCli to consume the latest version of the SDK. Remember, SarifCli consumes the SDK from NuGet, not as a P2P dependency.

@michaelcfanning FYI. Merging this. Continuing to address PR feedback on SarifCli.