### PR TITLE
Fix #584: GetProperty<T> should work for string properties.

### DIFF
--- a/src/Sarif.UnitTests/Core/PropertyBagHolderTests.cs
+++ b/src/Sarif.UnitTests/Core/PropertyBagHolderTests.cs
@@ -142,6 +142,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Core
         }
 
         [TestMethod]
+        public void PropertyBagHolder_GetPropertyOfT_WorksForStringProperties()
+        {
+            var inputObject = new TestClass();
+            inputObject.SetProperty(PropertyName, "x");
+
+            string value = inputObject.GetProperty<string>(PropertyName);
+            value.Should().Be("x");
+        }
+
+        [TestMethod]
         public void PropertyBagHolder_RemoveProperty_RemovesExistingProperty()
         {
             var inputObject = new TestClass();

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -89,11 +89,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public T GetProperty<T>(string propertyName)
         {
-            if (typeof(T) == typeof(string))
-            {
-                throw new InvalidOperationException(SdkResources.CallNonGenericGetProperty);
-            }
-
             if (!PropertyNames.Contains(propertyName))
             {
                 throw new InvalidOperationException(

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -79,15 +79,6 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To retrieve a property with a string value, call the non-generic GetProperty method..
-        /// </summary>
-        internal static string CallNonGenericGetProperty {
-            get {
-                return ResourceManager.GetString("CallNonGenericGetProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot write result: Tool not yet written..
         /// </summary>
         internal static string CannotWriteResultToolMissing {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -207,9 +207,6 @@
   <data name="ValueMustBeAtLeastOne" xml:space="preserve">
     <value>The value must be greater than or equal to 1.</value>
   </data>
-  <data name="CallNonGenericGetProperty" xml:space="preserve">
-    <value>To retrieve a property with a string value, call the non-generic GetProperty method.</value>
-  </data>
   <data name="CallGenericGetProperty" xml:space="preserve">
     <value>The non-generic GetProperty method only works for properties that are JSON strings. To retrieve a property with any other .NET type, call the generic method GetProperty&lt;T&gt;(string propertyName), where T is the .NET type of the object stored in the specified property.</value>
   </data>


### PR DESCRIPTION
As designed, `PropertyBagHolder.GetProperty<T>` throws an exception if you call it with a property name whose value is a string. The exception message tells you to call the non-generic method `PropertyBagHolder.GetProperty` instead. But there are cases where you don't know a property's type ahead of time (for example, when displaying the properties in a UI). There's no way to ask for a property's type ahead of time so that you can call the right `GetProperty` method, and even if there were, you shouldn't have to do that.

So remove the restriction that `GetProperty<T>` doesn't work on string properties.