### PR TITLE
Fix #642: Add TSLint support to the viewer VSIX

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
@@ -59,6 +61,174 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             var lineMarker = item.LineMarker;
 
             lineMarker.Should().Be(null);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenMessageIsAbsent_ContainsBlankMessage()
+        {
+            var result = new Result
+            {
+            };
+
+            var item = MakeErrorListItem(result);
+
+            item.Message.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenResultRefersToNonExistentRule_ContainsBlankMessage()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001",
+                FormattedRuleMessage = new FormattedRuleMessage("nonExistentFormatId", arguments: new string[0])
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Message.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenResultRefersToRuleWithNoMessageFormats_ContainsBlankMessage()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001",
+                FormattedRuleMessage = new FormattedRuleMessage("nonExistentFormatId", arguments: new string[0])
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    {
+                        "TST0001",
+                        new Rule
+                        {
+                            Id = "TST0001"
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Message.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenResultRefersToNonExistentMessageFormat_ContainsBlankMessage()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001",
+                FormattedRuleMessage = new FormattedRuleMessage("nonExistentFormatId", arguments: new string[0])
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    {
+                        "TST0001",
+                        new Rule
+                        {
+                            Id = "TST0001",
+                            MessageFormats = new Dictionary<string, string>
+                            {
+                                { "realFormatId", "The message" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Message.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenResultRefersToExistingMessageFormat_ContainsExpectedMessage()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001",
+                FormattedRuleMessage = new FormattedRuleMessage("greeting", new[] { "Mary" })
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    {
+                        "TST0001",
+                        new Rule
+                        {
+                            Id = "TST0001",
+                            MessageFormats = new Dictionary<string, string>
+                            {
+                                { "greeting", "Hello, {0}!" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Message.Should().Be("Hello, Mary!");
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenFixHasRelativePath_UsesThatPath()
+        {
+            var result = new Result
+            {
+                Fixes = new[]
+                {
+                    new Fix
+                    {
+                        FileChanges = new[]
+                        {
+                            new FileChange
+                            {
+                                Uri = new Uri("path/to/file.html", UriKind.Relative),
+                                Replacements = new[]
+                                {
+                                    new Replacement(0, 0, string.Empty)
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(result);
+
+            item.Fixes[0].FileChanges[0].FilePath.Should().Be("path/to/file.html");
+        }
+
+        private static SarifErrorListItem MakeErrorListItem(Result result)
+        {
+            return MakeErrorListItem(new Run(), result);
+        }
+
+        private static SarifErrorListItem MakeErrorListItem(Run run, Result result)
+        {
+            return new SarifErrorListItem(
+                run,
+                result,
+                "log.sarif",
+                new ProjectNameCache(solution: null));
         }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Net;
 using System.Windows.Forms;
 
-using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.Sarif.Viewer.ErrorList;
 using Microsoft.CodeAnalysis.Sarif.Converters;
@@ -32,11 +31,20 @@ namespace Microsoft.Sarif.Viewer
         public const int OpenClangFileCommandId = 0x0106;
         public const int OpenAndroidStudioFileCommandId = 0x0107;
         public const int OpenSemmleFileCommandId = 0x0108;
+        public const int OpenTSLintFileCommand = 0x0109;
 
         private static int[] s_commands = new int[]
         {
-            OpenSarifFileCommandId, OpenPREfastFileCommandId, OpenStaticDriverVerifierFileCommandId, OpenFxCopFileCommandId,
-            OpenFortifyFileCommandId, OpenCppCheckFileCommandId, OpenClangFileCommandId, OpenAndroidStudioFileCommandId, OpenSemmleFileCommandId
+            OpenSarifFileCommandId,
+            OpenPREfastFileCommandId,
+            OpenStaticDriverVerifierFileCommandId,
+            OpenFxCopFileCommandId,
+            OpenFortifyFileCommandId,
+            OpenCppCheckFileCommandId,
+            OpenClangFileCommandId,
+            OpenAndroidStudioFileCommandId,
+            OpenSemmleFileCommandId,
+            OpenTSLintFileCommand
         };
 
         /// <summary>
@@ -209,6 +217,13 @@ namespace Microsoft.Sarif.Viewer
                         toolFormat = ToolFormat.SemmleQL;
                         title = "Open Semmle QL CSV log file";
                         filter = "Semmle QL log files (*.csv)|*.csv";
+                        break;
+                    }
+                    case OpenTSLintFileCommand:
+                    {
+                        toolFormat = ToolFormat.TSLint;
+                        title = "Open TSLint JSON log file";
+                        filter = "TSLint log files (*.json)|*.json";
                         break;
                     }
                 }

--- a/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommandPackage.vsct
+++ b/src/Sarif.Viewer.VisualStudio/OpenSarifFileCommandPackage.vsct
@@ -129,6 +129,13 @@
           <ButtonText>Open Semmle QL CSV log file...</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidOpenSarifFileCommandPackageCmdSet" id="OpenTSLintFileCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidOpenSarifFileCommandPackageCmdSet" id="OpenFileSubMenuGroup" />
+        <!--<Icon guid="guidImages" id="bmpPic1" />-->
+        <Strings>
+          <ButtonText>Open TSLint log file...</ButtonText>
+        </Strings>
+      </Button>
       <Button guid="guidSarifViewerPackageCmdSet" id="cmdidSarifToolWindowCommand" priority="0x0100" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
         <!--<Icon guid="guidImages1" id="bmpPic1" />-->
@@ -167,6 +174,7 @@
       <IDSymbol name="OpenClangFileCommandId" value="0x0106" />
       <IDSymbol name="OpenAndroidStudioFileCommandId" value="0x0107" />
       <IDSymbol name="OpenSemmleFileCommandId" value="0x0108" />
+      <IDSymbol name="OpenTSLintFileCommandId" value="0x0109" />
       <IDSymbol name="OpenFileSubMenuGroup" value="0x1100" />
       <IDSymbol name="OpenFileMenuGroup" value="0x1150" />
       <IDSymbol name="cmdidTestSubCommand" value="0x0200" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif/FileChange.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/FileChange.extensions.cs
@@ -25,8 +25,11 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
             if (fileChange.Replacements != null)
             {
-                model.FilePath = fileChange.Uri.LocalPath;
-                if (!Path.IsPathRooted(model.FilePath))
+                model.FilePath = fileChange.Uri.IsAbsoluteUri
+                    ? fileChange.Uri.LocalPath
+                    : fileChange.Uri.OriginalString;
+
+                if (!Path.IsPathRooted(model.FilePath) && fileChange.Uri.IsAbsoluteUri)
                 {
                     model.FilePath = fileChange.Uri.AbsoluteUri;
                 }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
@@ -44,14 +44,17 @@ namespace Microsoft.Sarif.Viewer.Sarif
 
             if (run != null && run.Rules != null && (ruleId != null || ruleKey != null))
             {
+                Rule concreteRule = null;
                 if (ruleKey != null)
                 {
-                    rule = run.Rules[ruleKey];
+                    run.Rules.TryGetValue(ruleKey, out concreteRule);
                 }
                 else
                 {
-                    rule = run.Rules[ruleId];
+                    run.Rules.TryGetValue(ruleId, out concreteRule);
                 }
+
+                rule = concreteRule;
             }
             else if (ruleId != null)
             {

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -207,44 +207,48 @@ namespace Microsoft.CodeAnalysis.Sarif
             string text = result.Message;
             if (string.IsNullOrEmpty(text))
             {
-                Debug.Assert(rule != null);
+                text = string.Empty;    // Ensure that it's not null.
 
-                string formatId = result.FormattedRuleMessage.FormatId;
-                string messageFormat;
-
-                string[] arguments = null;
-
-                if (result.FormattedRuleMessage.Arguments != null)
+                if (rule != null)
                 {
-                    arguments = new string[result.FormattedRuleMessage.Arguments.Count];
-                    result.FormattedRuleMessage.Arguments.CopyTo(arguments, 0);
-                }
-                else
-                {
-                    arguments = new string[0];
-                }
+                    string formatId = result.FormattedRuleMessage.FormatId;
+                    string messageFormat;
 
-                Debug.Assert(rule.MessageFormats.ContainsKey(formatId));
+                    string[] arguments = null;
 
-                messageFormat = rule.MessageFormats[formatId];
+                    if (result.FormattedRuleMessage.Arguments != null)
+                    {
+                        arguments = new string[result.FormattedRuleMessage.Arguments.Count];
+                        result.FormattedRuleMessage.Arguments.CopyTo(arguments, 0);
+                    }
+                    else
+                    {
+                        arguments = new string[0];
+                    }
+
+                    if (rule.MessageFormats?.ContainsKey(formatId) == true)
+                    {
+                        messageFormat = rule.MessageFormats[formatId];
 
 #if DEBUG
-                int argumentsCount = arguments.Length;
-                for (int i = 0; i < argumentsCount; i++)
-                {
-                    // If this assert fires, there are too many arguments for the specifier
-                    // or there is an argument is skipped or not consumed in the specifier
-                    Debug.Assert(messageFormat.Contains("{" + i.ToString(CultureInfo.InvariantCulture) + "}"));
-                }
+                        int argumentsCount = arguments.Length;
+                        for (int i = 0; i < argumentsCount; i++)
+                        {
+                            // If this assert fires, there are too many arguments for the specifier
+                            // or there is an argument is skipped or not consumed in the specifier
+                            Debug.Assert(messageFormat.Contains("{" + i.ToString(CultureInfo.InvariantCulture) + "}"));
+                        }
 #endif
 
-                text = string.Format(CultureInfo.InvariantCulture, messageFormat, arguments);
+                        text = string.Format(CultureInfo.InvariantCulture, messageFormat, arguments);
 
 #if DEBUG
-                // If this assert fires, an insufficient # of arguments might
-                // have been provided to String.Format.
-                Debug.Assert(!text.Contains("{"));
+                        // If this assert fires, an insufficient # of arguments might
+                        // have been provided to String.Format.
+                        Debug.Assert(!text.Contains("{"));
 #endif
+                    }
+                }
             }
 
             if (concise)


### PR DESCRIPTION
Fix #642: Add TSLint support to the viewer VSIX

Also:
- Fix #640: SarifErrorListItem fails with certain invalid Results
- Fix #641: Viewer fails when a FileChange object specifies a relative URL