### PR TITLE
Extract multiple related locations from the messages in a Semmle csv file

### DIFF
--- a/src/ConvertToSarif/ConvertOptions.cs
+++ b/src/ConvertToSarif/ConvertOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.ConvertToSarif
         [Option(
             't',
             "tool",
-            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, Semmle, or StaticDriverVerifier.",
+            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, SemmleQL, or StaticDriverVerifier.",
             Required = true)]
         public ToolFormat ToolFormat { get; internal set; }
 

--- a/src/Sarif.Converters/SemmleConverter.cs
+++ b/src/Sarif.Converters/SemmleConverter.cs
@@ -164,11 +164,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 index = rawMessage.IndexOf("]]");
 
-                string embeddedLinkRawString = rawMessage.Substring(0, index - 1);
+                // embeddedLinksText contains the text for one set of embedded links except for the leading '[[' and trailing ']]'
+                // "hbm"|"relative://windows/Core/ntgdi/gre/brushapi.cxx:176:4882:3"],["hbm"|"relative://windows/Core/ntgdi/gre/windows/ntgdi.c:1873:50899:3"],["hbm"|"relative://windows/Core/ntgdi/gre/windows/ntgdi.c:5783:154466:3"
+                string embeddedLinksText = rawMessage.Substring(0, index - 1);
 
-                string[] embeddedLinks = embeddedLinkRawString.Split(new string[] { "],[" }, StringSplitOptions.None);
+                // embeddedLinks splits the set of embedded links into invividual links
+                // 1.  "hbm"|"relative://windows/Core/ntgdi/gre/brushapi.cxx:176:4882:3"
+                // 2.  "hbm"|"relative://windows/Core/ntgdi/gre/windows/ntgdi.c:1873:50899:3"
+                // 3.  "hbm"|"relative://windows/Core/ntgdi/gre/windows/ntgdi.c:5783:154466:3"
 
-                string tokenText = embeddedLinkRawString;
+                string[] embeddedLinks = embeddedLinksText.Split(new string[] { "],[" }, StringSplitOptions.None);
+
+                string tokenText = embeddedLinksText;
                 foreach (string embeddedLink in embeddedLinks)
                 {
                     string[] tokens = embeddedLink.Split(new char[] { '\"' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
The VS viewer change is essentially unrelated. However, I couldn't open the converted Semmle file in VS without it. I can split it into another PR if you guys so desire.