### PR TITLE
Fortify FPR converter

### DIFF
--- a/src/ConvertToSarif/ConvertOptions.cs
+++ b/src/ConvertToSarif/ConvertOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.ConvertToSarif
         [Option(
             't',
             "tool",
-            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FxCop, PREfast, Semmle, or StaticDriverVerifier.",
+            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, Semmle, or StaticDriverVerifier.",
             Required = true)]
         public ToolFormat ToolFormat { get; internal set; }
 

--- a/src/Sarif.Converters/AndroidStudioConverter.cs
+++ b/src/Sarif.Converters/AndroidStudioConverter.cs
@@ -9,9 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using Microsoft.CodeAnalysis.Sarif.Readers;
 using Microsoft.CodeAnalysis.Sarif.Writers;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
@@ -75,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var fileInfoFactory = new FileInfoFactory(uri => MimeType.Java);
             Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
 

--- a/src/Sarif.Converters/ClangAnalyzerConverter.cs
+++ b/src/Sarif.Converters/ClangAnalyzerConverter.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
                 Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-                output.Initialize(id: null, correlationId: null);
+                output.Initialize(id: null, automationId: null);
 
                 output.WriteTool(tool);
                 if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }

--- a/src/Sarif.Converters/CppCheckConverter.cs
+++ b/src/Sarif.Converters/CppCheckConverter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var fileInfoFactory = new FileInfoFactory(uri => MimeType.Cpp);
             Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
             if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }

--- a/src/Sarif.Converters/FortifyConverter.cs
+++ b/src/Sarif.Converters/FortifyConverter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
             Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
             if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private XmlReader _reader;
         private Invocation _invocation;
+        private string _runId;
         private string _automationId;
         private List<Result> _results = new List<Result>();
         private List<Notification> _toolNotifications = new List<Notification>();
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ParseFprFile(input);
             AddMessagesToResults();
 
-            output.Initialize(id: null, automationId: _automationId);
+            output.Initialize(id: _runId, automationId: _automationId);
 
             output.WriteTool(tool);
             output.WriteInvocation(_invocation);
@@ -117,6 +118,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 while (_reader.Read())
                 {
+                    if (AtStartOfNonEmpty(_strings.Uuid))
+                    {
+                        ParseUuid();
+                    }
                     if (AtStartOfNonEmpty(_strings.Build))
                     {
                         ParseBuild();
@@ -143,6 +148,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     }
                 }
             }
+        }
+
+        private void ParseUuid()
+        {
+            _runId = _reader.ReadElementContentAsString();
         }
 
         private void ParseBuild()

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ParseFprFile(input);
             AddMessagesToResults();
             AddSnippetsToResults();
+            AddSnippetsToAnnotatedCodeLocations();
 
             output.Initialize(id: _runId, automationId: _automationId);
 
@@ -585,6 +586,31 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     _snippetIdToSnippetTextDictionary.TryGetValue(snippetId, out snippetText))
                 {
                     result.Snippet = snippetText;
+                }
+            }
+        }
+
+        private void AddSnippetsToAnnotatedCodeLocations()
+        {
+            foreach (Result result in _results)
+            {
+                if (result.CodeFlows != null)
+                {
+                    foreach (CodeFlow codeFlow in result.CodeFlows)
+                    {
+                        if (codeFlow.Locations != null)
+                        {
+                            foreach (AnnotatedCodeLocation acl in codeFlow.Locations)
+                            {
+                                string snippetId, snippetText;
+                                if (_aclToSnippetIdDictionary.TryGetValue(acl, out snippetId) &&
+                                    _snippetIdToSnippetTextDictionary.TryGetValue(snippetId, out snippetText))
+                                {
+                                    acl.Snippet = snippetText;
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private readonly NameTable _nameTable;
         private readonly FortifyFprStrings _strings;
 
+        private XmlReader _reader;
         private Invocation _invocation;
         private string _automationId;
         private List<Notification> _toolNotifications = new List<Notification>();
@@ -99,78 +100,78 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 XmlResolver = null
             };
 
-            using (XmlReader reader = XmlReader.Create(auditStream, settings))
+            using (_reader = XmlReader.Create(auditStream, settings))
             {
-                while (reader.Read())
+                while (_reader.Read())
                 {
-                    if (reader.IsStartElement())
+                    if (_reader.IsStartElement())
                     {
-                        if (Ref.Equal(reader.LocalName, _strings.Build))
+                        if (Ref.Equal(_reader.LocalName, _strings.Build))
                         {
-                            ParseBuild(reader);
+                            ParseBuild();
                         }
-                        else if (Ref.Equal(reader.LocalName, _strings.CommandLine))
+                        else if (Ref.Equal(_reader.LocalName, _strings.CommandLine))
                         {
-                            ParseCommandLineArguments(reader);
+                            ParseCommandLineArguments();
                         }
-                        else if (Ref.Equal(reader.LocalName, _strings.Errors))
+                        else if (Ref.Equal(_reader.LocalName, _strings.Errors))
                         {
-                            ParseErrors(reader);
+                            ParseErrors();
                         }
-                        else if (Ref.Equal(reader.LocalName, _strings.MachineInfo))
+                        else if (Ref.Equal(_reader.LocalName, _strings.MachineInfo))
                         {
-                            ParseMachineInfo(reader);
+                            ParseMachineInfo();
                         }
                     }
                 }
             }
         }
 
-        private void ParseBuild(XmlReader reader)
+        private void ParseBuild()
         {
-            reader.Read();
-            while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.Build))
+            _reader.Read();
+            while (!_reader.EOF && !Ref.Equal(_reader.LocalName, _strings.Build))
             {
-                if (Ref.Equal(reader.LocalName, _strings.BuildId))
+                if (Ref.Equal(_reader.LocalName, _strings.BuildId))
                 {
-                    _automationId = reader.ReadElementContentAsString();
+                    _automationId = _reader.ReadElementContentAsString();
                 }
                 else
                 {
-                    reader.Read();
+                    _reader.Read();
                 }
             }
         }
 
-        private void ParseCommandLineArguments(XmlReader reader)
+        private void ParseCommandLineArguments()
         {
             var sb = new StringBuilder();
-            reader.MoveToElement();
-            reader.Read();
-            while (!reader.EOF && Ref.Equal(reader.LocalName, _strings.Argument))
+            _reader.MoveToElement();
+            _reader.Read();
+            while (!_reader.EOF && Ref.Equal(_reader.LocalName, _strings.Argument))
             {
-                string argument = reader.ReadElementContentAsString();
+                string argument = _reader.ReadElementContentAsString();
                 if (sb.Length > 0)
                 {
                     sb.Append(' ');
                 }
 
                 sb.Append(argument);
-                reader.MoveToElement();
+                _reader.MoveToElement();
             }
 
             _invocation.CommandLine = sb.ToString();
         }
 
-        private void ParseErrors(XmlReader reader)
+        private void ParseErrors()
         {
-            reader.Read();
-            while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.Errors))
+            _reader.Read();
+            while (!_reader.EOF && !Ref.Equal(_reader.LocalName, _strings.Errors))
             {
-                if (Ref.Equal(reader.LocalName, _strings.Error))
+                if (Ref.Equal(_reader.LocalName, _strings.Error))
                 {
-                    string errorCode = reader.GetAttribute(_strings.Code);
-                    string message = reader.ReadElementContentAsString();
+                    string errorCode = _reader.GetAttribute(_strings.Code);
+                    string message = _reader.ReadElementContentAsString();
 
                     _toolNotifications.Add(new Notification
                     {
@@ -181,27 +182,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
                 else
                 {
-                    reader.Read();
+                    _reader.Read();
                 }
             }
         }
 
-        private void ParseMachineInfo(XmlReader reader)
+        private void ParseMachineInfo()
         {
-            reader.Read();
-            while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.MachineInfo))
+            _reader.Read();
+            while (!_reader.EOF && !Ref.Equal(_reader.LocalName, _strings.MachineInfo))
             {
-                if (Ref.Equal(reader.LocalName, _strings.Hostname))
+                if (Ref.Equal(_reader.LocalName, _strings.Hostname))
                 {
-                    _invocation.Machine = reader.ReadElementContentAsString();
+                    _invocation.Machine = _reader.ReadElementContentAsString();
                 }
-                else if (Ref.Equal(reader.LocalName, _strings.Username))
+                else if (Ref.Equal(_reader.LocalName, _strings.Username))
                 {
-                    _invocation.Account = reader.ReadElementContentAsString();
+                    _invocation.Account = _reader.ReadElementContentAsString();
                 }
                 else
                 {
-                    reader.Read();
+                    _reader.Read();
                 }
             }
         }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.IO.Packaging;
 
 namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
@@ -37,12 +38,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Name = "Fortify"
             };
 
+            OpenFvdlStream(input);
             output.Initialize(id: null, correlationId: null);
 
             output.WriteTool(tool);
 
             output.OpenResults();
             output.CloseResults();
+        }
+
+        private void OpenFvdlStream(Stream input)
+        {
+            var package = Package.Open(input);
         }
     }
 }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             var sb = new StringBuilder(FortifyExecutable);
             _reader.Read();
-            while (!_reader.EOF && Ref.Equal(_reader.LocalName, _strings.Argument))
+            while (!AtEndOf(_strings.CommandLine))
             {
                 string argument = _reader.ReadElementContentAsString();
                 sb.Append(' ');
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private void ParseErrors()
         {
             _reader.Read();
-            while (!_reader.EOF && !Ref.Equal(_reader.LocalName, _strings.Errors))
+            while (!AtEndOf(_strings.Errors))
             {
                 if (Ref.Equal(_reader.LocalName, _strings.Error))
                 {
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private void ParseMachineInfo()
         {
             _reader.Read();
-            while (!_reader.EOF && !Ref.Equal(_reader.LocalName, _strings.MachineInfo))
+            while (!AtEndOf(_strings.MachineInfo))
             {
                 if (Ref.Equal(_reader.LocalName, _strings.Hostname))
                 {
@@ -201,6 +201,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     _reader.Read();
                 }
             }
+        }
+
+        private bool AtEndOf(string elementName)
+        {
+            return _reader.EOF ||
+                (_reader.NodeType == XmlNodeType.EndElement && Ref.Equal(_reader.LocalName, elementName));
         }
     }
 }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprConverter : ToolFileConverterBase
     {
-        private const string ErrorCodePrefix = "FPR";
         private const string FortifyExecutable = "[REMOVED]insourceanalyzer.exe";
 
         private readonly NameTable _nameTable;
@@ -415,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                     _toolNotifications.Add(new Notification
                     {
-                        Id = ErrorCodePrefix + errorCode,
+                        Id = errorCode,
                         Level = NotificationLevel.Error,
                         Message = message
                     });

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprConverter : ToolFileConverterBase
     {
+        private const string FortifyToolName = "HP Fortify Static Code Analyzer";
         private const string FortifyExecutable = "[REMOVED]insourceanalyzer.exe";
 
         private readonly NameTable _nameTable;
@@ -59,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var tool = new Tool
             {
-                Name = "Fortify"
+                Name = FortifyToolName
             };
 
             _invocation = new Invocation();

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -91,14 +91,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 while (reader.Read())
                 {
-                    if (Ref.Equal(reader.LocalName, _strings.CommandLine))
+                    if (reader.IsStartElement())
                     {
-                        ParseCommandLineArguments(reader);
-                    }
-
-                    if (Ref.Equal(reader.LocalName, _strings.Hostname))
-                    {
-                        _invocation.Machine = reader.ReadElementContentAsString();
+                        if (Ref.Equal(reader.LocalName, _strings.CommandLine))
+                        {
+                            ParseCommandLineArguments(reader);
+                        }
+                        else if (Ref.Equal(reader.LocalName, _strings.MachineInfo))
+                        {
+                            ParseMachineInfo(reader);
+                        }
                     }
                 }
             }
@@ -109,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var sb = new StringBuilder();
             reader.MoveToElement();
             reader.Read();
-            while (Ref.Equal(reader.LocalName, _strings.Argument))
+            while (!reader.EOF && Ref.Equal(reader.LocalName, _strings.Argument))
             {
                 string argument = reader.ReadElementContentAsString();
                 if (sb.Length > 0)
@@ -122,6 +124,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
 
             _invocation.CommandLine = sb.ToString();
+        }
+
+        private void ParseMachineInfo(XmlReader reader)
+        {
+            reader.Read();
+            while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.MachineInfo))
+            {
+                if (Ref.Equal(reader.LocalName, _strings.Hostname))
+                {
+                    _invocation.Machine = reader.ReadElementContentAsString();
+                }
+                else if (Ref.Equal(reader.LocalName, _strings.Username))
+                {
+                    _invocation.Account = reader.ReadElementContentAsString();
+                }
+                else
+                {
+                    reader.Read();
+                }
+            }
         }
     }
 }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -146,7 +146,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private void ParseCommandLineArguments()
         {
             var sb = new StringBuilder();
-            _reader.MoveToElement();
             _reader.Read();
             while (!_reader.EOF && Ref.Equal(_reader.LocalName, _strings.Argument))
             {

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             ParseFprFile(input);
 
-            output.Initialize(id: null, correlationId: _automationId);
+            output.Initialize(id: null, automationId: _automationId);
 
             output.WriteTool(tool);
             output.WriteInvocation(_invocation);

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -105,24 +105,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 while (_reader.Read())
                 {
-                    if (_reader.IsStartElement())
+                    if (AtStartOfNonEmpty(_strings.Build))
                     {
-                        if (Ref.Equal(_reader.LocalName, _strings.Build))
-                        {
-                            ParseBuild();
-                        }
-                        else if (Ref.Equal(_reader.LocalName, _strings.CommandLine))
-                        {
-                            ParseCommandLineArguments();
-                        }
-                        else if (Ref.Equal(_reader.LocalName, _strings.Errors))
-                        {
-                            ParseErrors();
-                        }
-                        else if (Ref.Equal(_reader.LocalName, _strings.MachineInfo))
-                        {
-                            ParseMachineInfo();
-                        }
+                        ParseBuild();
+                    }
+                    else if (AtStartOfNonEmpty(_strings.CommandLine))
+                    {
+                        ParseCommandLineArguments();
+                    }
+                    else if (AtStartOfNonEmpty(_strings.Errors))
+                    {
+                        ParseErrors();
+                    }
+                    else if (AtStartOfNonEmpty(_strings.MachineInfo))
+                    {
+                        ParseMachineInfo();
                     }
                 }
             }
@@ -133,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             _reader.Read();
             while (!AtEndOf(_strings.Build))
             {
-                if (AtStartOf(_strings.BuildId))
+                if (AtStartOfNonEmpty(_strings.BuildId))
                 {
                     _automationId = _reader.ReadElementContentAsString();
                 }
@@ -150,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             _reader.Read();
             while (!AtEndOf(_strings.CommandLine))
             {
-                if (AtStartOf(_strings.Argument))
+                if (AtStartOfNonEmpty(_strings.Argument))
                 {
                     string argument = _reader.ReadElementContentAsString();
                     sb.Append(' ');
@@ -171,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             _reader.Read();
             while (!AtEndOf(_strings.Errors))
             {
-                if (AtStartOf(_strings.Error))
+                if (AtStartOfNonEmpty(_strings.Error))
                 {
                     string errorCode = _reader.GetAttribute(_strings.Code);
                     string message = _reader.ReadElementContentAsString();
@@ -195,11 +192,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             _reader.Read();
             while (!AtEndOf(_strings.MachineInfo))
             {
-                if (AtStartOf(_strings.Hostname))
+                if (AtStartOfNonEmpty(_strings.Hostname))
                 {
                     _invocation.Machine = _reader.ReadElementContentAsString();
                 }
-                else if (AtStartOf(_strings.Username))
+                else if (AtStartOfNonEmpty(_strings.Username))
                 {
                     _invocation.Account = _reader.ReadElementContentAsString();
                 }
@@ -208,6 +205,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     _reader.Read();
                 }
             }
+        }
+
+        private bool AtStartOfNonEmpty(String elementName)
+        {
+            return AtStartOf(elementName) && !_reader.IsEmptyElement;
         }
 
         private bool AtStartOf(string elementName)

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     }
                     else if (AtStartOfNonEmpty(_strings.CommandLine))
                     {
-                        ParseCommandLineArguments();
+                        ParseCommandLine();
                     }
                     else if (AtStartOfNonEmpty(_strings.Errors))
                     {
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
         }
 
-        private void ParseCommandLineArguments()
+        private void ParseCommandLine()
         {
             var sb = new StringBuilder(FortifyExecutable);
             _reader.Read();

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Sarif.Converters
+{
+    internal class FortifyFprConverter : ToolFileConverterBase
+    {
+        /// <summary>Initializes a new instance of the <see cref="FortifyFprConverter"/> class.</summary>
+        public FortifyFprConverter()
+        {
+        }
+
+        /// <summary>
+        /// Interface implementation for converting a stream in Fortify FPR format to a stream in
+        /// SARIF format.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when one or more required arguments are null.</exception>
+        /// <param name="input">Stream in Fortify FPR format.</param>
+        /// <param name="output">Stream in SARIF format.</param>
+        public override void Convert(Stream input, IResultLogWriter output)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            var tool = new Tool
+            {
+                Name = "Fortify"
+            };
+
+            output.Initialize(id: null, correlationId: null);
+
+            output.WriteTool(tool);
+
+            output.OpenResults();
+            output.CloseResults();
+        }
+    }
+}

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -262,11 +262,40 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 {
                     result.RuleId = _reader.ReadElementContentAsString();
                 }
+                else if (AtStartOfNonEmpty(_strings.AnalysisInfo))
+                {
+                    Location location = ParseLocationFromAnalysisInfo();
+                    result.Locations = new List<Location> { location };
+                }
 
                 _reader.Read();
             }
 
             _results.Add(result);
+        }
+
+        private Location ParseLocationFromAnalysisInfo()
+        {
+            var location = new Location();
+
+            _reader.Read();
+            while (!AtEndOf(_strings.AnalysisInfo))
+            {
+                if (AtStartOfNonEmpty(_strings.Unified))
+                {
+                    _reader.Read();
+                    while (!AtEndOf(_strings.Unified))
+                    {
+                        _reader.Read();
+                    }
+                }
+                else
+                {
+                    _reader.Read();
+                }
+            }
+
+            return location;
         }
 
         private void ParseDescription()

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             reader.Read();
             while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.Build))
             {
-                if (Ref.Equal(reader.LocalName, _strings.BuildID))
+                if (Ref.Equal(reader.LocalName, _strings.BuildId))
                 {
                     _automationId = reader.ReadElementContentAsString();
                 }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private readonly NameTable _nameTable;
         private readonly FortifyFprStrings _strings;
         private Invocation _invocation;
+        private string _automationId;
 
         /// <summary>Initializes a new instance of the <see cref="FortifyFprConverter"/> class.</summary>
         public FortifyFprConverter()
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             ParseFprFile(input);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, correlationId: _automationId);
 
             output.WriteTool(tool);
             output.WriteInvocation(_invocation);
@@ -93,7 +94,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 {
                     if (reader.IsStartElement())
                     {
-                        if (Ref.Equal(reader.LocalName, _strings.CommandLine))
+                        if (Ref.Equal(reader.LocalName, _strings.Build))
+                        {
+                            ParseBuild(reader);
+                        }
+                        else if (Ref.Equal(reader.LocalName, _strings.CommandLine))
                         {
                             ParseCommandLineArguments(reader);
                         }
@@ -102,6 +107,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                             ParseMachineInfo(reader);
                         }
                     }
+                }
+            }
+        }
+
+        private void ParseBuild(XmlReader reader)
+        {
+            reader.Read();
+            while (!reader.EOF && !Ref.Equal(reader.LocalName, _strings.Build))
+            {
+                if (Ref.Equal(reader.LocalName, _strings.BuildID))
+                {
+                    _automationId = reader.ReadElementContentAsString();
+                }
+                else
+                {
+                    reader.Read();
                 }
             }
         }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -95,6 +95,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         ParseCommandLineArguments(reader);
                     }
+
+                    if (Ref.Equal(reader.LocalName, _strings.Hostname))
+                    {
+                        _invocation.Machine = reader.ReadElementContentAsString();
+                    }
                 }
             }
         }
@@ -108,7 +113,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 string argument = reader.ReadElementContentAsString();
                 if (sb.Length > 0)
+                {
                     sb.Append(' ');
+                }
+
                 sb.Append(argument);
                 reader.MoveToElement();
             }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     internal class FortifyFprConverter : ToolFileConverterBase
     {
         private const string ErrorCodePrefix = "FPR";
+        private const string FortifyExecutable = "[REMOVED]insourceanalyzer.exe";
 
         private readonly NameTable _nameTable;
         private readonly FortifyFprStrings _strings;
@@ -145,16 +146,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private void ParseCommandLineArguments()
         {
-            var sb = new StringBuilder();
+            var sb = new StringBuilder(FortifyExecutable);
             _reader.Read();
             while (!_reader.EOF && Ref.Equal(_reader.LocalName, _strings.Argument))
             {
                 string argument = _reader.ReadElementContentAsString();
-                if (sb.Length > 0)
-                {
-                    sb.Append(' ');
-                }
-
+                sb.Append(' ');
                 sb.Append(argument);
                 _reader.MoveToElement();
             }

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -51,6 +51,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "ClassID"</summary>
         public readonly string ClassId;
 
+        /// <summary>The string constant "AnalysisInfo"</summary>
+        public readonly string AnalysisInfo;
+
+        // Members and further nested members of AnalysisInfo
+
+        /// <summary>The string constant "Unified"</summary>
+        public readonly string Unified;
+
+        /// <summary>The string constant "Trace"</summary>
+        public readonly string Trace;
+
+        /// <summary>The string constant "Primary"</summary>
+        public readonly string Primary;
+
+        /// <summary>The string constant "Entry"</summary>
+        public readonly string Entry;
+
+        /// <summary>The string constant "Node"</summary>
+        public readonly string Node;
+
+        /// <summary>The string constant "SourceLocation"</summary>
+        public readonly string SourceLocation;
+
         // Description element
 
         /// <summary>The string constant "Description"</summary>
@@ -120,6 +143,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Vulnerabilities = nameTable.Add("Vulnerabilities");
             Vulnerability = nameTable.Add("Vulnerability");
             ClassId = nameTable.Add("ClassID");
+            AnalysisInfo = nameTable.Add("AnalysisInfo");
+            Unified = nameTable.Add("Unified");
+            Trace = nameTable.Add("Trace");
+            Primary = nameTable.Add("Primary");
+            Entry = nameTable.Add("Entry");
+            Node = nameTable.Add("Node");
+            SourceLocation = nameTable.Add("SourceLocation");
             Description = nameTable.Add("Description");
             ClassIdAttribute = nameTable.Add("classID");
             Abstract = nameTable.Add("Abstract");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -7,6 +7,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprStrings
     {
+        // Build element
+
+        /// <summary>The string constant "Build".</summary>
+        public readonly string Build;
+
+        // Build members
+
+        /// <summary>The string constant "BuildID"</summary>
+        public readonly string BuildID;
+
         // CommandLine element
 
         /// <summary>The string constant "CommandLine".</summary>
@@ -38,6 +48,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </param>
         public FortifyFprStrings(XmlNameTable nameTable)
         {
+            Build = nameTable.Add(nameof(Build));
+            BuildID = nameTable.Add(nameof(BuildID));
             CommandLine = nameTable.Add(nameof(CommandLine));
             Argument = nameTable.Add(nameof(Argument));
             MachineInfo = nameTable.Add(nameof(MachineInfo));

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -46,6 +46,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "Vulnerability"</summary>
         public readonly string Vulnerability;
 
+        // Vulnerability members
+
+        /// <summary>The string constant "ClassID"</summary>
+        public readonly string ClassId;
+
+        // Description element
+
+        /// <summary>The string constant "Description"</summary>
+        public readonly string Description;
+
+        // Description members
+
+        /// <summary>The string constant "classID"</summary>
+        public readonly string ClassIdAttribute;
+
+        /// <summary>The string constant "Abstract"</summary>
+        public readonly string Abstract;
+
         // CommandLine element
 
         /// <summary>The string constant "CommandLine".</summary>
@@ -101,6 +119,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Name = nameTable.Add("Name");
             Vulnerabilities = nameTable.Add("Vulnerabilities");
             Vulnerability = nameTable.Add("Vulnerability");
+            ClassId = nameTable.Add("ClassID");
+            Description = nameTable.Add("Description");
+            ClassIdAttribute = nameTable.Add("classID");
+            Abstract = nameTable.Add("Abstract");
             CommandLine = nameTable.Add("CommandLine");
             Argument = nameTable.Add("Argument");
             Errors = nameTable.Add("Errors");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -7,20 +7,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprStrings
     {
-        // Build element
-
         /// <summary>The string constant "Build".</summary>
         public readonly string Build;
-
-        // Build members
 
         /// <summary>The string constant "BuildID"</summary>
         public readonly string BuildId;
 
         /// <summary>The string constant "SourceFiles"</summary>
         public readonly string SourceFiles;
-
-        // SourceFiles members
 
         /// <summary>The string constant "File"</summary>
         public readonly string File;
@@ -31,22 +25,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "type"</summary>
         public readonly string TypeAttribute;
 
-        // File members
-
         /// <summary>The string constant "Name"</summary>
         public readonly string Name;
-
-        // Vulnerabilities element
 
         /// <summary>The string constant "Vulnerabilities"</summary>
         public readonly string Vulnerabilities;
 
-        // Vulnerabilities members
-
         /// <summary>The string constant "Vulnerability"</summary>
         public readonly string Vulnerability;
-
-        // Vulnerability members
 
         /// <summary>The string constant "ClassID"</summary>
         public readonly string ClassId;
@@ -58,8 +44,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         /// <summary>The string constant "SourceLocation"</summary>
         public readonly string SourceLocation;
-
-        // Members of SourceLocation
 
         /// <summary>The string constant "path"</summary>
         public readonly string PathAttribute;
@@ -73,12 +57,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "colEnd"</summary>
         public readonly string ColEndAttribute;
 
-        // Description element
-
         /// <summary>The string constant "Description"</summary>
         public readonly string Description;
-
-        // Description members
 
         /// <summary>The string constant "classID"</summary>
         public readonly string ClassIdAttribute;
@@ -86,37 +66,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "Abstract"</summary>
         public readonly string Abstract;
 
-        // CommandLine element
-
         /// <summary>The string constant "CommandLine".</summary>
         public readonly string CommandLine;
-
-        // CommandLine members
 
         /// <summary>The string constant "Argument".</summary>
         public readonly string Argument;
 
-        // Errors element
-
         /// <summary>The string constant "Errors".</summary>
         public readonly string Errors;
-
-        // Errors members
 
         /// <summary>The string constant "Error".</summary>
         public readonly string Error;
 
-        // Error members
-
         /// <summary>The string constant "code".</summary>
         public readonly string CodeAttribute;
 
-        // MachineInfo element
-
         /// <summary>The string constant "MachineInfo".</summary>
         public readonly string MachineInfo;
-
-        // MachineInfo members
 
         /// <summary>The string constant "Hostname".</summary>
         public readonly string Hostname;

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -17,6 +17,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "BuildID"</summary>
         public readonly string BuildId;
 
+        // Vulnerabilities element
+
+        /// <summary>The string constant "Vulnerabilities"</summary>
+        public readonly string Vulnerabilities;
+
+        // Vulnerabilities members
+
+        /// <summary>The string constant "Vulnerability"</summary>
+        public readonly string Vulnerability;
+
         // CommandLine element
 
         /// <summary>The string constant "CommandLine".</summary>
@@ -39,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         // Error members
 
-        /// <summary>The string constant "Error".</summary>
+        /// <summary>The string constant "code".</summary>
         public readonly string Code;
 
         // MachineInfo element
@@ -65,6 +75,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             Build = nameTable.Add("Build");
             BuildId = nameTable.Add("BuildID");
+            Vulnerabilities = nameTable.Add("Vulnerabilities");
+            Vulnerability = nameTable.Add("Vulnerability");
             CommandLine = nameTable.Add("CommandLine");
             Argument = nameTable.Add("Argument");
             Errors = nameTable.Add("Errors");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -57,6 +57,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "SourceLocation"</summary>
         public readonly string SourceLocation;
 
+        /// <summary>The string constant "snippet"</summary>
+        public readonly string SnippetAttribute;
+
         /// <summary>The string constant "path"</summary>
         public readonly string PathAttribute;
 
@@ -71,6 +74,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         /// <summary>The string constant "Description"</summary>
         public readonly string Description;
+
+        /// <summary>The string constant "Snippets"</summary>
+        public readonly string Snippets;
+
+        /// <summary>The string constant "Snippet"</summary>
+        public readonly string Snippet;
+
+        /// <summary>The string constant "id"</summary>
+        public readonly string IdAttribute;
+
+        /// <summary>The string constant "Text"</summary>
+        public readonly string Text;
 
         /// <summary>The string constant "classID"</summary>
         public readonly string ClassIdAttribute;
@@ -126,11 +141,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ClassId = nameTable.Add("ClassID");
             AnalysisInfo = nameTable.Add("AnalysisInfo");
             SourceLocation = nameTable.Add("SourceLocation");
+            SnippetAttribute = nameTable.Add("snippet");
             PathAttribute = nameTable.Add("path");
             LineAttribute = nameTable.Add("line");
             ColStartAttribute = nameTable.Add("colStart");
             ColEndAttribute = nameTable.Add("colEnd");
             Description = nameTable.Add("Description");
+            Snippets = nameTable.Add("Snippets");
+            Snippet = nameTable.Add("Snippet");
+            IdAttribute = nameTable.Add("id");
+            Text = nameTable.Add("Text");
             ClassIdAttribute = nameTable.Add("classID");
             Abstract = nameTable.Add("Abstract");
             CommandLine = nameTable.Add("CommandLine");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -56,23 +56,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         // Members and further nested members of AnalysisInfo
 
-        /// <summary>The string constant "Unified"</summary>
-        public readonly string Unified;
-
-        /// <summary>The string constant "Trace"</summary>
-        public readonly string Trace;
-
-        /// <summary>The string constant "Primary"</summary>
-        public readonly string Primary;
-
-        /// <summary>The string constant "Entry"</summary>
-        public readonly string Entry;
-
-        /// <summary>The string constant "Node"</summary>
-        public readonly string Node;
-
         /// <summary>The string constant "SourceLocation"</summary>
         public readonly string SourceLocation;
+
+        // Members of SourceLocation
+
+        /// <summary>The string constant "path"</summary>
+        public readonly string PathAttribute;
+
+        /// <summary>The string constant "line"</summary>
+        public readonly string LineAttribute;
+
+        /// <summary>The string constant "colStart"</summary>
+        public readonly string ColStartAttribute;
+
+        /// <summary>The string constant "colEnd"</summary>
+        public readonly string ColEndAttribute;
 
         // Description element
 
@@ -144,12 +143,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Vulnerability = nameTable.Add("Vulnerability");
             ClassId = nameTable.Add("ClassID");
             AnalysisInfo = nameTable.Add("AnalysisInfo");
-            Unified = nameTable.Add("Unified");
-            Trace = nameTable.Add("Trace");
-            Primary = nameTable.Add("Primary");
-            Entry = nameTable.Add("Entry");
-            Node = nameTable.Add("Node");
             SourceLocation = nameTable.Add("SourceLocation");
+            PathAttribute = nameTable.Add("path");
+            LineAttribute = nameTable.Add("line");
+            ColStartAttribute = nameTable.Add("colStart");
+            ColEndAttribute = nameTable.Add("colEnd");
             Description = nameTable.Add("Description");
             ClassIdAttribute = nameTable.Add("classID");
             Abstract = nameTable.Add("Abstract");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -27,6 +27,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "Argument".</summary>
         public readonly string Argument;
 
+        // Errors element
+
+        /// <summary>The string constant "Errors".</summary>
+        public readonly string Errors;
+
+        // Errors members
+
+        /// <summary>The string constant "Error".</summary>
+        public readonly string Error;
+
+        // Error members
+
+        /// <summary>The string constant "Error".</summary>
+        public readonly string Code;
+
         // MachineInfo element
 
         /// <summary>The string constant "MachineInfo".</summary>
@@ -52,6 +67,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             BuildID = nameTable.Add(nameof(BuildID));
             CommandLine = nameTable.Add(nameof(CommandLine));
             Argument = nameTable.Add(nameof(Argument));
+            Errors = nameTable.Add(nameof(Errors));
+            Error = nameTable.Add(nameof(Error));
+            Code = nameTable.Add("code");
             MachineInfo = nameTable.Add(nameof(MachineInfo));
             Hostname = nameTable.Add(nameof(Hostname));
             Username = nameTable.Add(nameof(Username));

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -17,6 +17,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "BuildID"</summary>
         public readonly string BuildId;
 
+        /// <summary>The string constant "SourceFiles"</summary>
+        public readonly string SourceFiles;
+
+        // SourceFiles members
+
+        /// <summary>The string constant "File"</summary>
+        public readonly string File;
+
+        /// <summary>The string constant "size"</summary>
+        public readonly string SizeAttribute;
+
+        /// <summary>The string constant "type"</summary>
+        public readonly string TypeAttribute;
+
+        // File members
+
+        /// <summary>The string constant "Name"</summary>
+        public readonly string Name;
+
         // Vulnerabilities element
 
         /// <summary>The string constant "Vulnerabilities"</summary>
@@ -50,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         // Error members
 
         /// <summary>The string constant "code".</summary>
-        public readonly string Code;
+        public readonly string CodeAttribute;
 
         // MachineInfo element
 
@@ -75,13 +94,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             Build = nameTable.Add("Build");
             BuildId = nameTable.Add("BuildID");
+            SourceFiles = nameTable.Add("SourceFiles");
+            File = nameTable.Add("File");
+            SizeAttribute = nameTable.Add("size");
+            TypeAttribute = nameTable.Add("type");
+            Name = nameTable.Add("Name");
             Vulnerabilities = nameTable.Add("Vulnerabilities");
             Vulnerability = nameTable.Add("Vulnerability");
             CommandLine = nameTable.Add("CommandLine");
             Argument = nameTable.Add("Argument");
             Errors = nameTable.Add("Errors");
             Error = nameTable.Add("Error");
-            Code = nameTable.Add("code");
+            CodeAttribute = nameTable.Add("code");
             MachineInfo = nameTable.Add("MachineInfo");
             Hostname = nameTable.Add("Hostname");
             Username = nameTable.Add("Username");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -7,6 +7,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprStrings
     {
+        /// <summary>The string constant "CreatedTS"</summary>
+        public readonly string CreatedTimestamp;
+
+        /// <summary>The string constant "date"</summary>
+        public readonly string DateAttribute;
+
+        /// <summary>The string constant "time"</summary>
+        public readonly string TimeAttribute;
+
         /// <summary>The string constant "UUID"</summary>
         public readonly string Uuid;
 
@@ -101,6 +110,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </param>
         public FortifyFprStrings(XmlNameTable nameTable)
         {
+            CreatedTimestamp = nameTable.Add("CreatedTS");
+            DateAttribute = nameTable.Add("date");
+            TimeAttribute = nameTable.Add("time");
             Uuid = nameTable.Add("UUID");
             Build = nameTable.Add("Build");
             BuildId = nameTable.Add("BuildID");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml;
+
+namespace Microsoft.CodeAnalysis.Sarif.Converters
+{
+    internal class FortifyFprStrings
+    {
+        // CommandLine element
+
+        /// <summary>The string constant "CommandLine".</summary>
+        public readonly string CommandLine;
+
+        // CommandLine members
+
+        /// <summary>The string constant "Argument".</summary>
+        public readonly string Argument;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FortifyFprStrings"/> class.
+        /// </summary>
+        /// <param name="nameTable">
+        /// The name table from which strings shall be retrieved.
+        /// </param>
+        public FortifyFprStrings(XmlNameTable nameTable)
+        {
+            CommandLine = nameTable.Add("CommandLine");
+            Argument = nameTable.Add("Argument");
+        }
+    }
+}

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         // Build members
 
         /// <summary>The string constant "BuildID"</summary>
-        public readonly string BuildID;
+        public readonly string BuildId;
 
         // CommandLine element
 
@@ -63,16 +63,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </param>
         public FortifyFprStrings(XmlNameTable nameTable)
         {
-            Build = nameTable.Add(nameof(Build));
-            BuildID = nameTable.Add(nameof(BuildID));
-            CommandLine = nameTable.Add(nameof(CommandLine));
-            Argument = nameTable.Add(nameof(Argument));
-            Errors = nameTable.Add(nameof(Errors));
-            Error = nameTable.Add(nameof(Error));
+            Build = nameTable.Add("Build");
+            BuildId = nameTable.Add("BuildID");
+            CommandLine = nameTable.Add("CommandLine");
+            Argument = nameTable.Add("Argument");
+            Errors = nameTable.Add("Errors");
+            Error = nameTable.Add("Error");
             Code = nameTable.Add("code");
-            MachineInfo = nameTable.Add(nameof(MachineInfo));
-            Hostname = nameTable.Add(nameof(Hostname));
-            Username = nameTable.Add(nameof(Username));
+            MachineInfo = nameTable.Add("MachineInfo");
+            Hostname = nameTable.Add("Hostname");
+            Username = nameTable.Add("Username");
         }
     }
 }

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -17,6 +17,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "Argument".</summary>
         public readonly string Argument;
 
+        // MachineInfo element
+
+        /// <summary>The string constant "MachineInfo".</summary>
+        public readonly string MachineInfo;
+
+        // MachineInfo members
+
+        /// <summary>The string constant "Hostname".</summary>
+        public readonly string Hostname;
+
+        /// <summary>The string constant "Username".</summary>
+        public readonly string Username;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FortifyFprStrings"/> class.
         /// </summary>
@@ -25,8 +38,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </param>
         public FortifyFprStrings(XmlNameTable nameTable)
         {
-            CommandLine = nameTable.Add("CommandLine");
-            Argument = nameTable.Add("Argument");
+            CommandLine = nameTable.Add(nameof(CommandLine));
+            Argument = nameTable.Add(nameof(Argument));
+            MachineInfo = nameTable.Add(nameof(MachineInfo));
+            Hostname = nameTable.Add(nameof(Hostname));
+            Username = nameTable.Add(nameof(Username));
         }
     }
 }

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -75,6 +75,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "Description"</summary>
         public readonly string Description;
 
+        /// <summary>The string constant "classID"</summary>
+        public readonly string ClassIdAttribute;
+
+        /// <summary>The string constant "Abstract"</summary>
+        public readonly string Abstract;
+
+        /// <summary>The string constant "Explanation"</summary>
+        public readonly string Explanation;
+
         /// <summary>The string constant "Snippets"</summary>
         public readonly string Snippets;
 
@@ -86,12 +95,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         /// <summary>The string constant "Text"</summary>
         public readonly string Text;
-
-        /// <summary>The string constant "classID"</summary>
-        public readonly string ClassIdAttribute;
-
-        /// <summary>The string constant "Abstract"</summary>
-        public readonly string Abstract;
 
         /// <summary>The string constant "CommandLine".</summary>
         public readonly string CommandLine;
@@ -147,12 +150,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ColStartAttribute = nameTable.Add("colStart");
             ColEndAttribute = nameTable.Add("colEnd");
             Description = nameTable.Add("Description");
+            ClassIdAttribute = nameTable.Add("classID");
+            Abstract = nameTable.Add("Abstract");
+            Explanation = nameTable.Add("Explanation");
             Snippets = nameTable.Add("Snippets");
             Snippet = nameTable.Add("Snippet");
             IdAttribute = nameTable.Add("id");
             Text = nameTable.Add("Text");
-            ClassIdAttribute = nameTable.Add("classID");
-            Abstract = nameTable.Add("Abstract");
             CommandLine = nameTable.Add("CommandLine");
             Argument = nameTable.Add("Argument");
             Errors = nameTable.Add("Errors");

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -7,6 +7,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     internal class FortifyFprStrings
     {
+        /// <summary>The string constant "UUID"</summary>
+        public readonly string Uuid;
+
         /// <summary>The string constant "Build".</summary>
         public readonly string Build;
 
@@ -98,6 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// </param>
         public FortifyFprStrings(XmlNameTable nameTable)
         {
+            Uuid = nameTable.Add("UUID");
             Build = nameTable.Add("Build");
             BuildId = nameTable.Add("BuildID");
             SourceFiles = nameTable.Add("SourceFiles");

--- a/src/Sarif.Converters/FxCopConverter.cs
+++ b/src/Sarif.Converters/FxCopConverter.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var fileInfoFactory = new FileInfoFactory(MimeType.DetermineFromFileExtension);
             Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
 

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="FileInfoFactory.cs" />
     <Compile Include="FortifyConverter.cs" />
+    <Compile Include="FortifyFprConverter.cs" />
     <Compile Include="FortifyIssue.cs" />
     <Compile Include="FortifyPathElement.cs" />
     <Compile Include="FortifyStrings.cs" />

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -26,13 +26,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -32,6 +32,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -53,6 +53,7 @@
     <Compile Include="FileInfoFactory.cs" />
     <Compile Include="FortifyConverter.cs" />
     <Compile Include="FortifyFprConverter.cs" />
+    <Compile Include="FortifyFprStrings.cs" />
     <Compile Include="FortifyIssue.cs" />
     <Compile Include="FortifyPathElement.cs" />
     <Compile Include="FortifyStrings.cs" />

--- a/src/Sarif.Converters/SemmleConverter.cs
+++ b/src/Sarif.Converters/SemmleConverter.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Name = "Semmle QL"
             };
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
 

--- a/src/Sarif.Converters/StaticDriverVerifierConverter.cs
+++ b/src/Sarif.Converters/StaticDriverVerifierConverter.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             var fileInfoFactory = new FileInfoFactory(null);
             Dictionary<string, FileData> fileDictionary = fileInfoFactory.Create(results);
 
-            output.Initialize(id: null, correlationId: null);
+            output.Initialize(id: null, automationId: null);
 
             output.WriteTool(tool);
             if (fileDictionary != null && fileDictionary.Count > 0) { output.WriteFiles(fileDictionary); }

--- a/src/Sarif.Converters/ToolFormat.cs
+++ b/src/Sarif.Converters/ToolFormat.cs
@@ -14,8 +14,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         ClangAnalyzer,
         /// <summary>CppCheck's file format.</summary>
         CppCheck,
-        /// <summary>Fortify's file format.</summary>
+        /// <summary>Fortify's report file format.</summary>
         Fortify,
+        /// <summary>Fortify's FPR file format.</summary>
+        FortifyFpr,
         /// <summary>FxCop's file format.</summary>
         FxCop,
         /// <summary>PREfast's file format.</summary>

--- a/src/Sarif.Converters/ToolFormatConverter.cs
+++ b/src/Sarif.Converters/ToolFormatConverter.cs
@@ -133,6 +133,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             CreateConverterRecord<CppCheckConverter>(result, ToolFormat.CppCheck);
             CreateConverterRecord<ClangAnalyzerConverter>(result, ToolFormat.ClangAnalyzer);
             CreateConverterRecord<FortifyConverter>(result, ToolFormat.Fortify);
+            CreateConverterRecord<FortifyFprConverter>(result, ToolFormat.FortifyFpr);
             CreateConverterRecord<FxCopConverter>(result, ToolFormat.FxCop);
             CreateConverterRecord<SemmleConverter>(result, ToolFormat.SemmleQL);
             CreateConverterRecord<StaticDriverVerifierConverter>(result, ToolFormat.StaticDriverVerifier);

--- a/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AlgorithmKindConverterTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 {
                     var run = new Run();
 
-                    uut.Initialize(id: null, correlationId: null);
+                    uut.Initialize(id: null, automationId: null);
 
                     uut.WriteTool(DefaultTool);
 

--- a/src/Sarif.UnitTests/Readers/AnnotatedCodeLocationKindConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/AnnotatedCodeLocationKindConverterTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 {
                     var run = new Run();
 
-                    uut.Initialize(id: null, correlationId: null);
+                    uut.Initialize(id: null, automationId: null);
 
                     uut.WriteTool(DefaultTool);
 

--- a/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/IsSuppressedInSourceConverterTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             {
                 var run = new Run();
 
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
 
                 uut.WriteTool(DefaultTool);
 
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             string actual = GetJson(uut =>
             {
                 var run = new Run();
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
                 uut.WriteTool(DefaultTool);
 
                 uut.WriteResults(new[] { new Result
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             {
                 var run = new Run();
 
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
 
                 uut.WriteTool(DefaultTool);
 

--- a/src/Sarif.UnitTests/Readers/RuleDictionaryConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/RuleDictionaryConverterTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             {
                 var run = new Run();
 
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
 
                 uut.WriteTool(DefaultTool);
 

--- a/src/Sarif.UnitTests/Readers/UriConverterTests.cs
+++ b/src/Sarif.UnitTests/Readers/UriConverterTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.UnitTests
             {
                 var run = new Run();
 
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
 
                 uut.WriteTool(DefaultTool);
 

--- a/src/Sarif.UnitTests/ResultLogObjectWriter.cs
+++ b/src/Sarif.UnitTests/ResultLogObjectWriter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         /// <summary>Gets the Run object.</summary>
         public Run Run { get; set;  }
 
-        public void Initialize(string id, string correlationId) { }
+        public void Initialize(string id, string automationId) { }
 
         /// <summary>Writes a tool information entry to the log.</summary>
         /// <exception cref="InvalidOperationException">Thrown if the tool info block has already been

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             Assert.AreEqual(expected, GetJson(uut =>
             {
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
             }));
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             string actual = GetJson(uut =>
             {
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
                 uut.WriteTool(DefaultTool);
                 uut.WriteResult(DefaultResult);
             });
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             string actual = GetJson(uut =>
             {
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
                 uut.WriteTool(DefaultTool);
                 uut.WriteInvocation(s_invocation);
             });
@@ -180,10 +180,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         }
 
         [TestMethod]
-        public void ResultLogJsonWriter_WritesIdAndCorrelationId()
+        public void ResultLogJsonWriter_WritesIdAndAutomationId()
         {
             string id = Guid.NewGuid().ToString();
-            string correlationId = Guid.NewGuid().ToString();
+            string automationId = Guid.NewGuid().ToString();
 
             string expected =
 @"{
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
   ""runs"": [
     {
       ""id"": """ + id + @""",
-      ""correlationId"": """ + correlationId + @""",
+      ""automationId"": """ + automationId + @""",
       ""tool"": {
         ""name"": null
       },
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             string actual = GetJson(uut =>
             {
-                uut.Initialize(id: id, correlationId: correlationId);
+                uut.Initialize(id: id, automationId: automationId);
                 uut.WriteTool(DefaultTool);
                 uut.WriteInvocation(s_invocation);
             });
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             string actual = GetJson(uut =>
             {
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
                 uut.WriteTool(DefaultTool);
                 uut.WriteConfigurationNotifications(s_notifications);
             });
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 }";
             string actual = GetJson(uut =>
             {
-                uut.Initialize(id: null, correlationId: null);
+                uut.Initialize(id: null, automationId: null);
                 uut.WriteTool(DefaultTool);
                 uut.WriteToolNotifications(s_notifications);
             });

--- a/src/Sarif/IResultLogWriter.cs
+++ b/src/Sarif/IResultLogWriter.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Initialize the current output log.
         /// </summary>
         /// <param name="id">A string that uniquely identifies a run.</param>
-        /// <param name="correlationId">A global identifier for a run that permits correlation with a larger automation process.</param> 
-        void Initialize(string id, string correlationId);
+        /// <param name="automationId">A global identifier for a run that permits correlation with a larger automation process.</param> 
+        void Initialize(string id, string automationId);
 
         /// <summary>Writes tool information to the log.</summary>
         /// <exception cref="IOException">A file IO error occured. Clients implementing

--- a/src/Sarif/Writers/MimeType.cs
+++ b/src/Sarif/Writers/MimeType.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             ImmutableArray.Create("text/ruby", "ruby", "gemspec"),
             ImmutableArray.Create(MimeType.Sarif, "sarif"),
             ImmutableArray.Create("text/scss", "scss"),
+            ImmutableArray.Create("text/x-sql", "sql", "tsql"),
             ImmutableArray.Create("text/typescript", "ts"),
             ImmutableArray.Create("text/x-vb", "vb"),
             ImmutableArray.Create("text/xml", "xml", "ascx", "aspx", "csproj", "xaml", "dtd", "xsd", "vcxproj", "vbproj", "wixproj", "jsproj", "proj", "targets", "props", "config"),

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         /// sufficient to being populating a run with results.
         /// </summary>
         /// <param name="id">A string that uniquely identifies a run.</param>
-        /// <param name="correlationId">A global identifier for a run that permits correlation with a larger automation process.</param>
-        public void Initialize(string id, string correlationId)
+        /// <param name="automationId">A global identifier for a run that permits correlation with a larger automation process.</param>
+        public void Initialize(string id, string automationId)
         {
             this.EnsureStateNotAlreadySet(Conditions.Disposed | Conditions.Initialized);
 
@@ -76,10 +76,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 _serializer.Serialize(_jsonWriter, id, typeof(string));
             }
 
-            if (!string.IsNullOrEmpty(correlationId))
+            if (!string.IsNullOrEmpty(automationId))
             {
-                _jsonWriter.WritePropertyName("correlationId");
-                _serializer.Serialize(_jsonWriter, correlationId, typeof(string));
+                _jsonWriter.WritePropertyName("automationId");
+                _serializer.Serialize(_jsonWriter, automationId, typeof(string));
             }
 
             _writeConditions |= Conditions.Initialized;
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         {
             if (_writeConditions == Conditions.None)
             {
-                Initialize(id : Guid.NewGuid().ToString(), correlationId: null);
+                Initialize(id : Guid.NewGuid().ToString(), automationId: null);
             }
         }
 


### PR DESCRIPTION
This is a first cut at a converter for the Fortify FPR format.

NOTES:

1. We emit the command line arguments, but at present we hard-code the tool executable name. The executable is actually present in the file, under a `Property` element:

    ```
    <Property>
        <name>com.fortify.SCAExecutablePath</name>
        <value>C:Program FilesHP_FortifyHP_Fortify_SCA_and_Apps_4.30binsourceanalyzer.exe</value>
    </Property>
    ```

    ... but it's missing the backslashes, which appears to be a Fortify bug.

2. This is the first converter that populates what SARIF refers to as the `automationId` property. This led to the discovery of #552, "Framework emits invalid attribute correlationId" -- the SDK still used the old name `correlationId` for this property (contrary to both the spec and the schema), so I fixed that.

