### PR TITLE
Rework ProjectNameCache and add unit tests

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ProjectNameCacheTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ProjectNameCacheTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using EnvDTE;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class ProjectNameCacheTests
+    {
+        private const string FileName = "SomeFile.cs";
+        private const string ProjectName = "SomeProject";
+
+        [Fact]
+        public void ProjectNameCache_GetName_WhereSolutionDoesNotContainFile_ReturnsEmptyString()
+        {
+            // Arrange.
+
+            // Create a solution which doesn't contain project items matching any file name.
+            var mockSolution = new Mock<Solution>();
+            mockSolution
+                .Setup(s => s.FindProjectItem(It.IsAny<string>()))
+                .Returns(default(ProjectItem));
+
+            var target = new ProjectNameCache(mockSolution.Object);
+
+            // Act.
+            string result = target.GetName(FileName);
+
+            // Assert.
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ProjectNameCache_GetName_WhereSolutionContainsFile_ReturnsNameOfProjectContainingFile()
+        {
+            // Arrange.
+
+            // Create a project with the specified name.
+            var mockProject = new Mock<Project>();
+            mockProject
+                .SetupGet(p => p.Name)
+                .Returns(ProjectName);
+
+            // Create an item within that project. The item's Name property doesn't matter;
+            // all that matters is its ContainingProject.
+            var mockProjectItem = new Mock<ProjectItem>();
+            mockProjectItem
+                .SetupGet(pi => pi.ContainingProject)
+                .Returns(mockProject.Object);
+
+            // Create a solution which returns that project item for the specified file name.
+            // Again, the ProjectItem's Name property doesn't have to be set to match the name
+            // by which we look it up.
+            var mockSolution = new Mock<Solution>(MockBehavior.Loose);
+            mockSolution
+                .Setup(s => s.FindProjectItem(FileName))
+                .Returns(mockProjectItem.Object);
+
+            var target = new ProjectNameCache(mockSolution.Object);
+
+            // Act.
+            string result = target.GetName(FileName);
+
+            // Assert.
+            result.Should().Be(ProjectName);
+        }
+
+        [Fact]
+        public void ProjectNameCache_GetName_LooksUpAGivenFileNameInTheSolutionOnlyOnce()
+        {
+            // Arrange.
+
+            // Create a project with the specified name.
+            var mockProject = new Mock<Project>();
+            mockProject
+                .SetupGet(p => p.Name)
+                .Returns(ProjectName);
+
+            // Create an item within that project. The item's Name property doesn't matter;
+            // all that matters is its ContainingProject.
+            var mockProjectItem = new Mock<ProjectItem>();
+            mockProjectItem
+                .SetupGet(pi => pi.ContainingProject)
+                .Returns(mockProject.Object);
+
+            // Create a solution which returns that project item for the specified file name.
+            // Again, the ProjectItem's Name property doesn't have to be set to match the name
+            // by which we look it up.
+            var mockSolution = new Mock<Solution>(MockBehavior.Loose);
+            mockSolution
+                .Setup(s => s.FindProjectItem(FileName))
+                .Returns(mockProjectItem.Object);
+
+            var target = new ProjectNameCache(mockSolution.Object);
+
+            // Act.
+            string result1 = target.GetName(FileName);
+            string result2 = target.GetName(FileName);
+
+            // Assert.
+            result1.Should().Be(ProjectName);
+            result2.Should().Be(ProjectName);
+
+            // We should have looked up the file name in the solution only once.
+            mockSolution.Verify(s => s.FindProjectItem(FileName), Times.Once());
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -14,6 +14,13 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., build.props))\build.props" />
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
@@ -23,6 +30,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,6 +66,7 @@
     <Compile Include="ErrorList\SarifSnapshotTests.cs" />
     <Compile Include="Models\CallTreeCollectionTests.cs" />
     <Compile Include="Models\CallTreeTests.cs" />
+    <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="UriExtensionsTests.cs" />
     <Compile Include="CallTreeTraversalTests.cs" />
     <Compile Include="Converters\CallTreeNodeToTextConverterTests.cs" />

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.1.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.2.1" targetFramework="net452" />
+  <package id="Moq" version="4.7.99" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/src/Sarif.Viewer.VisualStudio/Constants.cs
+++ b/src/Sarif.Viewer.VisualStudio/Constants.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Sarif.Viewer
 {
     class Constants
     {
-        public const string VSIX_NAME = "Sarif Viewer";
+        public const string VSIX_NAME = "SARIF Viewer";
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifSnapshot.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
                 else if (columnName == StandardTableKeyNames.ProjectName)
                 {
-                    content = ProjectNameCache.Instance.GetName(_errors[index].FileName);
+                    content = _errors[index].ProjectName;
                 }
                 else if (columnName == StandardTableKeyNames.HelpLink)
                 {

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableDataSource.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableDataSource.cs
@@ -127,10 +127,10 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             var cleanErrors = errors.Where(e => e != null && !string.IsNullOrEmpty(e.FileName));
 
-            foreach (var error in cleanErrors.GroupBy(t => t.FileName))
+            foreach (var fileErrorGroup in cleanErrors.GroupBy(t => t.FileName))
             {
-                var snapshot = new SarifSnapshot(error.Key, error);
-                _snapshots[error.Key] = snapshot;
+                var snapshot = new SarifSnapshot(fileErrorGroup.Key, fileErrorGroup);
+                _snapshots[fileErrorGroup.Key] = snapshot;
             }
 
             UpdateAllSinks();
@@ -182,7 +182,7 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
         public void BringToFront()
         {
-            SarifViewerPackage.Dte.ExecuteCommand("View.ErrorList");        
+            SarifViewerPackage.Dte.ExecuteCommand("View.ErrorList");
         }
 
         public bool HasErrors()

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
@@ -39,13 +38,14 @@ namespace Microsoft.Sarif.Viewer
             _fixes = new ObservableCollection<FixModel>();
         }
 
-        public SarifErrorListItem(Run run, Result result, string logFilePath) : this()
+        public SarifErrorListItem(Run run, Result result, string logFilePath, ProjectNameCache projectNameCache) : this()
         {
             IRule rule;
             run.TryGetRule(result.RuleId, result.RuleKey, out rule);
             Message = result.GetMessageText(rule, concise: false);
             ShortMessage = result.GetMessageText(rule, concise: true);
             FileName = result.GetPrimaryTargetFile();
+            ProjectName = projectNameCache.GetName(FileName);
             Category = result.GetCategory();
             Region = result.GetPrimaryTargetRegion();
             Level = result.Level;
@@ -137,6 +137,9 @@ namespace Microsoft.Sarif.Viewer
                 NotifyPropertyChanged("FileName");
             }
         }
+
+        [Browsable(false)]
+        public string ProjectName { get; set; }
 
         [Browsable(false)]
         public bool RegionPopulated { get; set; }

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Sarif.Viewer
                 logFile = openFileDialog.FileName;
             }
 
-            ErrorListService.ProcessLogFile(logFile, toolFormat);
+            ErrorListService.ProcessLogFile(logFile, SarifViewerPackage.Dte.Solution, toolFormat);
         }
 
         bool IsSarifProtocol(string path)

--- a/src/Sarif.Viewer.VisualStudio/ProjectNameCache.cs
+++ b/src/Sarif.Viewer.VisualStudio/ProjectNameCache.cs
@@ -1,46 +1,41 @@
-﻿using System.Collections.Generic;
+﻿using EnvDTE;
+using System.Collections.Generic;
 
 namespace Microsoft.Sarif.Viewer
 {
     public sealed class ProjectNameCache
     {
-        private readonly static ProjectNameCache instance = new ProjectNameCache();
-        private readonly object projectNameDictionaryLock = new object();
         private Dictionary<string, string> projectNames = new Dictionary<string, string>();
 
-        static ProjectNameCache() { }
-        private ProjectNameCache() { }
+        private readonly Solution solution;
 
-        public static ProjectNameCache Instance => instance;
-
-        public void SetName(string fileName)
+        public ProjectNameCache(Solution solution)
         {
-            lock (projectNameDictionaryLock)
-            {
-                if (projectNames.ContainsKey(fileName))
-                {
-                    return;
-                }
-
-                var project = SarifViewerPackage.Dte.Solution.FindProjectItem(fileName);
-                if (project?.ContainingProject != null)
-                {
-                    projectNames[fileName] = project.ContainingProject.Name;
-                }
-                else
-                {
-                    projectNames[fileName] = string.Empty;
-                }
-            }
+            this.solution = solution;
         }
 
         public string GetName(string fileName)
         {
             SetName(fileName);
 
-            lock (projectNameDictionaryLock)
+            return projectNames[fileName];
+        }
+
+        private void SetName(string fileName)
+        {
+            if (projectNames.ContainsKey(fileName))
             {
-                return projectNames[fileName];
+                return;
+            }
+
+            var project = solution?.FindProjectItem(fileName);
+            if (project?.ContainingProject != null)
+            {
+                projectNames[fileName] = project.ContainingProject.Name;
+            }
+            else
+            {
+                projectNames[fileName] = string.Empty;
             }
         }
     }

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -118,7 +118,7 @@
     <Compile Include="Guids.cs" />
     <Compile Include="Models\AnnotatedCodeLocationModel.cs" />
     <Compile Include="Models\AnnotatedCodeLocationCollection.cs" />
-    <Compile Include="OpenSarifFileCommand.cs" />
+    <Compile Include="OpenLogFileCommands.cs" />
     <Compile Include="ProjectHelper.cs" />
     <Compile Include="ProjectKind.cs" />
     <Compile Include="ResultTextMarker.cs" />
@@ -130,7 +130,7 @@
     <Compile Include="Models\SarifErrorListItem.cs" />
     <Compile Include="SdkUiUtilities.cs" />
     <Compile Include="ErrorList\SinkManager.cs" />
-    <Compile Include="ErrorList\TableDataSource.cs" />
+    <Compile Include="ErrorList\SarifTableDataSource.cs" />
     <Compile Include="ErrorList\SarifSnapshot.cs" />
     <Compile Include="ViewModels\ViewModelLocator.cs" />
     <Compile Include="WeakEventHandlerManager.cs" />

--- a/src/Sarif.Viewer.VisualStudio/SarifEditorFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/SarifEditorFactory.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Sarif.Viewer
 
             if ((grfCreateDoc & VSConstants.CEF_OPENFILE) == VSConstants.CEF_OPENFILE)
             {
-                ErrorListService.ProcessLogFile(pszMkDocument);
+                ErrorListService.ProcessLogFile(pszMkDocument, SarifViewerPackage.Dte.Solution);
             }
 
             return VSConstants.S_OK;


### PR DESCRIPTION
1. Redesign `ProjectNameCache` as an instance class. Instantiate it
each time we populate the error list (`ErrorListService.WriteRunToErrorList`).
This way, there is no need to lock.

2. Inject an object implementing the `Solution` interface into
`ProjectNameCache`'s ctor. This allows us to unit test it. The `Solution`
object originates at the calls to `ErrorListService.ProcessLogFile`.

3. Make `ProjectNameCache.SetName` private. With the new design, client code
never calls it.

4. Add unit tests for `ProjectNameCache`, taking advantage of the
injected `Solution` object.

5. Opportunistically make a few small improvements which we ran
across while investigating the code:

- Rename file to match class OpenLogFileCommands.
- Rename file to match class SarifTableDataSource.
- Improve a local variable name.
- Correct the VSIX name constant (the string is human readable, so write
    SARIF in ALLCAPS).
- Remove trailing whitespace from a line.