### PR TITLE
Fix #645: Viewer doesn't show ruleId unless rule metadata is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ bld/
 # Visual Studio 2017 browsing database files
 .BROWSE.VC.DB-*
 
+# Visual Studio 2017 Application/Debug properties
+launchSettings.json
+
 # VS Code configuration
 .vscode/
 

--- a/src/Sarif.Multitool/ConvertOptions.cs
+++ b/src/Sarif.Multitool/ConvertOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Option(
             't',
             "tool",
-            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, SemmleQL, StaticDriverVerifier, or a tool format for which a plugin assembly provides the converter.",
+            HelpText = "The tool format of the input file. Must be one of: AndroidStudio, ClangAnalyzer, CppCheck, Fortify, FortifyFpr, FxCop, PREfast, SemmleQL, StaticDriverVerifier, TSLint, or a tool format for which a plugin assembly provides the converter.",
             Required = true)]
         public string ToolFormat { get; internal set; }
 

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -265,6 +265,35 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.Rule.Id.Should().Be("TST0001");
         }
 
+        [Fact]
+        public void SarifErrorListItem_WhenMessageAndFormattedRuleMessageAreAbsentButRuleMetadataIsPresent_ContainsBlankMessage()
+        {
+            // This test prevents regression of #647,
+            // "Viewer NRE when result lacks message/formattedRuleMessage but rule metadata is present"
+            var result = new Result
+            {
+                RuleId = "TST0001"
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    {
+                        "TST0001",
+                        new Rule
+                        {
+                            Id = "TST0001"
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Message.Should().Be(string.Empty);
+        }
+
         private static SarifErrorListItem MakeErrorListItem(Result result)
         {
             return MakeErrorListItem(new Run(), result);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/ErrorList/SarifErrorListItemTests.cs
@@ -217,6 +217,54 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             item.Fixes[0].FileChanges[0].FilePath.Should().Be("path/to/file.html");
         }
 
+        [Fact]
+        public void SarifErrorListItem_WhenRuleMetadataIsPresent_PopulatesRuleModelFromSarifRule()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001-1"
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    {
+                        "TST0001-1",
+                        new Rule
+                        {
+                            Id = "TST0001"
+                        }
+                    }
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Rule.Id.Should().Be("TST0001");
+        }
+
+        [Fact]
+        public void SarifErrorListItem_WhenRuleMetadataIsAbsent_SynthesizesRuleModelFromResultRuleId()
+        {
+            var result = new Result
+            {
+                RuleId = "TST0001"
+            };
+
+            var run = new Run
+            {
+                Rules = new Dictionary<string, Rule>
+                {
+                    // No metadata for rule TST0001.
+                }
+            };
+
+            var item = MakeErrorListItem(run, result);
+
+            item.Rule.Id.Should().Be("TST0001");
+        }
+
         private static SarifErrorListItem MakeErrorListItem(Result result)
         {
             return MakeErrorListItem(new Run(), result);

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Sarif.Viewer
             }
 
             Tool = run.Tool.ToToolModel();
-            Rule = rule?.ToRuleModel(result.RuleId);
+            Rule = rule.ToRuleModel(result.RuleId);
             Invocation = run.Invocation.ToInvocationModel();
 
             if (String.IsNullOrWhiteSpace(run.Id))

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 text = string.Empty;    // Ensure that it's not null.
 
-                if (rule != null)
+                if (rule != null && result.FormattedRuleMessage != null)
                 {
                     string formatId = result.FormattedRuleMessage.FormatId;
                     string messageFormat;


### PR DESCRIPTION
Repro steps:

1. Open a SARIF log file that doesn't include rule metadata.

Expected: the `ruleId` from the result appears in the Code column of the Error List Window.

Actual: the Code column is blank.

Also:
- Fix #647: Viewer NRE when result lacks message/formattedRuleMessage but rule metadata is present
- Add `TSLint` to `-t` option help text.
- Add `launchSettings.json` (the file that contains the command line used by VS 2017 when you F5 a project) to `.gitignore`.