### PR TITLE
Change enum ToolFormat to a set of const strings

### DIFF
--- a/src/ConvertToSarif/ConvertOptions.cs
+++ b/src/ConvertToSarif/ConvertOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.ConvertToSarif
             "tool",
             HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, SemmleQL, or StaticDriverVerifier.",
             Required = true)]
-        public ToolFormat ToolFormat { get; internal set; }
+        public string ToolFormat { get; internal set; }
 
         [Option(
             'o',

--- a/src/ConvertToSarif/Program.cs
+++ b/src/ConvertToSarif/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.ConvertToSarif
                     convertOptions.OutputFilePath = convertOptions.InputFilePath + ".sarif";
                 }
 
-                if (convertOptions.ToolFormat == ToolFormat.PREfast)
+                if (convertOptions.ToolFormat.MatchesToolFormat(ToolFormat.PREfast))
                 {
                     string sarif = ToolFormatConverter.ConvertPREfastToStandardFormat(convertOptions.InputFilePath);
                     File.WriteAllText(convertOptions.OutputFilePath, sarif);

--- a/src/Sarif.Converters.UnitTests/ToolFormatConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/ToolFormatConverterTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var output = new ResultLogObjectWriter();
             using (var input = new MemoryStream())
             {
-                _converter.ConvertToStandardFormat(0, input, output);
+                _converter.ConvertToStandardFormat("UnknownTool", input, output);
             }
         }
 

--- a/src/Sarif.Converters/Extensions.cs
+++ b/src/Sarif.Converters/Extensions.cs
@@ -9,6 +9,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     public static class Extensions
     {
+        // Compare tool format strings with appropriate comparison type.
+        public static bool MatchesToolFormat(this string toolFormat, string other)
+        {
+            return toolFormat.Equals(other, StringComparison.OrdinalIgnoreCase);
+        }
+
         /// <summary>An XmlReader extension method that reads optional element's content as string.</summary>
         /// <param name="xmlReader">The xmlReader from which line data shall be retrieved.</param>
         /// <param name="elementName">Name of the element expected.</param>

--- a/src/Sarif.Converters/ToolFormat.cs
+++ b/src/Sarif.Converters/ToolFormat.cs
@@ -4,27 +4,36 @@
 namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     /// <summary>Values referring to a source format to convert to the static analysis results interchange format.</summary>
-    public enum ToolFormat
+    public static class ToolFormat
     {
         /// <summary>An unset tool format value.</summary>
-        None = 0,
+        public const string None = nameof(None);
+
         /// <summary>Android Studio's file format.</summary>
-        AndroidStudio,
+        public const string AndroidStudio = nameof(AndroidStudio);
+
         /// <summary>Clang analyzer's file format.</summary>
-        ClangAnalyzer,
+        public const string ClangAnalyzer = nameof(ClangAnalyzer);
+
         /// <summary>CppCheck's file format.</summary>
-        CppCheck,
+        public const string CppCheck = nameof(CppCheck);
+
         /// <summary>Fortify's report file format.</summary>
-        Fortify,
+        public const string Fortify = nameof(Fortify);
+
         /// <summary>Fortify's FPR file format.</summary>
-        FortifyFpr,
+        public const string FortifyFpr = nameof(FortifyFpr);
+
         /// <summary>FxCop's file format.</summary>
-        FxCop,
+        public const string FxCop = nameof(FxCop);
+
         /// <summary>PREfast's file format.</summary>
-        PREfast,
+        public const string PREfast = nameof(PREfast);
+
         /// <summary>Semmle's file format.</summary>
-        SemmleQL,
+        public const string SemmleQL = nameof(SemmleQL);
+
         /// <summary>Static Driver Verifier's file format.</summary>
-        StaticDriverVerifier,
+        public const string StaticDriverVerifier = nameof(StaticDriverVerifier);
     }
 }

--- a/src/Sarif.Converters/ToolFormatConverter.cs
+++ b/src/Sarif.Converters/ToolFormatConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// written. This cannot be a directory.</param>
         /// <param name="conversionOptions">Options for controlling the conversion.</param>
         public void ConvertToStandardFormat(
-            ToolFormat toolFormat,
+            string toolFormat,
             string inputFileName,
             string outputFileName,
             ToolFormatConversionOptions conversionOptions)
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 throw new InvalidOperationException("Output file already exists and option to overwrite was not specified.");
             }
 
-            if (toolFormat == ToolFormat.PREfast)
+            if (toolFormat.MatchesToolFormat(ToolFormat.PREfast))
             {
                 string sarif = ConvertPREfastToStandardFormat(inputFileName);
                 File.WriteAllText(outputFileName, sarif);
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <param name="outputFileName">The name of the file to which the resulting SARIF log shall be
         /// written. This cannot be a directory.</param>
         public void ConvertToStandardFormat(
-            ToolFormat toolFormat,
+            string toolFormat,
             string inputFileName,
             string outputFileName)
         {
@@ -101,11 +101,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <param name="inputStream">A stream that contains tool log contents.</param>
         /// <param name="outputStream">A stream to which the converted output should be written.</param>
         public void ConvertToStandardFormat(
-            ToolFormat toolFormat,
+            string toolFormat,
             Stream inputStream,
             IResultLogWriter outputStream)
         {
-            if (toolFormat == ToolFormat.PREfast)
+            if (toolFormat.MatchesToolFormat(ToolFormat.PREfast))
             {
                 throw new ArgumentException("Cannot convert PREfast XML from stream. Call ConvertPREfastToStandardFormat helper instead.");
             };
@@ -124,11 +124,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             }
         }
 
-        private readonly IDictionary<ToolFormat, Lazy<ToolFileConverterBase>> _converters = CreateConverterRecords();
+        private readonly IDictionary<string, Lazy<ToolFileConverterBase>> _converters = CreateConverterRecords();
 
-        private static Dictionary<ToolFormat, Lazy<ToolFileConverterBase>> CreateConverterRecords()
+        private static Dictionary<string, Lazy<ToolFileConverterBase>> CreateConverterRecords()
         {
-            var result = new Dictionary<ToolFormat, Lazy<ToolFileConverterBase>>();
+            var result = new Dictionary<string, Lazy<ToolFileConverterBase>>();
             CreateConverterRecord<AndroidStudioConverter>(result, ToolFormat.AndroidStudio);
             CreateConverterRecord<CppCheckConverter>(result, ToolFormat.CppCheck);
             CreateConverterRecord<ClangAnalyzerConverter>(result, ToolFormat.ClangAnalyzer);
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return result;
         }
 
-        private static void CreateConverterRecord<T>(IDictionary<ToolFormat, Lazy<ToolFileConverterBase>> dict, ToolFormat format)
+        private static void CreateConverterRecord<T>(IDictionary<string, Lazy<ToolFileConverterBase>> dict, string format)
             where T : ToolFileConverterBase, new()
         {
             dict.Add(format, new Lazy<ToolFileConverterBase>(() => new T(), LazyThreadSafetyMode.ExecutionAndPublication));

--- a/src/Sarif.FunctionalTests/SarifConverterTests.cs
+++ b/src/Sarif.FunctionalTests/SarifConverterTests.cs
@@ -93,17 +93,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private readonly ToolFormatConverter converter = new ToolFormatConverter();
 
-        private void BatchRunConverter(ToolFormat tool, TestMode testMode)
+        private void BatchRunConverter(string tool, TestMode testMode)
         {
             BatchRunConverter(tool, "*.xml", testMode);
         }
 
-        private void BatchRunConverter(ToolFormat tool, string inputFilter, TestMode testMode)
+        private void BatchRunConverter(string tool, string inputFilter, TestMode testMode)
         {
             var sb = new StringBuilder();
 
-            string toolName = Enum.GetName(typeof(ToolFormat), tool);
-            string testDirectory = SarifConverterTests.TestDirectory + "\\" + toolName;
+            string testDirectory = SarifConverterTests.TestDirectory + "\\" + tool;
             string[] testFiles = Directory.GetFiles(testDirectory, inputFilter);
 
             foreach (string file in testFiles)
@@ -111,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 RunConverter(sb, tool, file, testMode);
             }
 
-            sb.Length.Should().Be(0, FormatFailureReason(sb, toolName));
+            sb.Length.Should().Be(0, FormatFailureReason(sb, tool));
         }
 
         private static string FormatFailureReason(StringBuilder sb, string toolName)
@@ -123,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return sb.ToString();
         }
 
-        private void RunConverter(StringBuilder sb, ToolFormat toolFormat, string inputFileName, TestMode testMode)
+        private void RunConverter(StringBuilder sb, string toolFormat, string inputFileName, TestMode testMode)
         {
             string expectedFileName = inputFileName + ".sarif";
             string generatedFileName = inputFileName + ".actual.sarif";

--- a/src/Sarif.UnitTests/Sarif.UnitTests.csproj
+++ b/src/Sarif.UnitTests/Sarif.UnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="SparseReaderDispatchTableTests.cs" />
     <Compile Include="SparseReaderTests.cs" />
     <Compile Include="ConvertToSchemaUriTests.cs" />
+    <Compile Include="ToolFormatTests.cs" />
     <Compile Include="Writers\ResultLogJsonWriterTests.cs" />
     <Compile Include="ToolFormatConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Sarif.UnitTests/ToolFormatConverterTests.cs
+++ b/src/Sarif.UnitTests/ToolFormatConverterTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var output = new ResultLogObjectWriter();
             using (var input = new MemoryStream())
             {
-                _converter.ConvertToStandardFormat(0, input, output);
+                _converter.ConvertToStandardFormat("UnknownTool", input, output);
             }
         }
 

--- a/src/Sarif.UnitTests/ToolFormatTests.cs
+++ b/src/Sarif.UnitTests/ToolFormatTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis.Sarif.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    [TestClass]
+    public class ToolFormatTests
+    {
+        private static List<FieldInfo> publicFields;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            publicFields = typeof(ToolFormat)
+                .GetMembers(BindingFlags.Public | BindingFlags.Static)
+                .OfType<FieldInfo>()
+                .ToList();
+        }
+
+        [TestMethod]
+        public void ToolFormat_ContainsNoCaseInsensitiveDuplicateValues()
+        {
+            var alreadySeen = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            var duplicates = new List<string>();
+
+            foreach (FieldInfo field in publicFields)
+            {
+                string value = field.GetRawConstantValue() as string;
+                if (alreadySeen.Contains(value))
+                {
+                    duplicates.Add(value);
+                }
+                else
+                {
+                    alreadySeen.Add(value);
+                }
+            }
+
+            Assert.AreEqual(0, duplicates.Count, "Duplicate ToolFormat strings: " + string.Join(", ", duplicates));
+        }
+
+        [TestMethod]
+        public void ToolFormat_MemberNamesMatchStringValues()
+        {
+            var mismatches = new List<string>();
+
+            foreach (FieldInfo field in publicFields)
+            {
+                string value = field.GetRawConstantValue() as string;
+                if (!value.Equals(field.Name, StringComparison.Ordinal))
+                {
+                    mismatches.Add(field.Name);
+                }
+            }
+
+            Assert.AreEqual(0, mismatches.Count, "ToolFormat fields with mismatched values: " + string.Join(", ", mismatches));
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
     {
         public static readonly ErrorListService Instance = new ErrorListService();
 
-        public static void ProcessLogFile(string filePath, ToolFormat toolFormat = ToolFormat.None)
+        public static void ProcessLogFile(string filePath, string toolFormat = ToolFormat.None)
         {
             SarifLog log;
 
@@ -30,11 +30,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             string logText;
 
-            if (toolFormat == ToolFormat.None)
+            if (toolFormat.MatchesToolFormat(ToolFormat.None))
             {
                 logText = File.ReadAllText(filePath);
             }
-            else if (toolFormat == ToolFormat.PREfast)
+            else if (toolFormat.MatchesToolFormat(ToolFormat.PREfast))
             {
                 logText = ToolFormatConverter.ConvertPREfastToStandardFormat(filePath);
             }

--- a/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommand.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommand.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
 
-            ToolFormat toolFormat = ToolFormat.None;
+            string toolFormat = ToolFormat.None;
 
             if (logFile == null)
             {
@@ -156,7 +156,7 @@ namespace Microsoft.Sarif.Viewer
                 {
                     // These constants expressed in our VSCT
                     case OpenSarifFileCommandId:
-                        {
+                    {
                             // Native SARIF. All our defaults above are fine
                             break;
                     }
@@ -175,42 +175,42 @@ namespace Microsoft.Sarif.Viewer
                         break;
                     }
                     case OpenFxCopFileCommandId:
-                        {
-                            // FxCop. TODO. We need project file support. FxCop
-                            // fullMessages look broken.
-                            toolFormat = ToolFormat.FxCop;
-                            title = "Open FxCop XML log file";
-                            filter = "FxCop report and project files (*.xml)|*.xml";
-                            break;
-                        }
+                    {
+                        // FxCop. TODO. We need project file support. FxCop
+                        // fullMessages look broken.
+                        toolFormat = ToolFormat.FxCop;
+                        title = "Open FxCop XML log file";
+                        filter = "FxCop report and project files (*.xml)|*.xml";
+                        break;
+                    }
                     case OpenCppCheckFileCommandId:
-                        {
-                            toolFormat = ToolFormat.CppCheck;
-                            title = "Open CppCheck XML log file";
-                            filter = "CppCheck log files (*.xml)|*.xml";
-                            break;
-                        }
+                    {
+                        toolFormat = ToolFormat.CppCheck;
+                        title = "Open CppCheck XML log file";
+                        filter = "CppCheck log files (*.xml)|*.xml";
+                        break;
+                    }
                     case OpenClangFileCommandId:
-                        {
-                            toolFormat = ToolFormat.ClangAnalyzer;
-                            title = "Open Clang XML log file";
-                            filter = "Clang log files (*.xml)|*.xml";
-                            break;
-                        }
+                    {
+                        toolFormat = ToolFormat.ClangAnalyzer;
+                        title = "Open Clang XML log file";
+                        filter = "Clang log files (*.xml)|*.xml";
+                        break;
+                    }
                     case OpenAndroidStudioFileCommandId:
-                        {
-                            toolFormat = ToolFormat.AndroidStudio;
-                            title = "Open Android Studio XML log file";
-                            filter = "Android Studio log files (*.xml)|*.xml";
-                            break;
-                        }
+                    {
+                        toolFormat = ToolFormat.AndroidStudio;
+                        title = "Open Android Studio XML log file";
+                        filter = "Android Studio log files (*.xml)|*.xml";
+                        break;
+                    }
                     case OpenSemmleFileCommandId:
-                        {
-                            toolFormat = ToolFormat.SemmleQL;
-                            title = "Open Semmle QL CSV log file";
-                            filter = "Semmle QL log files (*.csv)|*.csv";
-                            break;
-                        }
+                    {
+                        toolFormat = ToolFormat.SemmleQL;
+                        title = "Open Semmle QL CSV log file";
+                        filter = "Semmle QL log files (*.csv)|*.csv";
+                        break;
+                    }
                 }
 
                 OpenFileDialog openFileDialog = new OpenFileDialog();


### PR DESCRIPTION
This is the first step in enabling third-party converter extensibility.

This is a replay of the PR I submitted earlier, but this time I updated my master branch before making the changes.

ALSO: I added the unit test you wanted, plus another one that you'll see.