### PR TITLE
Fix #634: Unit test fails due to lack of URL-escaping

### DIFF
--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             string logText = sb.ToString();
 
-            string fileDataKey = new Uri(file).ToString();
+            string fileDataKey = new Uri(file).AbsoluteUri;
 
             var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logText);
             sarifLog.Runs[0].Files[fileDataKey].MimeType.Should().Be(MimeType.Cpp);


### PR DESCRIPTION
The unit test `SarifLogger_WritesFileData` fails on my machine because it creates a temp file in my profile directory `C:\Users\Larry Golding\AppData\Local\Temp` -- and my user name contains a space. As a URL, this is `file:///C:/Users/Larry%20Golding/AppData/Local/Temp` (URL-escaping the space). But the unit test compares this string to `file:///C:/Users/Larry Golding/AppData/Local/Temp` (without URL-escaping the space).

The fix is to use `uri.AbsolutePath` (which performs URL-escaping) instead of `uri.ToString()` (which does not).