### PR TITLE
Logging options

### DIFF
--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandBaseTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandBaseTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif.Readers;
+using Microsoft.CodeAnalysis.Sarif.Writers;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -73,6 +75,36 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 Assert.Null(command.ExecutionException);
             }
             ExceptionRaisingRule.s_exceptionCondition = ExceptionCondition.None;
+        }
+
+        [Fact]
+        public void ConvertAnalyzeOptionsToLoggingOptions()
+        {
+            LoggingOptions loggingOptions;
+            var analyzeOptions = new TestAnalyzeOptions()
+            {
+                 ComputeFileHashes = true
+            };
+
+            loggingOptions = AnalyzeCommandBase<TestAnalysisContext, TestAnalyzeOptions>.ConvertAnalyzeOptionsToLoggingOption(analyzeOptions);
+            loggingOptions.Should().Be(LoggingOptions.ComputeFileHashes);
+
+            analyzeOptions = new TestAnalyzeOptions()
+            {
+                LogEnvironment = true
+            };
+
+            loggingOptions = AnalyzeCommandBase<TestAnalysisContext, TestAnalyzeOptions>.ConvertAnalyzeOptionsToLoggingOption(analyzeOptions);
+            loggingOptions.Should().Be(LoggingOptions.PersistEnvironment);
+
+            analyzeOptions = new TestAnalyzeOptions()
+            {
+                Verbose = true
+            };
+
+            loggingOptions = AnalyzeCommandBase<TestAnalysisContext, TestAnalyzeOptions>.ConvertAnalyzeOptionsToLoggingOption(analyzeOptions);
+            loggingOptions.Should().Be(LoggingOptions.Verbose);
+
         }
 
         [Fact]

--- a/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
+++ b/src/Sarif.Driver.UnitTests/AnalyzeCommandTests.cs
@@ -443,7 +443,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     Verbose = true,
                     Statistics = true,
                     Quiet = true,
-                    ComputeTargetsHash = true,
+                    ComputeFileHashes = true,
                     ConfigurationFilePath = TestAnalyzeCommand.DefaultPolicyName,
                     Recurse = true,
                     OutputFilePath = path,

--- a/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
+++ b/src/Sarif.Driver.UnitTests/Sarif.Driver.UnitTests.csproj
@@ -75,7 +75,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AnalyzeCommandTests.cs" />
+    <Compile Include="AnalyzeCommandBaseTests.cs" />
     <Compile Include="ExceptionCondition.cs" />
     <Compile Include="ExceptionRaisingRule.cs" />
     <Compile Include="FileSpecifierTests.cs" />

--- a/src/Sarif.Driver.UnitTests/Sdk/SarifLoggerTests.cs
+++ b/src/Sarif.Driver.UnitTests/Sdk/SarifLoggerTests.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var logger = new SarifLogger(
                 textWriter,
                 analysisTargets: Enumerable.Empty<string>(),
-                verbose: false,
-                computeTargetsHash: false,
-                logEnvironment: false,
+                loggingOptions: LoggingOptions.None,
                 prereleaseInfo: null,
                 invocationTokensToRedact: null,
                 invocationPropertiesToLog: null);

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -313,11 +313,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 (
                     () =>
                     {
-                        LoggingOptions loggingOptions = LoggingOptions.None;
-
-                        if (analyzeOptions.Verbose) { loggingOptions |= LoggingOptions.Verbose; }
-                        if (analyzeOptions.LogEnvironment) { loggingOptions |= LoggingOptions.Verbose; }
-                        if (analyzeOptions.ComputeFileHashes) { loggingOptions |= LoggingOptions.Verbose; }
+                        LoggingOptions loggingOptions;
+                        loggingOptions = ConvertAnalyzeOptionsToLoggingOption(analyzeOptions);
 
                         aggregatingLogger.Loggers.Add(
                                 new SarifLogger(
@@ -335,6 +332,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     }
                 );
             }
+        }
+
+        internal static LoggingOptions ConvertAnalyzeOptionsToLoggingOption(TOptions analyzeOptions)
+        {
+            LoggingOptions loggingOptions = LoggingOptions.None;
+
+            if (analyzeOptions.Verbose) { loggingOptions |= LoggingOptions.Verbose; }
+            if (analyzeOptions.LogEnvironment) { loggingOptions |= LoggingOptions.PersistEnvironment; }
+            if (analyzeOptions.ComputeFileHashes) { loggingOptions |= LoggingOptions.ComputeFileHashes; }
+
+            return loggingOptions;
         }
 
         private IEnumerable<string> GenerateSensitiveTokensList()

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -311,16 +311,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 InvokeCatchingRelevantIOExceptions
                 (
-                    () => aggregatingLogger.Loggers.Add(
-                            new SarifLogger(
-                                analyzeOptions.OutputFilePath,
-                                targets,
-                                analyzeOptions.Verbose,
-                                analyzeOptions.LogEnvironment,
-                                analyzeOptions.ComputeTargetsHash,
-                                Prerelease,
-                                invocationTokensToRedact: GenerateSensitiveTokensList(),
-                                invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog)),
+                    () =>
+                    {
+                        LoggingOptions loggingOptions = LoggingOptions.None;
+
+                        if (analyzeOptions.Verbose) { loggingOptions |= LoggingOptions.Verbose; }
+                        if (analyzeOptions.LogEnvironment) { loggingOptions |= LoggingOptions.Verbose; }
+                        if (analyzeOptions.ComputeFileHashes) { loggingOptions |= LoggingOptions.Verbose; }
+
+                        aggregatingLogger.Loggers.Add(
+                                new SarifLogger(
+                                    analyzeOptions.OutputFilePath,
+                                    targets,
+                                    loggingOptions,
+                                    Prerelease,
+                                    invocationTokensToRedact: GenerateSensitiveTokensList(),
+                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog));
+                    },
                     (ex) =>
                     {
                         Errors.LogExceptionCreatingLogFile(context, filePath, ex);

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -322,8 +322,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                         aggregatingLogger.Loggers.Add(
                                 new SarifLogger(
                                     analyzeOptions.OutputFilePath,
-                                    targets,
                                     loggingOptions,
+                                    targets,
                                     Prerelease,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
                                     invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog));

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             'h',
             "hashes",
             HelpText = "Output SHA-256 hash of analysis targets when emitting SARIF reports.")]
-        public bool ComputeTargetsHash { get; set; }
+        public bool ComputeFileHashes { get; set; }
 
         [Option(
             'e',

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -411,7 +411,6 @@ namespace Microsoft.CodeAnalysis.Sarif
             TestForLoggingOption(LoggingOptions.ComputeFileHashes);
         }
 
-
         [TestMethod]
         public void SarifLogger_LoggingOptions_None()
         {
@@ -456,10 +455,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             // to account for the new member.
             //     
             // Current values are:
-            // None, ComputeFileHashes, PersistEnvironment, PersistFileContents, PrettyPrint, Verbose, All  
+            // None, ComputeFileHashes, PersistEnvironment, PersistFileContents, PrettyPrint, Verbose, All
             Enum.GetNames(typeof(LoggingOptions)).Length.Should().Be(7);
         }
 
+        // This helper is intended to validate a single enum member only
+        // and not arbitrary combinations of bits. One defined member,
+        // All, contains all bits.
         private void TestForLoggingOption(LoggingOptions loggingOption)
         {
             string fileName = Path.GetTempFileName();
@@ -468,19 +470,23 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 SarifLogger logger;
 
+                // Validates overloads that accept a path argument.
                 using (logger = new SarifLogger(fileName, loggingOption))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 };
 
+
+                // Validates second set of overloads that accept any 
+                // TextWriter (for example, one instantiated over a
+                // StringBuilder instance).
                 var sb = new StringBuilder();
                 var stringWriter = new StringWriter(sb);
                 using (logger = new SarifLogger(stringWriter, loggingOption))
                 {
                     ValidateLoggerForExclusiveOption(logger, loggingOption);
                 };
-            }
-            
+            }            
             finally
             {
                 if (File.Exists(fileName)) { File.Delete(fileName); }
@@ -556,7 +562,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 default:
                 {
-                    throw new InvalidOperationException();
+                    throw new ArgumentException();
                 }
             }
         }

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -404,5 +404,161 @@ namespace Microsoft.CodeAnalysis.Sarif
                 sarifLogger.Log(rule, result);
             }
         }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_ComputeFileHashes()
+        {
+            TestForLoggingOption(LoggingOptions.ComputeFileHashes);
+        }
+
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_None()
+        {
+            TestForLoggingOption(LoggingOptions.None);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_PersistEnvironment()
+        {
+            TestForLoggingOption(LoggingOptions.PersistEnvironment);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_PersistFileContents()
+        {
+            TestForLoggingOption(LoggingOptions.PersistFileContents);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_PrettyPrint()
+        {
+            TestForLoggingOption(LoggingOptions.PrettyPrint);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_Verbose()
+        {
+            TestForLoggingOption(LoggingOptions.Verbose);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_All()
+        {
+            TestForLoggingOption(LoggingOptions.All);
+        }
+
+        [TestMethod]
+        public void SarifLogger_LoggingOptions_Count()
+        {
+            // This test exists in order to alert test developers when a new member is added to the
+            // LoggingOptions enum. In that case, this test and others should be updated/added
+            // to account for the new member.
+            //     
+            // Current values are:
+            // None, ComputeFileHashes, PersistEnvironment, PersistFileContents, PrettyPrint, Verbose, All  
+            Enum.GetNames(typeof(LoggingOptions)).Length.Should().Be(7);
+        }
+
+        private void TestForLoggingOption(LoggingOptions loggingOption)
+        {
+            string fileName = Path.GetTempFileName();
+
+            try
+            {
+                SarifLogger logger;
+
+                using (logger = new SarifLogger(fileName, loggingOption))
+                {
+                    ValidateLoggerForExclusiveOption(logger, loggingOption);
+                };
+
+                var sb = new StringBuilder();
+                var stringWriter = new StringWriter(sb);
+                using (logger = new SarifLogger(stringWriter, loggingOption))
+                {
+                    ValidateLoggerForExclusiveOption(logger, loggingOption);
+                };
+            }
+            
+            finally
+            {
+                if (File.Exists(fileName)) { File.Delete(fileName); }
+            }
+        }
+
+        private void ValidateLoggerForExclusiveOption(SarifLogger logger, LoggingOptions loggingOptions)
+        {
+            switch (loggingOptions)
+            {
+                case LoggingOptions.None:
+                {
+                    logger.ComputeFileHashes.Should().BeFalse();
+                    logger.PersistEnvironment.Should().BeFalse();
+                    logger.PersistFileContents.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.ComputeFileHashes:
+                {
+                    logger.ComputeFileHashes.Should().BeTrue();
+                    logger.PersistEnvironment.Should().BeFalse();
+                    logger.PersistFileContents.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.PersistEnvironment:
+                {
+                    logger.ComputeFileHashes.Should().BeFalse();
+                    logger.PersistEnvironment.Should().BeTrue();
+                    logger.PersistFileContents.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.PersistFileContents:
+                {
+                    logger.ComputeFileHashes.Should().BeFalse();
+                    logger.PersistEnvironment.Should().BeFalse();
+                    logger.PersistFileContents.Should().BeTrue();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.PrettyPrint:
+                {
+                    logger.ComputeFileHashes.Should().BeFalse();
+                    logger.PersistEnvironment.Should().BeFalse();
+                    logger.PersistFileContents.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeTrue();
+                    logger.Verbose.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.Verbose:
+                {
+                    logger.ComputeFileHashes.Should().BeFalse();
+                    logger.PersistEnvironment.Should().BeFalse();
+                    logger.PersistFileContents.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeTrue();
+                    break;
+                }
+                case LoggingOptions.All:
+                {
+                    logger.ComputeFileHashes.Should().BeTrue();
+                    logger.PersistEnvironment.Should().BeTrue();
+                    logger.PersistFileContents.Should().BeTrue();
+                    logger.PrettyPrint.Should().BeTrue();
+                    logger.Verbose.Should().BeTrue();
+                    break;
+                }
+                default:
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
     }
 }

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -79,9 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: false,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.None,
                     prereleaseInfo: null,
                     invocationTokensToRedact: tokensToRedact,
                     invocationPropertiesToLog: new List<string> { "CommandLine" })) { }
@@ -102,9 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: new string[] { @"foo.cpp" },
-                    verbose: false,
-                    computeTargetsHash: false,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.None,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null)) { }
@@ -134,9 +130,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: new string[] { file },
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null))
@@ -168,9 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null))
@@ -267,9 +259,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null))
@@ -305,9 +295,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: null))
@@ -339,9 +327,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: new[] { "WorkingDirectory", "ProcessId" }))
@@ -377,9 +363,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 using (var sarifLogger = new SarifLogger(
                     textWriter,
                     analysisTargets: null,
-                    verbose: false,
-                    computeTargetsHash: true,
-                    logEnvironment: false,
+                    loggingOptions: LoggingOptions.ComputeFileHashes,
                     prereleaseInfo: null,
                     invocationTokensToRedact: null,
                     invocationPropertiesToLog: new[] { "WORKINGDIRECTORY", "prOCessID" }))
@@ -404,7 +388,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             var sb = new StringBuilder();
 
             using (var writer = new StringWriter(sb))
-            using (var sarifLogger = new SarifLogger(writer, verbose: true))
+            using (var sarifLogger = new SarifLogger(writer, LoggingOptions.Verbose))
             {
                 var rule = new Rule()
                 {

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -112,6 +112,7 @@
     <Compile Include="UriHelper.cs" />
     <Compile Include="VersionConstants.cs" />
     <Compile Include="Warnings.cs" />
+    <Compile Include="Writers\LoggingOptions.cs" />
     <Compile Include="Writers\ResultLogJsonWriter.cs" />
     <Compile Include="Writers\MimeType.cs" />
     <Compile Include="Writers\SarifLogger.cs" />

--- a/src/Sarif/Writers/LoggingOptions.cs
+++ b/src/Sarif/Writers/LoggingOptions.cs
@@ -10,19 +10,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
     {
         None = 0,
 
-        // Persist SHA256 hash of all references files to log file
+        // Persist SHA256 hash of all referenced files to log file.
         ComputeFileHashes = 0x1,
 
-        // Persist base64 encoded file contents to log
+        // Persist base64 encoded file contents to log.
         PersistFileContents = 0x2,
         
-        // Persist environment variables to log file (which may contain security-sensitive information)
+        // Persist environment variables to log file (which may contain security-sensitive information).
         PersistEnvironment = 0x4,
 
-        // Indent persisted JSON for easy file viewing
+        // Indent persisted JSON for easy file viewing.
         PrettyPrint = 0x8,
 
-        // Persist verbose information to log file, such as informational messages
+        // Persist verbose information to log file, such as informational messages.
         Verbose = 0x10,
 
         All = ComputeFileHashes | PersistEnvironment | PersistFileContents | PrettyPrint | Verbose

--- a/src/Sarif/Writers/LoggingOptions.cs
+++ b/src/Sarif/Writers/LoggingOptions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Sarif.Writers
+{
+    public enum LoggingOptions
+    {
+        None = 0,
+        Verbose,
+        ComputeFileHashes,
+        PersistFileContents,
+        PersistEnvironment,
+        PrettyPrint
+    }
+}

--- a/src/Sarif/Writers/LoggingOptions.cs
+++ b/src/Sarif/Writers/LoggingOptions.cs
@@ -5,13 +5,26 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Sarif.Writers
 {
+    [Flags]
     public enum LoggingOptions
     {
         None = 0,
-        Verbose,
-        ComputeFileHashes,
-        PersistFileContents,
-        PersistEnvironment,
-        PrettyPrint
+
+        // Persist SHA256 hash of all references files to log file
+        ComputeFileHashes = 0x1,
+
+        // Persist base64 encoded file contents to log
+        PersistFileContents = 0x2,
+        
+        // Persist environment variables to log file (which may contain security-sensitive information)
+        PersistEnvironment = 0x4,
+
+        // Indent persisted JSON for easy file viewing
+        PrettyPrint = 0x8,
+
+        // Persist verbose information to log file, such as informational messages
+        Verbose = 0x10,
+
+        All = ComputeFileHashes | PersistEnvironment | PersistFileContents | PrettyPrint | Verbose
     }
 }

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -86,9 +86,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public SarifLogger(
             string outputFilePath, 
-            LoggingOptions loggingOptions,
-            Tool tool, 
-            Run run)
+            LoggingOptions loggingOptions = LoggingOptions.PrettyPrint,
+            Tool tool = null, 
+            Run run = null)
             : this(new StreamWriter(new FileStream(outputFilePath, FileMode.Create, FileAccess.Write, FileShare.None)),
                   loggingOptions,
                   tool,
@@ -99,25 +99,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public SarifLogger(
             TextWriter textWriter, 
-            LoggingOptions loggingOptions,
-            Tool tool, 
-            Run run) : this(textWriter, loggingOptions)
+            LoggingOptions loggingOptions = LoggingOptions.PrettyPrint,
+            Tool tool = null, 
+            Run run = null) : this(textWriter, loggingOptions)
         {
             _run = run ?? CreateRun(null, ComputeFileHashes, false, null, null);
+
+            tool = tool ?? Tool.CreateFromAssemblyData();
             SetSarifLoggerVersion(tool);
             _issueLogJsonWriter.WriteTool(tool);
         }
 
         public SarifLogger(
             string outputFilePath,
-            IEnumerable<string> analysisTargets,
             LoggingOptions loggingOptions,
+            IEnumerable<string> analysisTargets,
             string prereleaseInfo,
             IEnumerable<string> invocationTokensToRedact,
             IEnumerable<string> invocationPropertiesToLog = null)
             : this(new StreamWriter(new FileStream(outputFilePath, FileMode.Create, FileAccess.Write, FileShare.None)),
-                    analysisTargets,
                     loggingOptions,
+                    analysisTargets,
                     prereleaseInfo,
                     invocationTokensToRedact,
                     invocationPropertiesToLog)
@@ -126,8 +128,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public SarifLogger(
             TextWriter textWriter,
-            IEnumerable<string> analysisTargets,
             LoggingOptions loggingOptions,
+            IEnumerable<string> analysisTargets,
             string prereleaseInfo,
             IEnumerable<string> invocationTokensToRedact,
             IEnumerable<string> invocationPropertiesToLog = null) : this(textWriter, loggingOptions)
@@ -153,7 +155,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             tool.SarifLoggerVersion = FileVersionInfo.GetVersionInfo(sarifLoggerLocation).FileVersion;
         }
 
-        public SarifLogger(TextWriter textWriter, LoggingOptions loggingOptions)
+        private SarifLogger(TextWriter textWriter, LoggingOptions loggingOptions)
         {
             _textWriter = textWriter;
             _jsonTextWriter = new JsonTextWriter(_textWriter);
@@ -186,9 +188,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public bool ComputeFileHashes { get { return (_loggingOptions & LoggingOptions.ComputeFileHashes) == LoggingOptions.ComputeFileHashes; } }
 
-        public bool PersistEnvironment { get { return (_loggingOptions & LoggingOptions.ComputeFileHashes) == LoggingOptions.PersistEnvironment; } }
+        public bool PersistEnvironment { get { return (_loggingOptions & LoggingOptions.PersistEnvironment) == LoggingOptions.PersistEnvironment; } }
 
-        public bool PersistFileContents { get { return (_loggingOptions & LoggingOptions.ComputeFileHashes) == LoggingOptions.PersistFileContents; } }
+        public bool PersistFileContents { get { return (_loggingOptions & LoggingOptions.PersistFileContents) == LoggingOptions.PersistFileContents; } }
         
 
         public void Dispose()

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -182,16 +182,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
         }
 
-        public bool Verbose { get { return (_loggingOptions & LoggingOptions.Verbose) == LoggingOptions.Verbose; } }
-
-        public bool PrettyPrint { get { return (_loggingOptions & LoggingOptions.PrettyPrint) == LoggingOptions.PrettyPrint; } }
-
         public bool ComputeFileHashes { get { return (_loggingOptions & LoggingOptions.ComputeFileHashes) == LoggingOptions.ComputeFileHashes; } }
 
         public bool PersistEnvironment { get { return (_loggingOptions & LoggingOptions.PersistEnvironment) == LoggingOptions.PersistEnvironment; } }
 
         public bool PersistFileContents { get { return (_loggingOptions & LoggingOptions.PersistFileContents) == LoggingOptions.PersistFileContents; } }
-        
+
+        public bool PrettyPrint { get { return (_loggingOptions & LoggingOptions.PrettyPrint) == LoggingOptions.PrettyPrint; } }
+
+        public bool Verbose { get { return (_loggingOptions & LoggingOptions.Verbose) == LoggingOptions.Verbose; } }
 
         public void Dispose()
         {

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         private ResultLogJsonWriter _issueLogJsonWriter;
         private Dictionary<string, IRule> _rules;
 
+        private const LoggingOptions DefaultLoggingOptions = LoggingOptions.PrettyPrint;
+
         private static Run CreateRun(
             IEnumerable<string> analysisTargets,
             bool computeTargetsHash,
@@ -86,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         public SarifLogger(
             string outputFilePath, 
-            LoggingOptions loggingOptions = LoggingOptions.PrettyPrint,
+            LoggingOptions loggingOptions = DefaultLoggingOptions,
             Tool tool = null, 
             Run run = null)
             : this(new StreamWriter(new FileStream(outputFilePath, FileMode.Create, FileAccess.Write, FileShare.None)),
@@ -164,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             if (PrettyPrint)
             {
-                // for debugging it is nice to have the following line added.
+                // Indented output is preferable for debugging
                 _jsonTextWriter.Formatting = Newtonsoft.Json.Formatting.Indented;
             }        
 


### PR DESCRIPTION
@lgolding @vinaykapadia @jeff-bacon 

In advance of persisting file contents, I have cleaned up the SarifLogger class to accept an enum with various logging options (rather than introducing yet more Boolean arguments). I also cleaned up the API overloads a little bit. Also added testing to make sure that options passed in constructor flow properly to instances.

Next step, obviously, make the PersistFileContents flag do something useful. :)