### PR TITLE
Fix #663: TSLint converter unnecessarily emits empty fix description

### DIFF
--- a/src/Sarif.Converters.UnitTests/TSLintConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/TSLintConverterTests.cs
@@ -103,7 +103,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 new Fix()
                 {
-                    Description = string.Empty,
                     FileChanges = new List<FileChange>()
                     {
                         new FileChange()

--- a/src/Sarif.Converters/TSLintConverter.cs
+++ b/src/Sarif.Converters/TSLintConverter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 FileChange sarifFileChange = new FileChange(uri: analysisTargetUri, uriBaseId: null, replacements: replacements);
 
-                Fix sarifFix = new Fix(description: string.Empty, fileChanges: new List<FileChange>() { sarifFileChange });
+                Fix sarifFix = new Fix(description: null, fileChanges: new List<FileChange>() { sarifFileChange });
                 result.Fixes = new List<Fix> { sarifFix };
             } 
 

--- a/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-01.json.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-01.json.sarif
@@ -279,7 +279,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -475,7 +474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -511,7 +509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -547,7 +544,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -643,7 +639,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -780,7 +775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -817,7 +811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -854,7 +847,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -931,7 +923,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1127,7 +1118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1163,7 +1153,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1199,7 +1188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1295,7 +1283,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1432,7 +1419,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1469,7 +1455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1506,7 +1491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1583,7 +1567,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1620,7 +1603,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1657,7 +1639,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1694,7 +1675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1731,7 +1711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1768,7 +1747,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1805,7 +1783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1842,7 +1819,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1879,7 +1855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1936,7 +1911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1991,7 +1965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2028,7 +2001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2085,7 +2057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2121,7 +2092,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2157,7 +2127,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2193,7 +2162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2230,7 +2198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2267,7 +2234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2344,7 +2310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2441,7 +2406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2477,7 +2441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2513,7 +2476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2670,7 +2632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2707,7 +2668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2744,7 +2704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2941,7 +2900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2978,7 +2936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3135,7 +3092,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3271,7 +3227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3307,7 +3262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3343,7 +3297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3500,7 +3453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3537,7 +3489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3574,7 +3525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3611,7 +3561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3848,7 +3797,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3885,7 +3833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3942,7 +3889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -4038,7 +3984,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4074,7 +4019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4110,7 +4054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4267,7 +4210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4304,7 +4246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4341,7 +4282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4378,7 +4318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4595,7 +4534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4632,7 +4570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4789,7 +4726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4885,7 +4821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -4921,7 +4856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -4958,7 +4892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -5035,7 +4968,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -5131,7 +5063,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5167,7 +5098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5244,7 +5174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5340,7 +5269,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5376,7 +5304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5453,7 +5380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5529,7 +5455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -5565,7 +5490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -5702,7 +5626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5738,7 +5661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5815,7 +5737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5931,7 +5852,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5967,7 +5887,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6124,7 +6043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6161,7 +6079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6198,7 +6115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6235,7 +6151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6472,7 +6387,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6509,7 +6423,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6566,7 +6479,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6662,7 +6574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6698,7 +6609,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6775,7 +6685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6871,7 +6780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -6907,7 +6815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -6984,7 +6891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -7120,7 +7026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7156,7 +7061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7192,7 +7096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7349,7 +7252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7386,7 +7288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7423,7 +7324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7460,7 +7360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7697,7 +7596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7734,7 +7632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7791,7 +7688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7887,7 +7783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -7923,7 +7818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -8000,7 +7894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -8096,7 +7989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8132,7 +8024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8209,7 +8100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8305,7 +8195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8341,7 +8230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8418,7 +8306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8514,7 +8401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8550,7 +8436,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8627,7 +8512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8723,7 +8607,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8759,7 +8642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8836,7 +8718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8932,7 +8813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -8968,7 +8848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -9045,7 +8924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -9141,7 +9019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9177,7 +9054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9254,7 +9130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9290,7 +9165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9386,7 +9260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9422,7 +9295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9499,7 +9371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9595,7 +9466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9631,7 +9501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9708,7 +9577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9804,7 +9672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -9840,7 +9707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -9917,7 +9783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -10053,7 +9918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10089,7 +9953,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10125,7 +9988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10282,7 +10144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10319,7 +10180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10356,7 +10216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10393,7 +10252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10630,7 +10488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10667,7 +10524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10724,7 +10580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10820,7 +10675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -10856,7 +10710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -10933,7 +10786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -11069,7 +10921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11105,7 +10956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11141,7 +10991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11298,7 +11147,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11335,7 +11183,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11372,7 +11219,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11409,7 +11255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11646,7 +11491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11683,7 +11527,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11740,7 +11583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11836,7 +11678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -11872,7 +11713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -11949,7 +11789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -12045,7 +11884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12081,7 +11919,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12198,7 +12035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12235,7 +12071,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12272,7 +12107,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12429,7 +12263,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12466,7 +12299,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12523,7 +12355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12619,7 +12450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12655,7 +12485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12732,7 +12561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12828,7 +12656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -12864,7 +12691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -12941,7 +12767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -13037,7 +12862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13073,7 +12897,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13150,7 +12973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13246,7 +13068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13282,7 +13103,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13399,7 +13219,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13436,7 +13255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13473,7 +13291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13630,7 +13447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13667,7 +13483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13724,7 +13539,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13820,7 +13634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -13856,7 +13669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -13973,7 +13785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14010,7 +13821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14047,7 +13857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14204,7 +14013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14241,7 +14049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14298,7 +14105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14434,7 +14240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14470,7 +14275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14506,7 +14310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14663,7 +14466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14700,7 +14502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14737,7 +14538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14774,7 +14574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14891,7 +14690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14948,7 +14746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -15044,7 +14841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15080,7 +14876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15157,7 +14952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15253,7 +15047,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15289,7 +15082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15366,7 +15158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15462,7 +15253,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15498,7 +15288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15534,7 +15323,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15691,7 +15479,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15728,7 +15515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15765,7 +15551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15802,7 +15587,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16019,7 +15803,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16056,7 +15839,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16213,7 +15995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16349,7 +16130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16385,7 +16165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16421,7 +16200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16578,7 +16356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16615,7 +16392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16652,7 +16428,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16689,7 +16464,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16926,7 +16700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16963,7 +16736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -17020,7 +16792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -17116,7 +16887,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17152,7 +16922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17269,7 +17038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17306,7 +17074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17343,7 +17110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17500,7 +17266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17537,7 +17302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17594,7 +17358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17690,7 +17453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17726,7 +17488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17843,7 +17604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17880,7 +17640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17917,7 +17676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18074,7 +17832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18111,7 +17868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18168,7 +17924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18264,7 +18019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18300,7 +18054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18417,7 +18170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18454,7 +18206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18491,7 +18242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18648,7 +18398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18685,7 +18434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18742,7 +18490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18838,7 +18585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -18874,7 +18620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -18991,7 +18736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19028,7 +18772,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19065,7 +18808,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19222,7 +18964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19259,7 +19000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19316,7 +19056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19452,7 +19191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19488,7 +19226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19524,7 +19261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19681,7 +19417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19718,7 +19453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19755,7 +19489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19792,7 +19525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19909,7 +19641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19966,7 +19697,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -20062,7 +19792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20098,7 +19827,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20175,7 +19903,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20311,7 +20038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20347,7 +20073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20383,7 +20108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20540,7 +20264,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20577,7 +20300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20614,7 +20336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20651,7 +20372,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20888,7 +20608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20925,7 +20644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20982,7 +20700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -21078,7 +20795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21114,7 +20830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21231,7 +20946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21268,7 +20982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21305,7 +21018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21462,7 +21174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21499,7 +21210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21556,7 +21266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21652,7 +21361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21688,7 +21396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21724,7 +21431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21881,7 +21587,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21918,7 +21623,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21955,7 +21659,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21992,7 +21695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22209,7 +21911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22246,7 +21947,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22403,7 +22103,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22499,7 +22198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22535,7 +22233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22612,7 +22309,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22708,7 +22404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22744,7 +22439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22821,7 +22515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22917,7 +22610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22953,7 +22645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22989,7 +22680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23146,7 +22836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23183,7 +22872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23220,7 +22908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23257,7 +22944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23474,7 +23160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23511,7 +23196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23568,7 +23252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23664,7 +23347,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23700,7 +23382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23777,7 +23458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23873,7 +23553,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -23909,7 +23588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -23986,7 +23664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -24082,7 +23759,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24118,7 +23794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24195,7 +23870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24291,7 +23965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24327,7 +24000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24404,7 +24076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24540,7 +24211,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24576,7 +24246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24612,7 +24281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24769,7 +24437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24806,7 +24473,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24843,7 +24509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24880,7 +24545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25117,7 +24781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25154,7 +24817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25211,7 +24873,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25307,7 +24968,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25343,7 +25003,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25420,7 +25079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25536,7 +25194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25572,7 +25229,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25669,7 +25325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25765,7 +25420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25801,7 +25455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25878,7 +25531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25974,7 +25626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26010,7 +25661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26087,7 +25737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26183,7 +25832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26219,7 +25867,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26296,7 +25943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26392,7 +26038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26428,7 +26073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26545,7 +26189,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26582,7 +26225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26619,7 +26261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26776,7 +26417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26813,7 +26453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26870,7 +26509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26925,7 +26563,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -26981,7 +26618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -27018,7 +26654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -27055,7 +26690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27101,7 +26735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27138,7 +26771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27175,7 +26807,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27211,7 +26842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -27248,7 +26878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -27305,7 +26934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -27362,7 +26990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -27399,7 +27026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -27475,7 +27101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -27532,7 +27157,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27608,7 +27232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27665,7 +27288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27722,7 +27344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27759,7 +27380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27796,7 +27416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27833,7 +27452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27890,7 +27508,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -27947,7 +27564,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -27984,7 +27600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28060,7 +27675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28117,7 +27731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28154,7 +27767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28210,7 +27822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28247,7 +27858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28284,7 +27894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28321,7 +27930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -29297,7 +28905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29334,7 +28941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29371,7 +28977,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29408,7 +29013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29445,7 +29049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29482,7 +29085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29519,7 +29121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30036,7 +29637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30072,7 +29672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30108,7 +29707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30144,7 +29742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30500,7 +30097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30997,7 +30593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31474,7 +31069,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31510,7 +31104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31546,7 +31139,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31582,7 +31174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31618,7 +31209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31654,7 +31244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31690,7 +31279,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31726,7 +31314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31762,7 +31349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31798,7 +31384,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31834,7 +31419,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31870,7 +31454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31906,7 +31489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31942,7 +31524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31978,7 +31559,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32014,7 +31594,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32050,7 +31629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32086,7 +31664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32122,7 +31699,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32158,7 +31734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32194,7 +31769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32230,7 +31804,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32266,7 +31839,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32322,7 +31894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32359,7 +31930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32736,7 +32306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32772,7 +32341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32808,7 +32376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -35369,7 +34936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37585,7 +37151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37621,7 +37186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37657,7 +37221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37693,7 +37256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37729,7 +37291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37765,7 +37326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37801,7 +37361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37837,7 +37396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37873,7 +37431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37909,7 +37466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37945,7 +37501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37981,7 +37536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38017,7 +37571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38053,7 +37606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38089,7 +37641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38125,7 +37676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38161,7 +37711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38197,7 +37746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38233,7 +37781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38269,7 +37816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38305,7 +37851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38341,7 +37886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38377,7 +37921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38413,7 +37956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38449,7 +37991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38485,7 +38026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38521,7 +38061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38557,7 +38096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38593,7 +38131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38629,7 +38166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38665,7 +38201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38701,7 +38236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38737,7 +38271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38773,7 +38306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38809,7 +38341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38845,7 +38376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38881,7 +38411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38917,7 +38446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38953,7 +38481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38989,7 +38516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39025,7 +38551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39061,7 +38586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39097,7 +38621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39133,7 +38656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39169,7 +38691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39205,7 +38726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39241,7 +38761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39277,7 +38796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39313,7 +38831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39349,7 +38866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39385,7 +38901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39421,7 +38936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39457,7 +38971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39493,7 +39006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39529,7 +39041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39565,7 +39076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39601,7 +39111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39637,7 +39146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39673,7 +39181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39709,7 +39216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39745,7 +39251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39781,7 +39286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39817,7 +39321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39853,7 +39356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39889,7 +39391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39925,7 +39426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39961,7 +39461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39997,7 +39496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40033,7 +39531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40069,7 +39566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40105,7 +39601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40141,7 +39636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40177,7 +39671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40213,7 +39706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40249,7 +39741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40285,7 +39776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40321,7 +39811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40357,7 +39846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40393,7 +39881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40429,7 +39916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40465,7 +39951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40501,7 +39986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40537,7 +40021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40573,7 +40056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40609,7 +40091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40645,7 +40126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40681,7 +40161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -41717,7 +41196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -41994,7 +41472,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -42031,7 +41508,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43108,7 +42584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43145,7 +42620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43182,7 +42656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43219,7 +42692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43256,7 +42728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43292,7 +42763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43328,7 +42798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43365,7 +42834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43402,7 +42870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43439,7 +42906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45656,7 +45122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45692,7 +45157,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45728,7 +45192,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45764,7 +45227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45800,7 +45262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45836,7 +45297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45872,7 +45332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45908,7 +45367,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45944,7 +45402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45980,7 +45437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46016,7 +45472,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46052,7 +45507,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46088,7 +45542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46124,7 +45577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46160,7 +45612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46196,7 +45647,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46232,7 +45682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46268,7 +45717,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46304,7 +45752,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46340,7 +45787,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46376,7 +45822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46412,7 +45857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46448,7 +45892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46484,7 +45927,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46520,7 +45962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46556,7 +45997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46592,7 +46032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46628,7 +46067,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46664,7 +46102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46700,7 +46137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46736,7 +46172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46772,7 +46207,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46808,7 +46242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46844,7 +46277,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46880,7 +46312,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46916,7 +46347,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46952,7 +46382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -46993,7 +46422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47030,7 +46458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47067,7 +46494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47104,7 +46530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47141,7 +46566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47178,7 +46602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -47215,7 +46638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51731,7 +51153,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51767,7 +51188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51803,7 +51223,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51839,7 +51258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51875,7 +51293,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51911,7 +51328,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51947,7 +51363,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -51983,7 +51398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -52919,7 +52333,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -58755,7 +58168,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/require.d.ts",
@@ -58912,7 +58324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58954,7 +58365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58996,7 +58406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59037,7 +58446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59078,7 +58486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59119,7 +58526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59160,7 +58566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59201,7 +58606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59242,7 +58646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59283,7 +58686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59324,7 +58726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59365,7 +58766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59407,7 +58807,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59449,7 +58848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59491,7 +58889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60533,7 +59930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60570,7 +59966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60607,7 +60002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60644,7 +60038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60681,7 +60074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60718,7 +60110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60755,7 +60146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60792,7 +60182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60829,7 +60218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60866,7 +60254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60903,7 +60290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60940,7 +60326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60977,7 +60362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61014,7 +60398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61051,7 +60434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61088,7 +60470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61125,7 +60506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61162,7 +60542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61199,7 +60578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61236,7 +60614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61273,7 +60650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61310,7 +60686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61347,7 +60722,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61384,7 +60758,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61421,7 +60794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61458,7 +60830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61495,7 +60866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61532,7 +60902,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61569,7 +60938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61606,7 +60974,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61643,7 +61010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61680,7 +61046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61717,7 +61082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61754,7 +61118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61791,7 +61154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61828,7 +61190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61865,7 +61226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61902,7 +61262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61939,7 +61298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61976,7 +61334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62013,7 +61370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62050,7 +61406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62087,7 +61442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62124,7 +61478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62161,7 +61514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62198,7 +61550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62235,7 +61586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62272,7 +61622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62309,7 +61658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62346,7 +61694,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62383,7 +61730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62420,7 +61766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62457,7 +61802,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62494,7 +61838,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62531,7 +61874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62568,7 +61910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62605,7 +61946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62642,7 +61982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62679,7 +62018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62716,7 +62054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62753,7 +62090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62790,7 +62126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62827,7 +62162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62864,7 +62198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62901,7 +62234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62938,7 +62270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62975,7 +62306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63012,7 +62342,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63049,7 +62378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63086,7 +62414,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63123,7 +62450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63160,7 +62486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63197,7 +62522,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63234,7 +62558,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63271,7 +62594,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63308,7 +62630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63345,7 +62666,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63382,7 +62702,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63419,7 +62738,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63456,7 +62774,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63493,7 +62810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63530,7 +62846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63567,7 +62882,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63604,7 +62918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63641,7 +62954,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63678,7 +62990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63715,7 +63026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63752,7 +63062,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63789,7 +63098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63826,7 +63134,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63863,7 +63170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63900,7 +63206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63937,7 +63242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63974,7 +63278,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64011,7 +63314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64048,7 +63350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64085,7 +63386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64122,7 +63422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64159,7 +63458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64196,7 +63494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64233,7 +63530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64270,7 +63566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64307,7 +63602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64344,7 +63638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64381,7 +63674,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64418,7 +63710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64455,7 +63746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64492,7 +63782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64529,7 +63818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64566,7 +63854,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64603,7 +63890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64640,7 +63926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64677,7 +63962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64714,7 +63998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64751,7 +64034,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64788,7 +64070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64825,7 +64106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64862,7 +64142,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64899,7 +64178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64936,7 +64214,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64973,7 +64250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65010,7 +64286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65047,7 +64322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65084,7 +64358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65121,7 +64394,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65158,7 +64430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65195,7 +64466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65232,7 +64502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65269,7 +64538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65306,7 +64574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65343,7 +64610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65380,7 +64646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65417,7 +64682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65454,7 +64718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65491,7 +64754,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65528,7 +64790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65565,7 +64826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65602,7 +64862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65639,7 +64898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65676,7 +64934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65713,7 +64970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65750,7 +65006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65787,7 +65042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65824,7 +65078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65861,7 +65114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65898,7 +65150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65935,7 +65186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65972,7 +65222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66009,7 +65258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66046,7 +65294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66083,7 +65330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66120,7 +65366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66157,7 +65402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66194,7 +65438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66231,7 +65474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66268,7 +65510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66305,7 +65546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66342,7 +65582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66379,7 +65618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66416,7 +65654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66453,7 +65690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66490,7 +65726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66527,7 +65762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66564,7 +65798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66601,7 +65834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66638,7 +65870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66675,7 +65906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66712,7 +65942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66749,7 +65978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66786,7 +66014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66823,7 +66050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66860,7 +66086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66897,7 +66122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66934,7 +66158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66971,7 +66194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67008,7 +66230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67045,7 +66266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67082,7 +66302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67119,7 +66338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67156,7 +66374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67193,7 +66410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67230,7 +66446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67267,7 +66482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67304,7 +66518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67341,7 +66554,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67378,7 +66590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67415,7 +66626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67452,7 +66662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67489,7 +66698,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67526,7 +66734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67563,7 +66770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67600,7 +66806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67637,7 +66842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67674,7 +66878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67711,7 +66914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67748,7 +66950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67785,7 +66986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67822,7 +67022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67859,7 +67058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67896,7 +67094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67933,7 +67130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67970,7 +67166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68007,7 +67202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68044,7 +67238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68081,7 +67274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68118,7 +67310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68155,7 +67346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68192,7 +67382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68229,7 +67418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68266,7 +67454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68303,7 +67490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68340,7 +67526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68377,7 +67562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68414,7 +67598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68451,7 +67634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68488,7 +67670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68525,7 +67706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68562,7 +67742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68599,7 +67778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68636,7 +67814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68673,7 +67850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68710,7 +67886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68747,7 +67922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68784,7 +67958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68821,7 +67994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68858,7 +68030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68895,7 +68066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68932,7 +68102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68969,7 +68138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69006,7 +68174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69043,7 +68210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69080,7 +68246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69117,7 +68282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69154,7 +68318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69191,7 +68354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69228,7 +68390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69265,7 +68426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69302,7 +68462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69339,7 +68498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69376,7 +68534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69413,7 +68570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69450,7 +68606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69487,7 +68642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69524,7 +68678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69561,7 +68714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69598,7 +68750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69635,7 +68786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69672,7 +68822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69709,7 +68858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69746,7 +68894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69783,7 +68930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69820,7 +68966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69857,7 +69002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69894,7 +69038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69931,7 +69074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69968,7 +69110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70005,7 +69146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70042,7 +69182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70079,7 +69218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70116,7 +69254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70153,7 +69290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70190,7 +69326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70227,7 +69362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70264,7 +69398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70301,7 +69434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70338,7 +69470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70375,7 +69506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70412,7 +69542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70449,7 +69578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70486,7 +69614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70523,7 +69650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70560,7 +69686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70597,7 +69722,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70634,7 +69758,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70671,7 +69794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70708,7 +69830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70745,7 +69866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70782,7 +69902,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70819,7 +69938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70856,7 +69974,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70893,7 +70010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70930,7 +70046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70967,7 +70082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71004,7 +70118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71041,7 +70154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71078,7 +70190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71115,7 +70226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71152,7 +70262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71189,7 +70298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71226,7 +70334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71263,7 +70370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71300,7 +70406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71337,7 +70442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71374,7 +70478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71411,7 +70514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71448,7 +70550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71485,7 +70586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71522,7 +70622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71559,7 +70658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71596,7 +70694,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71633,7 +70730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71670,7 +70766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71707,7 +70802,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71744,7 +70838,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71781,7 +70874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71818,7 +70910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71855,7 +70946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71892,7 +70982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71929,7 +71018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71966,7 +71054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72003,7 +71090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72040,7 +71126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72077,7 +71162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72114,7 +71198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72151,7 +71234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72188,7 +71270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72225,7 +71306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72262,7 +71342,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72299,7 +71378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72336,7 +71414,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72373,7 +71450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72410,7 +71486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72447,7 +71522,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72484,7 +71558,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72521,7 +71594,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72558,7 +71630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72595,7 +71666,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72632,7 +71702,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72669,7 +71738,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72706,7 +71774,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72743,7 +71810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72780,7 +71846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72817,7 +71882,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72854,7 +71918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72891,7 +71954,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72928,7 +71990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72965,7 +72026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73002,7 +72062,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73039,7 +72098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73076,7 +72134,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73113,7 +72170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73150,7 +72206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73187,7 +72242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73224,7 +72278,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73261,7 +72314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73298,7 +72350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73335,7 +72386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73372,7 +72422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73409,7 +72458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73446,7 +72494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73483,7 +72530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73520,7 +72566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73557,7 +72602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73594,7 +72638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73631,7 +72674,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73668,7 +72710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73705,7 +72746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73742,7 +72782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73779,7 +72818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73816,7 +72854,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73853,7 +72890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73890,7 +72926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73927,7 +72962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73964,7 +72998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74001,7 +73034,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74038,7 +73070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74075,7 +73106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74112,7 +73142,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74149,7 +73178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74186,7 +73214,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74223,7 +73250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74260,7 +73286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74297,7 +73322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74334,7 +73358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74371,7 +73394,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74408,7 +73430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74445,7 +73466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74482,7 +73502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74519,7 +73538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74556,7 +73574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74593,7 +73610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74630,7 +73646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74667,7 +73682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74704,7 +73718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74741,7 +73754,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74778,7 +73790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74815,7 +73826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74852,7 +73862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74889,7 +73898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74926,7 +73934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74963,7 +73970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75000,7 +74006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75037,7 +74042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75074,7 +74078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75111,7 +74114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75148,7 +74150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75185,7 +74186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75222,7 +74222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75259,7 +74258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75296,7 +74294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75333,7 +74330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75370,7 +74366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75407,7 +74402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75444,7 +74438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75481,7 +74474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75518,7 +74510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75555,7 +74546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75592,7 +74582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75629,7 +74618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75666,7 +74654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75703,7 +74690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75740,7 +74726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75777,7 +74762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75814,7 +74798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75851,7 +74834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75888,7 +74870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75925,7 +74906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75962,7 +74942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75999,7 +74978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76036,7 +75014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76073,7 +75050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76110,7 +75086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76147,7 +75122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76184,7 +75158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76221,7 +75194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76258,7 +75230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76295,7 +75266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76332,7 +75302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76369,7 +75338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76406,7 +75374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76443,7 +75410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76480,7 +75446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76517,7 +75482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76554,7 +75518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76591,7 +75554,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76628,7 +75590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76665,7 +75626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76702,7 +75662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76739,7 +75698,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76776,7 +75734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76813,7 +75770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76850,7 +75806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76887,7 +75842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76924,7 +75878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76961,7 +75914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76998,7 +75950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77035,7 +75986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77072,7 +76022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77109,7 +76058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77146,7 +76094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77183,7 +76130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77220,7 +76166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77257,7 +76202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77294,7 +76238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77331,7 +76274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77368,7 +76310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77405,7 +76346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77442,7 +76382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77479,7 +76418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77516,7 +76454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77553,7 +76490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77590,7 +76526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77627,7 +76562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77664,7 +76598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77701,7 +76634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77738,7 +76670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77775,7 +76706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77812,7 +76742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77849,7 +76778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77886,7 +76814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77923,7 +76850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77960,7 +76886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77997,7 +76922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78034,7 +76958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78071,7 +76994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78108,7 +77030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78145,7 +77066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78182,7 +77102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78219,7 +77138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78256,7 +77174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78293,7 +77210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78330,7 +77246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78367,7 +77282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78404,7 +77318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78441,7 +77354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78478,7 +77390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78515,7 +77426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78552,7 +77462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78589,7 +77498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78626,7 +77534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78663,7 +77570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78700,7 +77606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78737,7 +77642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78774,7 +77678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78811,7 +77714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78848,7 +77750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78885,7 +77786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78922,7 +77822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79019,7 +77918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -99395,7 +98293,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -99452,7 +98349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -99909,7 +98805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -99945,7 +98840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -99981,7 +98875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100017,7 +98910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100053,7 +98945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100089,7 +98980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100125,7 +99015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100161,7 +99050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100197,7 +99085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100233,7 +99120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100269,7 +99155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100305,7 +99190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100341,7 +99225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100377,7 +99260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100413,7 +99295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100449,7 +99330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100485,7 +99365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100521,7 +99400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100557,7 +99435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100593,7 +99470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100629,7 +99505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100665,7 +99540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100701,7 +99575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100737,7 +99610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100773,7 +99645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100809,7 +99680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100845,7 +99715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100881,7 +99750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100917,7 +99785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100953,7 +99820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -100989,7 +99855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101025,7 +99890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101061,7 +99925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101097,7 +99960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101133,7 +99995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101169,7 +100030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101205,7 +100065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101241,7 +100100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101277,7 +100135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101313,7 +100170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101349,7 +100205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101385,7 +100240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101421,7 +100275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101457,7 +100310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101493,7 +100345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101529,7 +100380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101565,7 +100415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101601,7 +100450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101637,7 +100485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101673,7 +100520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101709,7 +100555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101745,7 +100590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101781,7 +100625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101817,7 +100660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101853,7 +100695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101889,7 +100730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101925,7 +100765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101961,7 +100800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101997,7 +100835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102033,7 +100870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102069,7 +100905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102105,7 +100940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102141,7 +100975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102177,7 +101010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102213,7 +101045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102249,7 +101080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102285,7 +101115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102321,7 +101150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102357,7 +101185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102393,7 +101220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102429,7 +101255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102465,7 +101290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102501,7 +101325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102537,7 +101360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102573,7 +101395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102609,7 +101430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102645,7 +101465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102681,7 +101500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102717,7 +101535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102753,7 +101570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102789,7 +101605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102825,7 +101640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102861,7 +101675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102897,7 +101710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102933,7 +101745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102969,7 +101780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103005,7 +101815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103041,7 +101850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103077,7 +101885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103113,7 +101920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103149,7 +101955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103185,7 +101990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103221,7 +102025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103257,7 +102060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103293,7 +102095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103329,7 +102130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103365,7 +102165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103401,7 +102200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103437,7 +102235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103473,7 +102270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103509,7 +102305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103545,7 +102340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103581,7 +102375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103617,7 +102410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103653,7 +102445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103689,7 +102480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103725,7 +102515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103761,7 +102550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103797,7 +102585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103833,7 +102620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103869,7 +102655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103905,7 +102690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103941,7 +102725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103977,7 +102760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104013,7 +102795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104049,7 +102830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104085,7 +102865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104121,7 +102900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104157,7 +102935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104193,7 +102970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104229,7 +103005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104265,7 +103040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104301,7 +103075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104337,7 +103110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104373,7 +103145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104409,7 +103180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104445,7 +103215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104481,7 +103250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104517,7 +103285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104553,7 +103320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104589,7 +103355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104625,7 +103390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104661,7 +103425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104697,7 +103460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104733,7 +103495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104769,7 +103530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104805,7 +103565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104841,7 +103600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104877,7 +103635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104913,7 +103670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104949,7 +103705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104985,7 +103740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105021,7 +103775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105057,7 +103810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105093,7 +103845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105129,7 +103880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105165,7 +103915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105201,7 +103950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105237,7 +103985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105273,7 +104020,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105309,7 +104055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105345,7 +104090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105381,7 +104125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105417,7 +104160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105453,7 +104195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105489,7 +104230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105525,7 +104265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105561,7 +104300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105597,7 +104335,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105633,7 +104370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105669,7 +104405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105705,7 +104440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105741,7 +104475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105777,7 +104510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105813,7 +104545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105849,7 +104580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105885,7 +104615,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105921,7 +104650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105957,7 +104685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105993,7 +104720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106029,7 +104755,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106065,7 +104790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106101,7 +104825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106137,7 +104860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106173,7 +104895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106209,7 +104930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106245,7 +104965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106281,7 +105000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106317,7 +105035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106353,7 +105070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106389,7 +105105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106425,7 +105140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106461,7 +105175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106497,7 +105210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106533,7 +105245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106569,7 +105280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106605,7 +105315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106641,7 +105350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106677,7 +105385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106713,7 +105420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106749,7 +105455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106785,7 +105490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106821,7 +105525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106857,7 +105560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106893,7 +105595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106929,7 +105630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106965,7 +105665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107001,7 +105700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107037,7 +105735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107073,7 +105770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107109,7 +105805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107145,7 +105840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107181,7 +105875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107217,7 +105910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107253,7 +105945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107289,7 +105980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107325,7 +106015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107361,7 +106050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107397,7 +106085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107433,7 +106120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107469,7 +106155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107505,7 +106190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107541,7 +106225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107577,7 +106260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107613,7 +106295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107649,7 +106330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107685,7 +106365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107721,7 +106400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107757,7 +106435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107793,7 +106470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107829,7 +106505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107865,7 +106540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107901,7 +106575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107937,7 +106610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107973,7 +106645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108009,7 +106680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108045,7 +106715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108081,7 +106750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108117,7 +106785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108153,7 +106820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108189,7 +106855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108225,7 +106890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108261,7 +106925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108297,7 +106960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108333,7 +106995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108369,7 +107030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108405,7 +107065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108441,7 +107100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108477,7 +107135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108513,7 +107170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108549,7 +107205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108585,7 +107240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108621,7 +107275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108657,7 +107310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108693,7 +107345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108729,7 +107380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108765,7 +107415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108801,7 +107450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108837,7 +107485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108873,7 +107520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108909,7 +107555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108945,7 +107590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108981,7 +107625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109017,7 +107660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109053,7 +107695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109089,7 +107730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109125,7 +107765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109161,7 +107800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109197,7 +107835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109233,7 +107870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109269,7 +107905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109305,7 +107940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109341,7 +107975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109377,7 +108010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109413,7 +108045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109449,7 +108080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109485,7 +108115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109521,7 +108150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109557,7 +108185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109593,7 +108220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109629,7 +108255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109665,7 +108290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109701,7 +108325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109737,7 +108360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109773,7 +108395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109809,7 +108430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109845,7 +108465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109881,7 +108500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109917,7 +108535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109953,7 +108570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109989,7 +108605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110025,7 +108640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110061,7 +108675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110097,7 +108710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110133,7 +108745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110169,7 +108780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110205,7 +108815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110241,7 +108850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110277,7 +108885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110313,7 +108920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110349,7 +108955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110385,7 +108990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110421,7 +109025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110457,7 +109060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110493,7 +109095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110529,7 +109130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110565,7 +109165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110601,7 +109200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110637,7 +109235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110673,7 +109270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110709,7 +109305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110745,7 +109340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110781,7 +109375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110817,7 +109410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110853,7 +109445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110889,7 +109480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110925,7 +109515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110961,7 +109550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110997,7 +109585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111033,7 +109620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111069,7 +109655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111105,7 +109690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111141,7 +109725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111177,7 +109760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111213,7 +109795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111249,7 +109830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111285,7 +109865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111321,7 +109900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111357,7 +109935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111393,7 +109970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111429,7 +110005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111465,7 +110040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111501,7 +110075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111537,7 +110110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111573,7 +110145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111609,7 +110180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111645,7 +110215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111681,7 +110250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111717,7 +110285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111753,7 +110320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111789,7 +110355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111825,7 +110390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111861,7 +110425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111897,7 +110460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111933,7 +110495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111969,7 +110530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112005,7 +110565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112041,7 +110600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112077,7 +110635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112113,7 +110670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112149,7 +110705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112185,7 +110740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112221,7 +110775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112257,7 +110810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112293,7 +110845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112329,7 +110880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112365,7 +110915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112401,7 +110950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112437,7 +110985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112473,7 +111020,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112509,7 +111055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112545,7 +111090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112581,7 +111125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112617,7 +111160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112653,7 +111195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112689,7 +111230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112725,7 +111265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112761,7 +111300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112797,7 +111335,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112833,7 +111370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112869,7 +111405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112905,7 +111440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112941,7 +111475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112977,7 +111510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113013,7 +111545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113049,7 +111580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113085,7 +111615,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113121,7 +111650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113157,7 +111685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113193,7 +111720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113229,7 +111755,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113265,7 +111790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113301,7 +111825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113337,7 +111860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113373,7 +111895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113409,7 +111930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113445,7 +111965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113481,7 +112000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113517,7 +112035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113553,7 +112070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113589,7 +112105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113625,7 +112140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113661,7 +112175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113697,7 +112210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113733,7 +112245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113769,7 +112280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113805,7 +112315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113841,7 +112350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113877,7 +112385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113913,7 +112420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113949,7 +112455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113985,7 +112490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114021,7 +112525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114057,7 +112560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114093,7 +112595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114129,7 +112630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114165,7 +112665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114201,7 +112700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114237,7 +112735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114273,7 +112770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114309,7 +112805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114345,7 +112840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114381,7 +112875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114417,7 +112910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114453,7 +112945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114489,7 +112980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114525,7 +113015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114561,7 +113050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114597,7 +113085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114633,7 +113120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114669,7 +113155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114705,7 +113190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114741,7 +113225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114777,7 +113260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114813,7 +113295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114849,7 +113330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114885,7 +113365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114921,7 +113400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114957,7 +113435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114993,7 +113470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115029,7 +113505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115065,7 +113540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115101,7 +113575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115137,7 +113610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115173,7 +113645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115209,7 +113680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115245,7 +113715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115281,7 +113750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115317,7 +113785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115353,7 +113820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115389,7 +113855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115425,7 +113890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115461,7 +113925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115497,7 +113960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115533,7 +113995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115569,7 +114030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115605,7 +114065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115641,7 +114100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115677,7 +114135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115713,7 +114170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115749,7 +114205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115785,7 +114240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115821,7 +114275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115857,7 +114310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115893,7 +114345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115929,7 +114380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115965,7 +114415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116001,7 +114450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116037,7 +114485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116073,7 +114520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116109,7 +114555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116145,7 +114590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116181,7 +114625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116217,7 +114660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116253,7 +114695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116289,7 +114730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116325,7 +114765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116361,7 +114800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116397,7 +114835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116433,7 +114870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116469,7 +114905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116505,7 +114940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116541,7 +114975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116577,7 +115010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116613,7 +115045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116649,7 +115080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116685,7 +115115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116721,7 +115150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116757,7 +115185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116793,7 +115220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116829,7 +115255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116865,7 +115290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116901,7 +115325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116937,7 +115360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116973,7 +115395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117009,7 +115430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117045,7 +115465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117081,7 +115500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117117,7 +115535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117153,7 +115570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117189,7 +115605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117225,7 +115640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117261,7 +115675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117297,7 +115710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117333,7 +115745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117369,7 +115780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117405,7 +115815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117441,7 +115850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117477,7 +115885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117513,7 +115920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117549,7 +115955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117585,7 +115990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117621,7 +116025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117657,7 +116060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117693,7 +116095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117729,7 +116130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117765,7 +116165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117801,7 +116200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117837,7 +116235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117873,7 +116270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118569,7 +116965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118605,7 +117000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118641,7 +117035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118677,7 +117070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118713,7 +117105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118749,7 +117140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118785,7 +117175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118821,7 +117210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118857,7 +117245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118893,7 +117280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118929,7 +117315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118965,7 +117350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119001,7 +117385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119037,7 +117420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119073,7 +117455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119109,7 +117490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119145,7 +117525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119181,7 +117560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119217,7 +117595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119253,7 +117630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119289,7 +117665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119325,7 +117700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119361,7 +117735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119397,7 +117770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119433,7 +117805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119469,7 +117840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119505,7 +117875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119541,7 +117910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119577,7 +117945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119613,7 +117980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119649,7 +118015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119685,7 +118050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119721,7 +118085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119757,7 +118120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119793,7 +118155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119829,7 +118190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119865,7 +118225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119901,7 +118260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119937,7 +118295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119973,7 +118330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120009,7 +118365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120045,7 +118400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120081,7 +118435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120117,7 +118470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120153,7 +118505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120189,7 +118540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120225,7 +118575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120261,7 +118610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120297,7 +118645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120333,7 +118680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120369,7 +118715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120405,7 +118750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120441,7 +118785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120477,7 +118820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120513,7 +118855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120549,7 +118890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120585,7 +118925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120621,7 +118960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120657,7 +118995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120693,7 +119030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120729,7 +119065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120765,7 +119100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120801,7 +119135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120837,7 +119170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120873,7 +119205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120909,7 +119240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120945,7 +119275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120981,7 +119310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121017,7 +119345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121053,7 +119380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121089,7 +119415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121125,7 +119450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121161,7 +119485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121197,7 +119520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121233,7 +119555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121269,7 +119590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121305,7 +119625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121341,7 +119660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121377,7 +119695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121413,7 +119730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121449,7 +119765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121485,7 +119800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121521,7 +119835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121557,7 +119870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121593,7 +119905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121629,7 +119940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121665,7 +119975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121701,7 +120010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121737,7 +120045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121773,7 +120080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121809,7 +120115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121845,7 +120150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121881,7 +120185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121917,7 +120220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121953,7 +120255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121989,7 +120290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122025,7 +120325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122061,7 +120360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122097,7 +120395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122133,7 +120430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122169,7 +120465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122205,7 +120500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122241,7 +120535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122277,7 +120570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122313,7 +120605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122349,7 +120640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122385,7 +120675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122421,7 +120710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122457,7 +120745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122493,7 +120780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122529,7 +120815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122565,7 +120850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122601,7 +120885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122637,7 +120920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122673,7 +120955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122709,7 +120990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122745,7 +121025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122781,7 +121060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122817,7 +121095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122853,7 +121130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122889,7 +121165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122925,7 +121200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122961,7 +121235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122997,7 +121270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123033,7 +121305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123069,7 +121340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123105,7 +121375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123141,7 +121410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123177,7 +121445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123213,7 +121480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123249,7 +121515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123285,7 +121550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123321,7 +121585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123357,7 +121620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123393,7 +121655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123429,7 +121690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123465,7 +121725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123501,7 +121760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123537,7 +121795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123573,7 +121830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123609,7 +121865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123645,7 +121900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123681,7 +121935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123717,7 +121970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123753,7 +122005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123789,7 +122040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123825,7 +122075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123861,7 +122110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123897,7 +122145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123933,7 +122180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123969,7 +122215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124005,7 +122250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124041,7 +122285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124077,7 +122320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124113,7 +122355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124149,7 +122390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124185,7 +122425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124221,7 +122460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124257,7 +122495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124293,7 +122530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124329,7 +122565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124365,7 +122600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124401,7 +122635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124437,7 +122670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124473,7 +122705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124509,7 +122740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124545,7 +122775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124581,7 +122810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124617,7 +122845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124653,7 +122880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124689,7 +122915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124725,7 +122950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124761,7 +122985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124797,7 +123020,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124833,7 +123055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124869,7 +123090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124905,7 +123125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124941,7 +123160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124977,7 +123195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125013,7 +123230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125049,7 +123265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125085,7 +123300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125121,7 +123335,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125157,7 +123370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125193,7 +123405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125229,7 +123440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125265,7 +123475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125301,7 +123510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125337,7 +123545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125373,7 +123580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125409,7 +123615,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125445,7 +123650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125481,7 +123685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125517,7 +123720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125553,7 +123755,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125589,7 +123790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125625,7 +123825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125661,7 +123860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125697,7 +123895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125733,7 +123930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125769,7 +123965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125805,7 +124000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125841,7 +124035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125877,7 +124070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125913,7 +124105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125949,7 +124140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125985,7 +124175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126021,7 +124210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126057,7 +124245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126093,7 +124280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126129,7 +124315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126165,7 +124350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126201,7 +124385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126237,7 +124420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126273,7 +124455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126309,7 +124490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126345,7 +124525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126381,7 +124560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126417,7 +124595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126453,7 +124630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126489,7 +124665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126525,7 +124700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126561,7 +124735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126597,7 +124770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126633,7 +124805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126669,7 +124840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126705,7 +124875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126741,7 +124910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126777,7 +124945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126813,7 +124980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126849,7 +125015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126885,7 +125050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126921,7 +125085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126957,7 +125120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126993,7 +125155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127029,7 +125190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127065,7 +125225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127101,7 +125260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127137,7 +125295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127173,7 +125330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127209,7 +125365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127245,7 +125400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127281,7 +125435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127317,7 +125470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127353,7 +125505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127389,7 +125540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127425,7 +125575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127461,7 +125610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127497,7 +125645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127533,7 +125680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127569,7 +125715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127605,7 +125750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127641,7 +125785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",

--- a/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-02.json.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-02.json.sarif
@@ -279,7 +279,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -475,7 +474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -511,7 +509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -547,7 +544,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -643,7 +639,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -780,7 +775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -817,7 +811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -854,7 +847,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -931,7 +923,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1127,7 +1118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1163,7 +1153,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1199,7 +1188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1295,7 +1283,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1432,7 +1419,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1469,7 +1455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1506,7 +1491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1583,7 +1567,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1620,7 +1603,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1657,7 +1639,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1694,7 +1675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1731,7 +1711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1768,7 +1747,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1805,7 +1783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1842,7 +1819,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1879,7 +1855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1936,7 +1911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1991,7 +1965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2028,7 +2001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2085,7 +2057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2121,7 +2092,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2157,7 +2127,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2193,7 +2162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2230,7 +2198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2267,7 +2234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2344,7 +2310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2441,7 +2406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2477,7 +2441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2513,7 +2476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2670,7 +2632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2707,7 +2668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2744,7 +2704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2941,7 +2900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2978,7 +2936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3135,7 +3092,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3271,7 +3227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3307,7 +3262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3343,7 +3297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3500,7 +3453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3537,7 +3489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3574,7 +3525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3611,7 +3561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3848,7 +3797,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3885,7 +3833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3942,7 +3889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -4038,7 +3984,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4074,7 +4019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4110,7 +4054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4267,7 +4210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4304,7 +4246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4341,7 +4282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4378,7 +4318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4595,7 +4534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4632,7 +4570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4789,7 +4726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -4885,7 +4821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -4921,7 +4856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -4958,7 +4892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -5035,7 +4968,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -5131,7 +5063,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5167,7 +5098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5244,7 +5174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -5340,7 +5269,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5376,7 +5304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5453,7 +5380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -5529,7 +5455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -5565,7 +5490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -5702,7 +5626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5738,7 +5661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5815,7 +5737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -5931,7 +5852,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5967,7 +5887,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6124,7 +6043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6161,7 +6079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6198,7 +6115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6235,7 +6151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6472,7 +6387,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6509,7 +6423,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6566,7 +6479,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -6662,7 +6574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6698,7 +6609,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6775,7 +6685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -6871,7 +6780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -6907,7 +6815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -6984,7 +6891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -7120,7 +7026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7156,7 +7061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7192,7 +7096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7349,7 +7252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7386,7 +7288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7423,7 +7324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7460,7 +7360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7697,7 +7596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7734,7 +7632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7791,7 +7688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -7887,7 +7783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -7923,7 +7818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -8000,7 +7894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -8096,7 +7989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8132,7 +8024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8209,7 +8100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -8305,7 +8195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8341,7 +8230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8418,7 +8306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -8514,7 +8401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8550,7 +8436,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8627,7 +8512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -8723,7 +8607,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8759,7 +8642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8836,7 +8718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -8932,7 +8813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -8968,7 +8848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -9045,7 +8924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -9141,7 +9019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9177,7 +9054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9254,7 +9130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -9290,7 +9165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9386,7 +9260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9422,7 +9295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9499,7 +9371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -9595,7 +9466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9631,7 +9501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9708,7 +9577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -9804,7 +9672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -9840,7 +9707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -9917,7 +9783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -10053,7 +9918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10089,7 +9953,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10125,7 +9988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10282,7 +10144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10319,7 +10180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10356,7 +10216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10393,7 +10252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10630,7 +10488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10667,7 +10524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10724,7 +10580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -10820,7 +10675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -10856,7 +10710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -10933,7 +10786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -11069,7 +10921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11105,7 +10956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11141,7 +10991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11298,7 +11147,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11335,7 +11183,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11372,7 +11219,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11409,7 +11255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11646,7 +11491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11683,7 +11527,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11740,7 +11583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -11836,7 +11678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -11872,7 +11713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -11949,7 +11789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -12045,7 +11884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12081,7 +11919,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12198,7 +12035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12235,7 +12071,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12272,7 +12107,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12429,7 +12263,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12466,7 +12299,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12523,7 +12355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -12619,7 +12450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12655,7 +12485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12732,7 +12561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -12828,7 +12656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -12864,7 +12691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -12941,7 +12767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -13037,7 +12862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13073,7 +12897,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13150,7 +12973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -13246,7 +13068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13282,7 +13103,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13399,7 +13219,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13436,7 +13255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13473,7 +13291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13630,7 +13447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13667,7 +13483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13724,7 +13539,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -13820,7 +13634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -13856,7 +13669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -13973,7 +13785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14010,7 +13821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14047,7 +13857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14204,7 +14013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14241,7 +14049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14298,7 +14105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -14434,7 +14240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14470,7 +14275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14506,7 +14310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14663,7 +14466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14700,7 +14502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14737,7 +14538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14774,7 +14574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14891,7 +14690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -14948,7 +14746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -15044,7 +14841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15080,7 +14876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15157,7 +14952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -15253,7 +15047,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15289,7 +15082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15366,7 +15158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -15462,7 +15253,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15498,7 +15288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15534,7 +15323,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15691,7 +15479,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15728,7 +15515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15765,7 +15551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15802,7 +15587,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16019,7 +15803,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16056,7 +15839,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16213,7 +15995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -16349,7 +16130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16385,7 +16165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16421,7 +16200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16578,7 +16356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16615,7 +16392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16652,7 +16428,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16689,7 +16464,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16926,7 +16700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -16963,7 +16736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -17020,7 +16792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -17116,7 +16887,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17152,7 +16922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17269,7 +17038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17306,7 +17074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17343,7 +17110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17500,7 +17266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17537,7 +17302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17594,7 +17358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -17690,7 +17453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17726,7 +17488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17843,7 +17604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17880,7 +17640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -17917,7 +17676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18074,7 +17832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18111,7 +17868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18168,7 +17924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -18264,7 +18019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18300,7 +18054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18417,7 +18170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18454,7 +18206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18491,7 +18242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18648,7 +18398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18685,7 +18434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18742,7 +18490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -18838,7 +18585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -18874,7 +18620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -18991,7 +18736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19028,7 +18772,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19065,7 +18808,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19222,7 +18964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19259,7 +19000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19316,7 +19056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -19452,7 +19191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19488,7 +19226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19524,7 +19261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19681,7 +19417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19718,7 +19453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19755,7 +19489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19792,7 +19525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19909,7 +19641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -19966,7 +19697,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -20062,7 +19792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20098,7 +19827,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20175,7 +19903,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -20311,7 +20038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20347,7 +20073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20383,7 +20108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20540,7 +20264,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20577,7 +20300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20614,7 +20336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20651,7 +20372,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20888,7 +20608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20925,7 +20644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -20982,7 +20700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -21078,7 +20795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21114,7 +20830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21231,7 +20946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21268,7 +20982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21305,7 +21018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21462,7 +21174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21499,7 +21210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21556,7 +21266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -21652,7 +21361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21688,7 +21396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21724,7 +21431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21881,7 +21587,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21918,7 +21623,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21955,7 +21659,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21992,7 +21695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22209,7 +21911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22246,7 +21947,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22403,7 +22103,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -22499,7 +22198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22535,7 +22233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22612,7 +22309,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -22708,7 +22404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22744,7 +22439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22821,7 +22515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -22917,7 +22610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22953,7 +22645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22989,7 +22680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23146,7 +22836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23183,7 +22872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23220,7 +22908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23257,7 +22944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23474,7 +23160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23511,7 +23196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23568,7 +23252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -23664,7 +23347,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23700,7 +23382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23777,7 +23458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -23873,7 +23553,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -23909,7 +23588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -23986,7 +23664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -24082,7 +23759,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24118,7 +23794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24195,7 +23870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -24291,7 +23965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24327,7 +24000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24404,7 +24076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -24540,7 +24211,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24576,7 +24246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24612,7 +24281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24769,7 +24437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24806,7 +24473,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24843,7 +24509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -24880,7 +24545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25117,7 +24781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25154,7 +24817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25211,7 +24873,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -25307,7 +24968,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25343,7 +25003,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25420,7 +25079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -25536,7 +25194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25572,7 +25229,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25669,7 +25325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -25765,7 +25420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25801,7 +25455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25878,7 +25531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -25974,7 +25626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26010,7 +25661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26087,7 +25737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -26183,7 +25832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26219,7 +25867,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26296,7 +25943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -26392,7 +26038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26428,7 +26073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26545,7 +26189,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26582,7 +26225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26619,7 +26261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26776,7 +26417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26813,7 +26453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26870,7 +26509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -26925,7 +26563,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -26981,7 +26618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -27018,7 +26654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -27055,7 +26690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27101,7 +26735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27138,7 +26771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27175,7 +26807,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -27211,7 +26842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -27248,7 +26878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -27305,7 +26934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -27362,7 +26990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -27399,7 +27026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -27475,7 +27101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -27532,7 +27157,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27608,7 +27232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27665,7 +27288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27722,7 +27344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27759,7 +27380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27796,7 +27416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27833,7 +27452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -27890,7 +27508,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -27947,7 +27564,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -27984,7 +27600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28060,7 +27675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28117,7 +27731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -28154,7 +27767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28210,7 +27822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28247,7 +27858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28284,7 +27894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -28321,7 +27930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -29297,7 +28905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29334,7 +28941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29371,7 +28977,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29408,7 +29013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29445,7 +29049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29482,7 +29085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -29519,7 +29121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30036,7 +29637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30072,7 +29672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30108,7 +29707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30144,7 +29742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30500,7 +30097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -30977,7 +30573,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31013,7 +30608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31049,7 +30643,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31085,7 +30678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31121,7 +30713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31157,7 +30748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31193,7 +30783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31229,7 +30818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/chai.d.ts",
@@ -31285,7 +30873,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31762,7 +31349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31798,7 +31384,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31834,7 +31419,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31870,7 +31454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31906,7 +31489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31942,7 +31524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -31978,7 +31559,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32014,7 +31594,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32050,7 +31629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32086,7 +31664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32122,7 +31699,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32158,7 +31734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32194,7 +31769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32230,7 +31804,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32266,7 +31839,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32302,7 +31874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32338,7 +31909,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32374,7 +31944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32410,7 +31979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32446,7 +32014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32482,7 +32049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32518,7 +32084,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32554,7 +32119,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32610,7 +32174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -32647,7 +32210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/mocha.d.ts",
@@ -33024,7 +32586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33060,7 +32621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33096,7 +32656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33132,7 +32691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -35693,7 +35251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37909,7 +37466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37945,7 +37501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -37981,7 +37536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38017,7 +37571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38053,7 +37606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38089,7 +37641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38125,7 +37676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38161,7 +37711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38197,7 +37746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38233,7 +37781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38269,7 +37816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38305,7 +37851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38341,7 +37886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38377,7 +37921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38413,7 +37956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38449,7 +37991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38485,7 +38026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38521,7 +38061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38557,7 +38096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38593,7 +38131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38629,7 +38166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38665,7 +38201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38701,7 +38236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38737,7 +38271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38773,7 +38306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38809,7 +38341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38845,7 +38376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38881,7 +38411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38917,7 +38446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38953,7 +38481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -38989,7 +38516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39025,7 +38551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39061,7 +38586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39097,7 +38621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39133,7 +38656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39169,7 +38691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39205,7 +38726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39241,7 +38761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39277,7 +38796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39313,7 +38831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39349,7 +38866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39385,7 +38901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39421,7 +38936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39457,7 +38971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39493,7 +39006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39529,7 +39041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39565,7 +39076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39601,7 +39111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39637,7 +39146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39673,7 +39181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39709,7 +39216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39745,7 +39251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39781,7 +39286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39817,7 +39321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39853,7 +39356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39889,7 +39391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39925,7 +39426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39961,7 +39461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -39997,7 +39496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40033,7 +39531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40069,7 +39566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40105,7 +39601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40141,7 +39636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40177,7 +39671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40213,7 +39706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40249,7 +39741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40285,7 +39776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40321,7 +39811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40357,7 +39846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40393,7 +39881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40429,7 +39916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40465,7 +39951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40501,7 +39986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40537,7 +40021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40573,7 +40056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40609,7 +40091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40645,7 +40126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40681,7 +40161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40717,7 +40196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40753,7 +40231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40789,7 +40266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40825,7 +40301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40861,7 +40336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40897,7 +40371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40933,7 +40406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -40969,7 +40441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -41005,7 +40476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -42041,7 +41511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -42318,7 +41787,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -42355,7 +41823,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43432,7 +42899,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43469,7 +42935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43506,7 +42971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43543,7 +43007,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43580,7 +43043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43616,7 +43078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43652,7 +43113,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43689,7 +43149,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43726,7 +43185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -43763,7 +43221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -45980,7 +45437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46016,7 +45472,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46052,7 +45507,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46088,7 +45542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46124,7 +45577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46160,7 +45612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46196,7 +45647,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46232,7 +45682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46268,7 +45717,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46304,7 +45752,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46340,7 +45787,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46376,7 +45822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46412,7 +45857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46448,7 +45892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46484,7 +45927,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46520,7 +45962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46556,7 +45997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46592,7 +46032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46628,7 +46067,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46664,7 +46102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46700,7 +46137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46736,7 +46172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46772,7 +46207,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46808,7 +46242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46844,7 +46277,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46880,7 +46312,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46916,7 +46347,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46952,7 +46382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -46988,7 +46417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47024,7 +46452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47060,7 +46487,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47096,7 +46522,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47132,7 +46557,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47168,7 +46592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47204,7 +46627,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47240,7 +46662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47276,7 +46697,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47313,7 +46733,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47350,7 +46769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47387,7 +46805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47424,7 +46841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47461,7 +46877,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47498,7 +46913,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47535,7 +46949,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47572,7 +46985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47609,7 +47021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47646,7 +47057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47683,7 +47093,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47720,7 +47129,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47757,7 +47165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47794,7 +47201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47831,7 +47237,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47868,7 +47273,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47905,7 +47309,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47942,7 +47345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -47979,7 +47381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48016,7 +47417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48053,7 +47453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48090,7 +47489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48127,7 +47525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48164,7 +47561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48201,7 +47597,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48238,7 +47633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48275,7 +47669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48312,7 +47705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48349,7 +47741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48386,7 +47777,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48423,7 +47813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48460,7 +47849,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48497,7 +47885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48534,7 +47921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -48571,7 +47957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48612,7 +47997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48649,7 +48033,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48686,7 +48069,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48723,7 +48105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48760,7 +48141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48797,7 +48177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -48834,7 +48213,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53350,7 +52728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53386,7 +52763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53422,7 +52798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53458,7 +52833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53494,7 +52868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53530,7 +52903,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53566,7 +52938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -53602,7 +52973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -54538,7 +53908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -54594,7 +53963,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/require.d.ts",
@@ -60411,7 +59779,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/require.d.ts",
@@ -60568,7 +59935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60610,7 +59976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60652,7 +60017,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60693,7 +60057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60734,7 +60097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60775,7 +60137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60816,7 +60177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60857,7 +60217,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60898,7 +60257,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60939,7 +60297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60980,7 +60337,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61021,7 +60377,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61063,7 +60418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61105,7 +60459,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61147,7 +60500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62189,7 +61541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62226,7 +61577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62263,7 +61613,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62300,7 +61649,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62337,7 +61685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62374,7 +61721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62411,7 +61757,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62448,7 +61793,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62485,7 +61829,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62522,7 +61865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62559,7 +61901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62596,7 +61937,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62633,7 +61973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62670,7 +62009,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62707,7 +62045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62744,7 +62081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62781,7 +62117,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62818,7 +62153,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62855,7 +62189,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62892,7 +62225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62929,7 +62261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62966,7 +62297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63003,7 +62333,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63040,7 +62369,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63077,7 +62405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63114,7 +62441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63151,7 +62477,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63188,7 +62513,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63225,7 +62549,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63262,7 +62585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63299,7 +62621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63336,7 +62657,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63373,7 +62693,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63410,7 +62729,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63447,7 +62765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63484,7 +62801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63521,7 +62837,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63558,7 +62873,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63595,7 +62909,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63632,7 +62945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63669,7 +62981,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63706,7 +63017,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63743,7 +63053,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63780,7 +63089,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63817,7 +63125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63854,7 +63161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63891,7 +63197,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63928,7 +63233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63965,7 +63269,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64002,7 +63305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64039,7 +63341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64076,7 +63377,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64113,7 +63413,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64150,7 +63449,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64187,7 +63485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64224,7 +63521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64261,7 +63557,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64298,7 +63593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64335,7 +63629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64372,7 +63665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64409,7 +63701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64446,7 +63737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64483,7 +63773,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64520,7 +63809,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64557,7 +63845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64594,7 +63881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64631,7 +63917,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64668,7 +63953,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64705,7 +63989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64742,7 +64025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64779,7 +64061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64816,7 +64097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64853,7 +64133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64890,7 +64169,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64927,7 +64205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64964,7 +64241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65001,7 +64277,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65038,7 +64313,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65075,7 +64349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65112,7 +64385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65149,7 +64421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65186,7 +64457,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65223,7 +64493,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65260,7 +64529,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65297,7 +64565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65334,7 +64601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65371,7 +64637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65408,7 +64673,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65445,7 +64709,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65482,7 +64745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65519,7 +64781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65556,7 +64817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65593,7 +64853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65630,7 +64889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65667,7 +64925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65704,7 +64961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65741,7 +64997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65778,7 +65033,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65815,7 +65069,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65852,7 +65105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65889,7 +65141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65926,7 +65177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65963,7 +65213,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66000,7 +65249,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66037,7 +65285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66074,7 +65321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66111,7 +65357,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66148,7 +65393,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66185,7 +65429,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66222,7 +65465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66259,7 +65501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66296,7 +65537,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66333,7 +65573,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66370,7 +65609,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66407,7 +65645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66444,7 +65681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66481,7 +65717,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66518,7 +65753,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66555,7 +65789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66592,7 +65825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66629,7 +65861,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66666,7 +65897,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66703,7 +65933,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66740,7 +65969,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66777,7 +66005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66814,7 +66041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66851,7 +66077,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66888,7 +66113,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66925,7 +66149,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66962,7 +66185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66999,7 +66221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67036,7 +66257,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67073,7 +66293,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67110,7 +66329,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67147,7 +66365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67184,7 +66401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67221,7 +66437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67258,7 +66473,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67295,7 +66509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67332,7 +66545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67369,7 +66581,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67406,7 +66617,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67443,7 +66653,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67480,7 +66689,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67517,7 +66725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67554,7 +66761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67591,7 +66797,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67628,7 +66833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67665,7 +66869,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67702,7 +66905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67739,7 +66941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67776,7 +66977,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67813,7 +67013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67850,7 +67049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67887,7 +67085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67924,7 +67121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67961,7 +67157,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67998,7 +67193,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68035,7 +67229,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68072,7 +67265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68109,7 +67301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68146,7 +67337,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68183,7 +67373,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68220,7 +67409,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68257,7 +67445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68294,7 +67481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68331,7 +67517,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68368,7 +67553,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68405,7 +67589,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68442,7 +67625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68479,7 +67661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68516,7 +67697,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68553,7 +67733,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68590,7 +67769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68627,7 +67805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68664,7 +67841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68701,7 +67877,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68738,7 +67913,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68775,7 +67949,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68812,7 +67985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68849,7 +68021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68886,7 +68057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68923,7 +68093,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68960,7 +68129,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68997,7 +68165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69034,7 +68201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69071,7 +68237,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69108,7 +68273,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69145,7 +68309,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69182,7 +68345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69219,7 +68381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69256,7 +68417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69293,7 +68453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69330,7 +68489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69367,7 +68525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69404,7 +68561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69441,7 +68597,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69478,7 +68633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69515,7 +68669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69552,7 +68705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69589,7 +68741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69626,7 +68777,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69663,7 +68813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69700,7 +68849,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69737,7 +68885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69774,7 +68921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69811,7 +68957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69848,7 +68993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69885,7 +69029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69922,7 +69065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69959,7 +69101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69996,7 +69137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70033,7 +69173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70070,7 +69209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70107,7 +69245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70144,7 +69281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70181,7 +69317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70218,7 +69353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70255,7 +69389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70292,7 +69425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70329,7 +69461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70366,7 +69497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70403,7 +69533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70440,7 +69569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70477,7 +69605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70514,7 +69641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70551,7 +69677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70588,7 +69713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70625,7 +69749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70662,7 +69785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70699,7 +69821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70736,7 +69857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70773,7 +69893,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70810,7 +69929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70847,7 +69965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70884,7 +70001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70921,7 +70037,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70958,7 +70073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70995,7 +70109,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71032,7 +70145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71069,7 +70181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71106,7 +70217,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71143,7 +70253,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71180,7 +70289,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71217,7 +70325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71254,7 +70361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71291,7 +70397,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71328,7 +70433,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71365,7 +70469,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71402,7 +70505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71439,7 +70541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71476,7 +70577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71513,7 +70613,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71550,7 +70649,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71587,7 +70685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71624,7 +70721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71661,7 +70757,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71698,7 +70793,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71735,7 +70829,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71772,7 +70865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71809,7 +70901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71846,7 +70937,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71883,7 +70973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71920,7 +71009,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71957,7 +71045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71994,7 +71081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72031,7 +71117,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72068,7 +71153,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72105,7 +71189,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72142,7 +71225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72179,7 +71261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72216,7 +71297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72253,7 +71333,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72290,7 +71369,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72327,7 +71405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72364,7 +71441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72401,7 +71477,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72438,7 +71513,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72475,7 +71549,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72512,7 +71585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72549,7 +71621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72586,7 +71657,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72623,7 +71693,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72660,7 +71729,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72697,7 +71765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72734,7 +71801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72771,7 +71837,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72808,7 +71873,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72845,7 +71909,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72882,7 +71945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72919,7 +71981,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72956,7 +72017,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72993,7 +72053,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73030,7 +72089,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73067,7 +72125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73104,7 +72161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73141,7 +72197,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73178,7 +72233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73215,7 +72269,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73252,7 +72305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73289,7 +72341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73326,7 +72377,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73363,7 +72413,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73400,7 +72449,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73437,7 +72485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73474,7 +72521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73511,7 +72557,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73548,7 +72593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73585,7 +72629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73622,7 +72665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73659,7 +72701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73696,7 +72737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73733,7 +72773,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73770,7 +72809,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73807,7 +72845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73844,7 +72881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73881,7 +72917,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73918,7 +72953,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73955,7 +72989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73992,7 +73025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74029,7 +73061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74066,7 +73097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74103,7 +73133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74140,7 +73169,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74177,7 +73205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74214,7 +73241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74251,7 +73277,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74288,7 +73313,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74325,7 +73349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74362,7 +73385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74399,7 +73421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74436,7 +73457,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74473,7 +73493,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74510,7 +73529,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74547,7 +73565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74584,7 +73601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74621,7 +73637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74658,7 +73673,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74695,7 +73709,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74732,7 +73745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74769,7 +73781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74806,7 +73817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74843,7 +73853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74880,7 +73889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74917,7 +73925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74954,7 +73961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -74991,7 +73997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75028,7 +74033,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75065,7 +74069,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75102,7 +74105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75139,7 +74141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75176,7 +74177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75213,7 +74213,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75250,7 +74249,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75287,7 +74285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75324,7 +74321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75361,7 +74357,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75398,7 +74393,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75435,7 +74429,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75472,7 +74465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75509,7 +74501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75546,7 +74537,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75583,7 +74573,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75620,7 +74609,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75657,7 +74645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75694,7 +74681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75731,7 +74717,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75768,7 +74753,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75805,7 +74789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75842,7 +74825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75879,7 +74861,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75916,7 +74897,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75953,7 +74933,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -75990,7 +74969,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76027,7 +75005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76064,7 +75041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76101,7 +75077,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76138,7 +75113,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76175,7 +75149,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76212,7 +75185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76249,7 +75221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76286,7 +75257,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76323,7 +75293,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76360,7 +75329,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76397,7 +75365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76434,7 +75401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76471,7 +75437,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76508,7 +75473,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76545,7 +75509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76582,7 +75545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76619,7 +75581,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76656,7 +75617,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76693,7 +75653,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76730,7 +75689,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76767,7 +75725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76804,7 +75761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76841,7 +75797,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76878,7 +75833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76915,7 +75869,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76952,7 +75905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -76989,7 +75941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77026,7 +75977,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77063,7 +76013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77100,7 +76049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77137,7 +76085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77174,7 +76121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77211,7 +76157,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77248,7 +76193,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77285,7 +76229,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77322,7 +76265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77359,7 +76301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77396,7 +76337,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77433,7 +76373,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77470,7 +76409,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77507,7 +76445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77544,7 +76481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77581,7 +76517,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77618,7 +76553,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77655,7 +76589,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77692,7 +76625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77729,7 +76661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77766,7 +76697,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77803,7 +76733,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77840,7 +76769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77877,7 +76805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77914,7 +76841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77951,7 +76877,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -77988,7 +76913,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78025,7 +76949,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78062,7 +76985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78099,7 +77021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78136,7 +77057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78173,7 +77093,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78210,7 +77129,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78247,7 +77165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78284,7 +77201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78321,7 +77237,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78358,7 +77273,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78395,7 +77309,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78432,7 +77345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78469,7 +77381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78506,7 +77417,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78543,7 +77453,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78580,7 +77489,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78617,7 +77525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78654,7 +77561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78691,7 +77597,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78728,7 +77633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78765,7 +77669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78802,7 +77705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78839,7 +77741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78876,7 +77777,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78913,7 +77813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78950,7 +77849,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -78987,7 +77885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79024,7 +77921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79061,7 +77957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79098,7 +77993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79135,7 +78029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79172,7 +78065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79209,7 +78101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79246,7 +78137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79283,7 +78173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79320,7 +78209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79357,7 +78245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79394,7 +78281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79431,7 +78317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79468,7 +78353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79505,7 +78389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79542,7 +78425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79579,7 +78461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79616,7 +78497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79653,7 +78533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79690,7 +78569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79727,7 +78605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79764,7 +78641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79801,7 +78677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79838,7 +78713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79875,7 +78749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79912,7 +78785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79949,7 +78821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -79986,7 +78857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80023,7 +78893,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80060,7 +78929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80097,7 +78965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80134,7 +79001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80171,7 +79037,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80208,7 +79073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80245,7 +79109,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80282,7 +79145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80319,7 +79181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80356,7 +79217,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80393,7 +79253,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80430,7 +79289,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80467,7 +79325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80504,7 +79361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80541,7 +79397,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80578,7 +79433,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -80675,7 +79529,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101051,7 +99904,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101108,7 +99960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101565,7 +100416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101601,7 +100451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101637,7 +100486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101673,7 +100521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101709,7 +100556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101745,7 +100591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101781,7 +100626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101817,7 +100661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101853,7 +100696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101889,7 +100731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101925,7 +100766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101961,7 +100801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -101997,7 +100836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102033,7 +100871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102069,7 +100906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102105,7 +100941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102141,7 +100976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102177,7 +101011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102213,7 +101046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102249,7 +101081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102285,7 +101116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102321,7 +101151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102357,7 +101186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102393,7 +101221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102429,7 +101256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102465,7 +101291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102501,7 +101326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102537,7 +101361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102573,7 +101396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102609,7 +101431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102645,7 +101466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102681,7 +101501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102717,7 +101536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102753,7 +101571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102789,7 +101606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102825,7 +101641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102861,7 +101676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102897,7 +101711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102933,7 +101746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -102969,7 +101781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103005,7 +101816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103041,7 +101851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103077,7 +101886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103113,7 +101921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103149,7 +101956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103185,7 +101991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103221,7 +102026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103257,7 +102061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103293,7 +102096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103329,7 +102131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103365,7 +102166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103401,7 +102201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103437,7 +102236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103473,7 +102271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103509,7 +102306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103545,7 +102341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103581,7 +102376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103617,7 +102411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103653,7 +102446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103689,7 +102481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103725,7 +102516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103761,7 +102551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103797,7 +102586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103833,7 +102621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103869,7 +102656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103905,7 +102691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103941,7 +102726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -103977,7 +102761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104013,7 +102796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104049,7 +102831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104085,7 +102866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104121,7 +102901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104157,7 +102936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104193,7 +102971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104229,7 +103006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104265,7 +103041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104301,7 +103076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104337,7 +103111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104373,7 +103146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104409,7 +103181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104445,7 +103216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104481,7 +103251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104517,7 +103286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104553,7 +103321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104589,7 +103356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104625,7 +103391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104661,7 +103426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104697,7 +103461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104733,7 +103496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104769,7 +103531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104805,7 +103566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104841,7 +103601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104877,7 +103636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104913,7 +103671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104949,7 +103706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -104985,7 +103741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105021,7 +103776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105057,7 +103811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105093,7 +103846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105129,7 +103881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105165,7 +103916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105201,7 +103951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105237,7 +103986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105273,7 +104021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105309,7 +104056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105345,7 +104091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105381,7 +104126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105417,7 +104161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105453,7 +104196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105489,7 +104231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105525,7 +104266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105561,7 +104301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105597,7 +104336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105633,7 +104371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105669,7 +104406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105705,7 +104441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105741,7 +104476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105777,7 +104511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105813,7 +104546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105849,7 +104581,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105885,7 +104616,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105921,7 +104651,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105957,7 +104686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -105993,7 +104721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106029,7 +104756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106065,7 +104791,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106101,7 +104826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106137,7 +104861,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106173,7 +104896,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106209,7 +104931,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106245,7 +104966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106281,7 +105001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106317,7 +105036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106353,7 +105071,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106389,7 +105106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106425,7 +105141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106461,7 +105176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106497,7 +105211,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106533,7 +105246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106569,7 +105281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106605,7 +105316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106641,7 +105351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106677,7 +105386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106713,7 +105421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106749,7 +105456,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106785,7 +105491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106821,7 +105526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106857,7 +105561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106893,7 +105596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106929,7 +105631,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -106965,7 +105666,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107001,7 +105701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107037,7 +105736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107073,7 +105771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107109,7 +105806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107145,7 +105841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107181,7 +105876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107217,7 +105911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107253,7 +105946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107289,7 +105981,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107325,7 +106016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107361,7 +106051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107397,7 +106086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107433,7 +106121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107469,7 +106156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107505,7 +106191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107541,7 +106226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107577,7 +106261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107613,7 +106296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107649,7 +106331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107685,7 +106366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107721,7 +106401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107757,7 +106436,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107793,7 +106471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107829,7 +106506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107865,7 +106541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107901,7 +106576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107937,7 +106611,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -107973,7 +106646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108009,7 +106681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108045,7 +106716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108081,7 +106751,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108117,7 +106786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108153,7 +106821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108189,7 +106856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108225,7 +106891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108261,7 +106926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108297,7 +106961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108333,7 +106996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108369,7 +107031,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108405,7 +107066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108441,7 +107101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108477,7 +107136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108513,7 +107171,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108549,7 +107206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108585,7 +107241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108621,7 +107276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108657,7 +107311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108693,7 +107346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108729,7 +107381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108765,7 +107416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108801,7 +107451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108837,7 +107486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108873,7 +107521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108909,7 +107556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108945,7 +107591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -108981,7 +107626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109017,7 +107661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109053,7 +107696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109089,7 +107731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109125,7 +107766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109161,7 +107801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109197,7 +107836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109233,7 +107871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109269,7 +107906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109305,7 +107941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109341,7 +107976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109377,7 +108011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109413,7 +108046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109449,7 +108081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109485,7 +108116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109521,7 +108151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109557,7 +108186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109593,7 +108221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109629,7 +108256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109665,7 +108291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109701,7 +108326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109737,7 +108361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109773,7 +108396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109809,7 +108431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109845,7 +108466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109881,7 +108501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109917,7 +108536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109953,7 +108571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -109989,7 +108606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110025,7 +108641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110061,7 +108676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110097,7 +108711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110133,7 +108746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110169,7 +108781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110205,7 +108816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110241,7 +108851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110277,7 +108886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110313,7 +108921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110349,7 +108956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110385,7 +108991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110421,7 +109026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110457,7 +109061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110493,7 +109096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110529,7 +109131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110565,7 +109166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110601,7 +109201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110637,7 +109236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110673,7 +109271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110709,7 +109306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110745,7 +109341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110781,7 +109376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110817,7 +109411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110853,7 +109446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110889,7 +109481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110925,7 +109516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110961,7 +109551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -110997,7 +109586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111033,7 +109621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111069,7 +109656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111105,7 +109691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111141,7 +109726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111177,7 +109761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111213,7 +109796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111249,7 +109831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111285,7 +109866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111321,7 +109901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111357,7 +109936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111393,7 +109971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111429,7 +110006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111465,7 +110041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111501,7 +110076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111537,7 +110111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111573,7 +110146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111609,7 +110181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111645,7 +110216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111681,7 +110251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111717,7 +110286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111753,7 +110321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111789,7 +110356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111825,7 +110391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111861,7 +110426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111897,7 +110461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111933,7 +110496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -111969,7 +110531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112005,7 +110566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112041,7 +110601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112077,7 +110636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112113,7 +110671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112149,7 +110706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112185,7 +110741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112221,7 +110776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112257,7 +110811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112293,7 +110846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112329,7 +110881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112365,7 +110916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112401,7 +110951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112437,7 +110986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112473,7 +111021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112509,7 +111056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112545,7 +111091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112581,7 +111126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112617,7 +111161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112653,7 +111196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112689,7 +111231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112725,7 +111266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112761,7 +111301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112797,7 +111336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112833,7 +111371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112869,7 +111406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112905,7 +111441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112941,7 +111476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -112977,7 +111511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113013,7 +111546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113049,7 +111581,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113085,7 +111616,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113121,7 +111651,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113157,7 +111686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113193,7 +111721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113229,7 +111756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113265,7 +111791,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113301,7 +111826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113337,7 +111861,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113373,7 +111896,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113409,7 +111931,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113445,7 +111966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113481,7 +112001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113517,7 +112036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113553,7 +112071,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113589,7 +112106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113625,7 +112141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113661,7 +112176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113697,7 +112211,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113733,7 +112246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113769,7 +112281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113805,7 +112316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113841,7 +112351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113877,7 +112386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113913,7 +112421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113949,7 +112456,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -113985,7 +112491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114021,7 +112526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114057,7 +112561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114093,7 +112596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114129,7 +112631,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114165,7 +112666,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114201,7 +112701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114237,7 +112736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114273,7 +112771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114309,7 +112806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114345,7 +112841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114381,7 +112876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114417,7 +112911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114453,7 +112946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114489,7 +112981,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114525,7 +113016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114561,7 +113051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114597,7 +113086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114633,7 +113121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114669,7 +113156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114705,7 +113191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114741,7 +113226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114777,7 +113261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114813,7 +113296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114849,7 +113331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114885,7 +113366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114921,7 +113401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114957,7 +113436,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -114993,7 +113471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115029,7 +113506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115065,7 +113541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115101,7 +113576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115137,7 +113611,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115173,7 +113646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115209,7 +113681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115245,7 +113716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115281,7 +113751,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115317,7 +113786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115353,7 +113821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115389,7 +113856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115425,7 +113891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115461,7 +113926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115497,7 +113961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115533,7 +113996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115569,7 +114031,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115605,7 +114066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115641,7 +114101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115677,7 +114136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115713,7 +114171,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115749,7 +114206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115785,7 +114241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115821,7 +114276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115857,7 +114311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115893,7 +114346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115929,7 +114381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -115965,7 +114416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116001,7 +114451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116037,7 +114486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116073,7 +114521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116109,7 +114556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116145,7 +114591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116181,7 +114626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116217,7 +114661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116253,7 +114696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116289,7 +114731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116325,7 +114766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116361,7 +114801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116397,7 +114836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116433,7 +114871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116469,7 +114906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116505,7 +114941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116541,7 +114976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116577,7 +115011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116613,7 +115046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116649,7 +115081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116685,7 +115116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116721,7 +115151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116757,7 +115186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116793,7 +115221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116829,7 +115256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116865,7 +115291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116901,7 +115326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116937,7 +115361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -116973,7 +115396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117009,7 +115431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117045,7 +115466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117081,7 +115501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117117,7 +115536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117153,7 +115571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117189,7 +115606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117225,7 +115641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117261,7 +115676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117297,7 +115711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117333,7 +115746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117369,7 +115781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117405,7 +115816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117441,7 +115851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117477,7 +115886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117513,7 +115921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117549,7 +115956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117585,7 +115991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117621,7 +116026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117657,7 +116061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117693,7 +116096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117729,7 +116131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117765,7 +116166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117801,7 +116201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117837,7 +116236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117873,7 +116271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117909,7 +116306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117945,7 +116341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -117981,7 +116376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118017,7 +116411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118053,7 +116446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118089,7 +116481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118125,7 +116516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118161,7 +116551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118197,7 +116586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118233,7 +116621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118269,7 +116656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118305,7 +116691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118341,7 +116726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118377,7 +116761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118413,7 +116796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118449,7 +116831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118485,7 +116866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118521,7 +116901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118557,7 +116936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118593,7 +116971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118629,7 +117006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118665,7 +117041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118701,7 +117076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118737,7 +117111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118773,7 +117146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118809,7 +117181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118845,7 +117216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118881,7 +117251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118917,7 +117286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118953,7 +117321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -118989,7 +117356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119025,7 +117391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119061,7 +117426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119097,7 +117461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119133,7 +117496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119169,7 +117531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119205,7 +117566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119241,7 +117601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119277,7 +117636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119313,7 +117671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119349,7 +117706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119385,7 +117741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119421,7 +117776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119457,7 +117811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119493,7 +117846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -119529,7 +117881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120225,7 +118576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120261,7 +118611,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120297,7 +118646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120333,7 +118681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120369,7 +118716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120405,7 +118751,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120441,7 +118786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120477,7 +118821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120513,7 +118856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120549,7 +118891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120585,7 +118926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120621,7 +118961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120657,7 +118996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120693,7 +119031,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120729,7 +119066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120765,7 +119101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120801,7 +119136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120837,7 +119171,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120873,7 +119206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120909,7 +119241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120945,7 +119276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -120981,7 +119311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121017,7 +119346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121053,7 +119381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121089,7 +119416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121125,7 +119451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121161,7 +119486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121197,7 +119521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121233,7 +119556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121269,7 +119591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121305,7 +119626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121341,7 +119661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121377,7 +119696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121413,7 +119731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121449,7 +119766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121485,7 +119801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121521,7 +119836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121557,7 +119871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121593,7 +119906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121629,7 +119941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121665,7 +119976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121701,7 +120011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121737,7 +120046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121773,7 +120081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121809,7 +120116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121845,7 +120151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121881,7 +120186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121917,7 +120221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121953,7 +120256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -121989,7 +120291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122025,7 +120326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122061,7 +120361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122097,7 +120396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122133,7 +120431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122169,7 +120466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122205,7 +120501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122241,7 +120536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122277,7 +120571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122313,7 +120606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122349,7 +120641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122385,7 +120676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122421,7 +120711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122457,7 +120746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122493,7 +120781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122529,7 +120816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122565,7 +120851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122601,7 +120886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122637,7 +120921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122673,7 +120956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122709,7 +120991,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122745,7 +121026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122781,7 +121061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122817,7 +121096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122853,7 +121131,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122889,7 +121166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122925,7 +121201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122961,7 +121236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -122997,7 +121271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123033,7 +121306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123069,7 +121341,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123105,7 +121376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123141,7 +121411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123177,7 +121446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123213,7 +121481,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123249,7 +121516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123285,7 +121551,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123321,7 +121586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123357,7 +121621,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123393,7 +121656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123429,7 +121691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123465,7 +121726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123501,7 +121761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123537,7 +121796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123573,7 +121831,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123609,7 +121866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123645,7 +121901,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123681,7 +121936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123717,7 +121971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123753,7 +122006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123789,7 +122041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123825,7 +122076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123861,7 +122111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123897,7 +122146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123933,7 +122181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -123969,7 +122216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124005,7 +122251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124041,7 +122286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124077,7 +122321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124113,7 +122356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124149,7 +122391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124185,7 +122426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124221,7 +122461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124257,7 +122496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124293,7 +122531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124329,7 +122566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124365,7 +122601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124401,7 +122636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124437,7 +122671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124473,7 +122706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124509,7 +122741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124545,7 +122776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124581,7 +122811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124617,7 +122846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124653,7 +122881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124689,7 +122916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124725,7 +122951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124761,7 +122986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124797,7 +123021,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124833,7 +123056,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124869,7 +123091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124905,7 +123126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124941,7 +123161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -124977,7 +123196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125013,7 +123231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125049,7 +123266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125085,7 +123301,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125121,7 +123336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125157,7 +123371,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125193,7 +123406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125229,7 +123441,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125265,7 +123476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125301,7 +123511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125337,7 +123546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125373,7 +123581,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125409,7 +123616,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125445,7 +123651,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125481,7 +123686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125517,7 +123721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125553,7 +123756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125589,7 +123791,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125625,7 +123826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125661,7 +123861,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125697,7 +123896,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125733,7 +123931,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125769,7 +123966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125805,7 +124001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125841,7 +124036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125877,7 +124071,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125913,7 +124106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125949,7 +124141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -125985,7 +124176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126021,7 +124211,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126057,7 +124246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126093,7 +124281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126129,7 +124316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126165,7 +124351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126201,7 +124386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126237,7 +124421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126273,7 +124456,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126309,7 +124491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126345,7 +124526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126381,7 +124561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126417,7 +124596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126453,7 +124631,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126489,7 +124666,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126525,7 +124701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126561,7 +124736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126597,7 +124771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126633,7 +124806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126669,7 +124841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126705,7 +124876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126741,7 +124911,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126777,7 +124946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126813,7 +124981,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126849,7 +125016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126885,7 +125051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126921,7 +125086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126957,7 +125121,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -126993,7 +125156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127029,7 +125191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127065,7 +125226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127101,7 +125261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127137,7 +125296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127173,7 +125331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127209,7 +125366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127245,7 +125401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127281,7 +125436,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127317,7 +125471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127353,7 +125506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127389,7 +125541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127425,7 +125576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127461,7 +125611,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127497,7 +125646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127533,7 +125681,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127569,7 +125716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127605,7 +125751,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127641,7 +125786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127677,7 +125821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127713,7 +125856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127749,7 +125891,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127785,7 +125926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127821,7 +125961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127857,7 +125996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127893,7 +126031,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127929,7 +126066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -127965,7 +126101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128001,7 +126136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128037,7 +126171,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128073,7 +126206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128109,7 +126241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128145,7 +126276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128181,7 +126311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128217,7 +126346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128253,7 +126381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128289,7 +126416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128325,7 +126451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128361,7 +126486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128397,7 +126521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128433,7 +126556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128469,7 +126591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128505,7 +126626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128541,7 +126661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128577,7 +126696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128613,7 +126731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128649,7 +126766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128685,7 +126801,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128721,7 +126836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128757,7 +126871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128793,7 +126906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128829,7 +126941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128865,7 +126976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128901,7 +127011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128937,7 +127046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -128973,7 +127081,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129009,7 +127116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129045,7 +127151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129081,7 +127186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129117,7 +127221,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129153,7 +127256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129189,7 +127291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129225,7 +127326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129261,7 +127361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129297,7 +127396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129333,7 +127431,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129369,7 +127466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129405,7 +127501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129441,7 +127536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129477,7 +127571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129513,7 +127606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129549,7 +127641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129585,7 +127676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129621,7 +127711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129657,7 +127746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129693,7 +127781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129729,7 +127816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129765,7 +127851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129801,7 +127886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129837,7 +127921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -129873,7 +127956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",

--- a/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-03.json.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-03.json.sarif
@@ -579,7 +579,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -636,7 +635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -673,7 +671,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -710,7 +707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -747,7 +743,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/js/index.d.ts",
@@ -1104,7 +1099,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1161,7 +1155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1198,7 +1191,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1235,7 +1227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1272,7 +1263,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/index.d.ts",
@@ -1329,7 +1319,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1366,7 +1355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1403,7 +1391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1440,7 +1427,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1477,7 +1463,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1514,7 +1499,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1551,7 +1535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1687,7 +1670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1724,7 +1706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1781,7 +1762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1817,7 +1797,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1853,7 +1832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1889,7 +1867,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -1926,7 +1903,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2063,7 +2039,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2340,7 +2315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2377,7 +2351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2514,7 +2487,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -2690,7 +2662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2987,7 +2958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3024,7 +2994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3061,7 +3030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -3197,7 +3165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3494,7 +3461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3531,7 +3497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3668,7 +3633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3784,7 +3748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3821,7 +3784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3898,7 +3860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -4014,7 +3975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -4091,7 +4051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -4207,7 +4166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -4284,7 +4242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -4380,7 +4337,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -4537,7 +4493,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -4614,7 +4569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -4750,7 +4704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5047,7 +5000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5084,7 +5036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5121,7 +5072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5237,7 +5187,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -5314,7 +5263,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -5430,7 +5378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -5507,7 +5454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -5683,7 +5629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -5980,7 +5925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6017,7 +5961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6054,7 +5997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6170,7 +6112,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -6247,7 +6188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -6363,7 +6303,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -6440,7 +6379,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -6556,7 +6494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -6633,7 +6570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -6749,7 +6685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -6826,7 +6761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -6942,7 +6876,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -7019,7 +6952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -7135,7 +7067,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -7212,7 +7143,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -7328,7 +7258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -7405,7 +7334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -7541,7 +7469,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -7618,7 +7545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -7734,7 +7660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -7811,7 +7736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -7927,7 +7851,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -8004,7 +7927,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -8180,7 +8102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8477,7 +8398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8514,7 +8434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8551,7 +8470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8667,7 +8585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -8744,7 +8661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -8920,7 +8836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9217,7 +9132,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9254,7 +9168,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9291,7 +9204,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9407,7 +9319,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -9484,7 +9395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -9600,7 +9510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -9837,7 +9746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -9874,7 +9782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -9911,7 +9818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -10027,7 +9933,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -10104,7 +10009,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -10220,7 +10124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -10297,7 +10200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -10413,7 +10315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -10490,7 +10391,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -10606,7 +10506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -10843,7 +10742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -10880,7 +10778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -10917,7 +10814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -11033,7 +10929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -11270,7 +11165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -11307,7 +11201,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -11344,7 +11237,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -11520,7 +11412,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -11817,7 +11708,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -11854,7 +11744,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -11970,7 +11859,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -12047,7 +11935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -12163,7 +12050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -12240,7 +12126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -12376,7 +12261,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -12673,7 +12557,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -12710,7 +12593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -12847,7 +12729,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -13023,7 +12904,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -13320,7 +13200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -13357,7 +13236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -13394,7 +13272,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -13510,7 +13387,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -13747,7 +13623,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -13784,7 +13659,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -13821,7 +13695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -13937,7 +13810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -14174,7 +14046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -14211,7 +14082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -14248,7 +14118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -14364,7 +14233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -14601,7 +14469,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -14638,7 +14505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -14675,7 +14541,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -14791,7 +14656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -15028,7 +14892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -15065,7 +14928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -15102,7 +14964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -15278,7 +15139,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -15575,7 +15435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -15612,7 +15471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -15728,7 +15586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -15805,7 +15662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -15981,7 +15837,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -16278,7 +16133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -16315,7 +16169,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -16352,7 +16205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -16468,7 +16320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -16705,7 +16556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -16742,7 +16592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -16779,7 +16628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -16915,7 +16763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -17212,7 +17059,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -17249,7 +17095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -17386,7 +17231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -17502,7 +17346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -17579,7 +17422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -17695,7 +17537,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -17772,7 +17613,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -17908,7 +17748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -18205,7 +18044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -18242,7 +18080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -18279,7 +18116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -18395,7 +18231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -18472,7 +18307,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -18588,7 +18422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -18665,7 +18498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -18781,7 +18613,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -18858,7 +18689,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -18974,7 +18804,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -19051,7 +18880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -19227,7 +19055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -19524,7 +19351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -19561,7 +19387,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -19598,7 +19423,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -19714,7 +19538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -19791,7 +19614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -19927,7 +19749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -20024,7 +19845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -20140,7 +19960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -20217,7 +20036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -20333,7 +20151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -20410,7 +20227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -20526,7 +20342,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -20603,7 +20418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -20719,7 +20533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -20956,7 +20769,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -20993,7 +20805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -21030,7 +20841,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -21085,7 +20895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -21141,7 +20950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -21197,7 +21005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -21234,7 +21041,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -21290,7 +21096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -21327,7 +21132,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -21424,7 +21228,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -21621,7 +21424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -21658,7 +21460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -21815,7 +21616,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -22012,7 +21812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -24047,7 +23846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -24083,7 +23881,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -24119,7 +23916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29360,7 +29156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29477,7 +29272,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29514,7 +29308,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29551,7 +29344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29588,7 +29380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29625,7 +29416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29662,7 +29452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29699,7 +29488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29736,7 +29524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29773,7 +29560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29810,7 +29596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29847,7 +29632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29884,7 +29668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29921,7 +29704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29958,7 +29740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -29995,7 +29776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30032,7 +29812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30069,7 +29848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30106,7 +29884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30143,7 +29920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30180,7 +29956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30217,7 +29992,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30254,7 +30028,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30291,7 +30064,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30328,7 +30100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30365,7 +30136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30402,7 +30172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30439,7 +30208,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30476,7 +30244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30513,7 +30280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30550,7 +30316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30587,7 +30352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30624,7 +30388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30661,7 +30424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30698,7 +30460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30735,7 +30496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30772,7 +30532,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30809,7 +30568,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30846,7 +30604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30883,7 +30640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30920,7 +30676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30957,7 +30712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -30994,7 +30748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31031,7 +30784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31068,7 +30820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31105,7 +30856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31142,7 +30892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31179,7 +30928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31216,7 +30964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31253,7 +31000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31290,7 +31036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -31327,7 +31072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32004,7 +31748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32040,7 +31783,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32076,7 +31818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32112,7 +31853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32148,7 +31888,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32184,7 +31923,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32220,7 +31958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32256,7 +31993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32292,7 +32028,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32328,7 +32063,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32364,7 +32098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32400,7 +32133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32436,7 +32168,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32472,7 +32203,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32508,7 +32238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32544,7 +32273,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32580,7 +32308,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32616,7 +32343,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32652,7 +32378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32688,7 +32413,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32724,7 +32448,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32760,7 +32483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32796,7 +32518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32832,7 +32553,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32868,7 +32588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32904,7 +32623,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32940,7 +32658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -32976,7 +32693,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33012,7 +32728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33048,7 +32763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33084,7 +32798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33120,7 +32833,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33156,7 +32868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33192,7 +32903,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33228,7 +32938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33264,7 +32973,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/node.d.ts",
@@ -33300,7 +33008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -38661,7 +38368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -38698,7 +38404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -38735,7 +38440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -38772,7 +38476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -38809,7 +38512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/react.d.ts",
@@ -44325,7 +44027,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/require.d.ts",
@@ -44362,7 +44063,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44404,7 +44104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44446,7 +44145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44487,7 +44185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44528,7 +44225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44569,7 +44265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44610,7 +44305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44651,7 +44345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44692,7 +44385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44733,7 +44425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44774,7 +44465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44815,7 +44505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44857,7 +44546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44899,7 +44587,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -44941,7 +44628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55543,7 +55229,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55620,7 +55305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55656,7 +55340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55692,7 +55375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55728,7 +55410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55764,7 +55445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55800,7 +55480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55836,7 +55515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55872,7 +55550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55908,7 +55585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55944,7 +55620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -55980,7 +55655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56016,7 +55690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56052,7 +55725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56088,7 +55760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56124,7 +55795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56160,7 +55830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56196,7 +55865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56232,7 +55900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56268,7 +55935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56304,7 +55970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56340,7 +56005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56376,7 +56040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56412,7 +56075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56448,7 +56110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56484,7 +56145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56520,7 +56180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56556,7 +56215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56592,7 +56250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56628,7 +56285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56664,7 +56320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56700,7 +56355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56736,7 +56390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56772,7 +56425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56808,7 +56460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56844,7 +56495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56880,7 +56530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56916,7 +56565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56952,7 +56600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -56988,7 +56635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57024,7 +56670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57060,7 +56705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57096,7 +56740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57132,7 +56775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57168,7 +56810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57204,7 +56845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57240,7 +56880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57276,7 +56915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57312,7 +56950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57348,7 +56985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57384,7 +57020,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57420,7 +57055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57456,7 +57090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57492,7 +57125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57528,7 +57160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57564,7 +57195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57600,7 +57230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57636,7 +57265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57672,7 +57300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57708,7 +57335,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57744,7 +57370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57780,7 +57405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57816,7 +57440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57852,7 +57475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57888,7 +57510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57924,7 +57545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57960,7 +57580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -57996,7 +57615,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58032,7 +57650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58068,7 +57685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58104,7 +57720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58140,7 +57755,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58176,7 +57790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58212,7 +57825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58248,7 +57860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58284,7 +57895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58320,7 +57930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58356,7 +57965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58392,7 +58000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58428,7 +58035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58464,7 +58070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58500,7 +58105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58536,7 +58140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58572,7 +58175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58608,7 +58210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58644,7 +58245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58680,7 +58280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58716,7 +58315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58752,7 +58350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58788,7 +58385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58824,7 +58420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58860,7 +58455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58896,7 +58490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58932,7 +58525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -58968,7 +58560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59004,7 +58595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59040,7 +58630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59076,7 +58665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59112,7 +58700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59148,7 +58735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59184,7 +58770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59220,7 +58805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59256,7 +58840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59292,7 +58875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59328,7 +58910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59364,7 +58945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59400,7 +58980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59436,7 +59015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59472,7 +59050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59508,7 +59085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59544,7 +59120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59580,7 +59155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59616,7 +59190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59652,7 +59225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59688,7 +59260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59724,7 +59295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59760,7 +59330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59796,7 +59365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59832,7 +59400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59868,7 +59435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59904,7 +59470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59940,7 +59505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -59976,7 +59540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60012,7 +59575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60048,7 +59610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60084,7 +59645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60120,7 +59680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60156,7 +59715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60192,7 +59750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60228,7 +59785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60264,7 +59820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60300,7 +59855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60336,7 +59890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60372,7 +59925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60408,7 +59960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60444,7 +59995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60480,7 +60030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60516,7 +60065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60552,7 +60100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60588,7 +60135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60624,7 +60170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60660,7 +60205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60696,7 +60240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60732,7 +60275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60768,7 +60310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60804,7 +60345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60840,7 +60380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60876,7 +60415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60912,7 +60450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60948,7 +60485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -60984,7 +60520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61020,7 +60555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61056,7 +60590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61092,7 +60625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61128,7 +60660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61164,7 +60695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61200,7 +60730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61236,7 +60765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61272,7 +60800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61308,7 +60835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61344,7 +60870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61380,7 +60905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61416,7 +60940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61452,7 +60975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61488,7 +61010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61524,7 +61045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61560,7 +61080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61596,7 +61115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61632,7 +61150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61668,7 +61185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61704,7 +61220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61740,7 +61255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61776,7 +61290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61812,7 +61325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61848,7 +61360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61884,7 +61395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61920,7 +61430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61956,7 +61465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -61992,7 +61500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62028,7 +61535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62064,7 +61570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62100,7 +61605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62136,7 +61640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62172,7 +61675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62208,7 +61710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62244,7 +61745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62280,7 +61780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62316,7 +61815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62352,7 +61850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62388,7 +61885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62424,7 +61920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62460,7 +61955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62496,7 +61990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62532,7 +62025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62568,7 +62060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62604,7 +62095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62640,7 +62130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62676,7 +62165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62712,7 +62200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62748,7 +62235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62784,7 +62270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62820,7 +62305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62856,7 +62340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62892,7 +62375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62928,7 +62410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -62964,7 +62445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63000,7 +62480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63036,7 +62515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63072,7 +62550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63108,7 +62585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63144,7 +62620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63180,7 +62655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63216,7 +62690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63252,7 +62725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63288,7 +62760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63324,7 +62795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63360,7 +62830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63396,7 +62865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63432,7 +62900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63468,7 +62935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63504,7 +62970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63540,7 +63005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63576,7 +63040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63612,7 +63075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63648,7 +63110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63684,7 +63145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63720,7 +63180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63756,7 +63215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63792,7 +63250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63828,7 +63285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63864,7 +63320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63900,7 +63355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63936,7 +63390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -63972,7 +63425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64008,7 +63460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64044,7 +63495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64080,7 +63530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64116,7 +63565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64152,7 +63600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64188,7 +63635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64224,7 +63670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64260,7 +63705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64296,7 +63740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64332,7 +63775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64368,7 +63810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64404,7 +63845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64440,7 +63880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64476,7 +63915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64632,7 +64070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64668,7 +64105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64704,7 +64140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64740,7 +64175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64776,7 +64210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64812,7 +64245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64848,7 +64280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64884,7 +64315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64920,7 +64350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64956,7 +64385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -64992,7 +64420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65028,7 +64455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65064,7 +64490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65100,7 +64525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65136,7 +64560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65172,7 +64595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65208,7 +64630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65244,7 +64665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65280,7 +64700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65316,7 +64735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65352,7 +64770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65388,7 +64805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65424,7 +64840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65460,7 +64875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65496,7 +64910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65532,7 +64945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65568,7 +64980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65604,7 +65015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65640,7 +65050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65676,7 +65085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65712,7 +65120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65748,7 +65155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65784,7 +65190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65820,7 +65225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65856,7 +65260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65892,7 +65295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65928,7 +65330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -65964,7 +65365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66000,7 +65400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66036,7 +65435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66072,7 +65470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66108,7 +65505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66144,7 +65540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66180,7 +65575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66216,7 +65610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66252,7 +65645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66288,7 +65680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66324,7 +65715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66360,7 +65750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66396,7 +65785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66432,7 +65820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66468,7 +65855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66504,7 +65890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66540,7 +65925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66576,7 +65960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66612,7 +65995,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66648,7 +66030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66684,7 +66065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66720,7 +66100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66756,7 +66135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66792,7 +66170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66828,7 +66205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66864,7 +66240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66900,7 +66275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66936,7 +66310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -66972,7 +66345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67008,7 +66380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67044,7 +66415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67080,7 +66450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67116,7 +66485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67152,7 +66520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67188,7 +66555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67224,7 +66590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67260,7 +66625,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67296,7 +66660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67332,7 +66695,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67368,7 +66730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67404,7 +66765,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67440,7 +66800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67476,7 +66835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67512,7 +66870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67548,7 +66905,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67584,7 +66940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67620,7 +66975,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67656,7 +67010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67692,7 +67045,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67728,7 +67080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67764,7 +67115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67800,7 +67150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67836,7 +67185,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67872,7 +67220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67908,7 +67255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67944,7 +67290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -67980,7 +67325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68016,7 +67360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68052,7 +67395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68088,7 +67430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68124,7 +67465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68160,7 +67500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68196,7 +67535,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68232,7 +67570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68268,7 +67605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68304,7 +67640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68340,7 +67675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68376,7 +67710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68412,7 +67745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68448,7 +67780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68484,7 +67815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68520,7 +67850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68556,7 +67885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68592,7 +67920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68628,7 +67955,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68664,7 +67990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68700,7 +68025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68736,7 +68060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68772,7 +68095,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68808,7 +68130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68844,7 +68165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68880,7 +68200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68916,7 +68235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68952,7 +68270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -68988,7 +68305,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69024,7 +68340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69060,7 +68375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69096,7 +68410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69132,7 +68445,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69168,7 +68480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69204,7 +68515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69240,7 +68550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69276,7 +68585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69312,7 +68620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69348,7 +68655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69384,7 +68690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69420,7 +68725,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69456,7 +68760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69492,7 +68795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69528,7 +68830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69564,7 +68865,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69600,7 +68900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69636,7 +68935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69672,7 +68970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69708,7 +69005,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69744,7 +69040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69780,7 +69075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69816,7 +69110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69852,7 +69145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69888,7 +69180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69924,7 +69215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69960,7 +69250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -69996,7 +69285,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70032,7 +69320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70068,7 +69355,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70104,7 +69390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70140,7 +69425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70176,7 +69460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70212,7 +69495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70248,7 +69530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70284,7 +69565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70320,7 +69600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70356,7 +69635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70392,7 +69670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70428,7 +69705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70464,7 +69740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70500,7 +69775,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70536,7 +69810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70572,7 +69845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70608,7 +69880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70644,7 +69915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70680,7 +69950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70716,7 +69985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70752,7 +70020,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70788,7 +70055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70824,7 +70090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70860,7 +70125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70896,7 +70160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70932,7 +70195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -70968,7 +70230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71004,7 +70265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71040,7 +70300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71076,7 +70335,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71112,7 +70370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71148,7 +70405,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71184,7 +70440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71220,7 +70475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71256,7 +70510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71292,7 +70545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71328,7 +70580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71364,7 +70615,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71400,7 +70650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71436,7 +70685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71472,7 +70720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71508,7 +70755,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71544,7 +70790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71580,7 +70825,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71616,7 +70860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71652,7 +70895,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71688,7 +70930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71724,7 +70965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71760,7 +71000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71796,7 +71035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71832,7 +71070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71868,7 +71105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71904,7 +71140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71940,7 +71175,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -71976,7 +71210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72012,7 +71245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72048,7 +71280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72084,7 +71315,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72120,7 +71350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72156,7 +71385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72192,7 +71420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72228,7 +71455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72264,7 +71490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72300,7 +71525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72336,7 +71560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72372,7 +71595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72408,7 +71630,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72444,7 +71665,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72480,7 +71700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72516,7 +71735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72552,7 +71770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72588,7 +71805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72624,7 +71840,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72660,7 +71875,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72696,7 +71910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72732,7 +71945,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72768,7 +71980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72804,7 +72015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72840,7 +72050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72876,7 +72085,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72912,7 +72120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72948,7 +72155,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -72984,7 +72190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73020,7 +72225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73056,7 +72260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73092,7 +72295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73128,7 +72330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73164,7 +72365,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73200,7 +72400,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73236,7 +72435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73272,7 +72470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73308,7 +72505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73344,7 +72540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73380,7 +72575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73416,7 +72610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73452,7 +72645,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73488,7 +72680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73524,7 +72715,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73560,7 +72750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73596,7 +72785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73632,7 +72820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73668,7 +72855,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",
@@ -73704,7 +72890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/typings/underscore.d.ts",

--- a/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-04.json.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-04.json.sarif
@@ -255,7 +255,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -292,7 +291,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -329,7 +327,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -366,7 +363,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -403,7 +399,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -440,7 +435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -477,7 +471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -514,7 +507,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -551,7 +543,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -608,7 +599,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -663,7 +653,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -700,7 +689,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -757,7 +745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -793,7 +780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -829,7 +815,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -865,7 +850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -902,7 +886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -939,7 +922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -1016,7 +998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -1113,7 +1094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1149,7 +1129,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1185,7 +1164,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1342,7 +1320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1379,7 +1356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1416,7 +1392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1613,7 +1588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1650,7 +1624,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1807,7 +1780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -1943,7 +1915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -1979,7 +1950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2015,7 +1985,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2172,7 +2141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2209,7 +2177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2246,7 +2213,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2283,7 +2249,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2520,7 +2485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2557,7 +2521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2614,7 +2577,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -2710,7 +2672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -2746,7 +2707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -2782,7 +2742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -2939,7 +2898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -2976,7 +2934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3013,7 +2970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3050,7 +3006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3267,7 +3222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3304,7 +3258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3461,7 +3414,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -3557,7 +3509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3593,7 +3544,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3630,7 +3580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3707,7 +3656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -3803,7 +3751,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -3839,7 +3786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -3916,7 +3862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -4012,7 +3957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -4048,7 +3992,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -4125,7 +4068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -4201,7 +4143,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -4237,7 +4178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -4374,7 +4314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -4410,7 +4349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -4487,7 +4425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -4603,7 +4540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -4639,7 +4575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -4796,7 +4731,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -4833,7 +4767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -4870,7 +4803,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -4907,7 +4839,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5144,7 +5075,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5181,7 +5111,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5238,7 +5167,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -5334,7 +5262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -5370,7 +5297,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -5447,7 +5373,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -5543,7 +5468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -5579,7 +5503,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -5656,7 +5579,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -5792,7 +5714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -5828,7 +5749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -5864,7 +5784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6021,7 +5940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6058,7 +5976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6095,7 +6012,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6132,7 +6048,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6369,7 +6284,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6406,7 +6320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6463,7 +6376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -6559,7 +6471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -6595,7 +6506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -6672,7 +6582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -6768,7 +6677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -6804,7 +6712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -6881,7 +6788,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -6977,7 +6883,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -7013,7 +6918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -7090,7 +6994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -7186,7 +7089,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -7222,7 +7124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -7299,7 +7200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -7395,7 +7295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -7431,7 +7330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -7508,7 +7406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -7604,7 +7501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -7640,7 +7536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -7717,7 +7612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -7813,7 +7707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -7849,7 +7742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -7926,7 +7818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -7962,7 +7853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -8058,7 +7948,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -8094,7 +7983,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -8171,7 +8059,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -8267,7 +8154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -8303,7 +8189,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -8380,7 +8265,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -8476,7 +8360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -8512,7 +8395,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -8589,7 +8471,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -8725,7 +8606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8761,7 +8641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8797,7 +8676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8954,7 +8832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -8991,7 +8868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9028,7 +8904,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9065,7 +8940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9302,7 +9176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9339,7 +9212,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9396,7 +9268,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -9492,7 +9363,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -9528,7 +9398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -9605,7 +9474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -9741,7 +9609,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9777,7 +9644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9813,7 +9679,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -9970,7 +9835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10007,7 +9871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10044,7 +9907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10081,7 +9943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10318,7 +10179,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10355,7 +10215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10412,7 +10271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -10508,7 +10366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -10544,7 +10401,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -10621,7 +10477,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -10717,7 +10572,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -10753,7 +10607,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -10870,7 +10723,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -10907,7 +10759,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -10944,7 +10795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -11101,7 +10951,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -11138,7 +10987,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -11195,7 +11043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -11291,7 +11138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -11327,7 +11173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -11404,7 +11249,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -11500,7 +11344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -11536,7 +11379,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -11613,7 +11455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -11709,7 +11550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -11745,7 +11585,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -11822,7 +11661,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -11918,7 +11756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -11954,7 +11791,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12071,7 +11907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12108,7 +11943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12145,7 +11979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12302,7 +12135,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12339,7 +12171,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12396,7 +12227,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -12492,7 +12322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12528,7 +12357,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12645,7 +12473,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12682,7 +12509,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12719,7 +12545,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12876,7 +12701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12913,7 +12737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -12970,7 +12793,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -13106,7 +12928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13142,7 +12963,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13178,7 +12998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13335,7 +13154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13372,7 +13190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13409,7 +13226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13446,7 +13262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13563,7 +13378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13620,7 +13434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -13716,7 +13529,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -13752,7 +13564,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -13829,7 +13640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -13925,7 +13735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -13961,7 +13770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -14038,7 +13846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -14134,7 +13941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14170,7 +13976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14206,7 +14011,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14363,7 +14167,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14400,7 +14203,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14437,7 +14239,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14474,7 +14275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14691,7 +14491,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14728,7 +14527,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -14885,7 +14683,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -15021,7 +14818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15057,7 +14853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15093,7 +14888,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15250,7 +15044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15287,7 +15080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15324,7 +15116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15361,7 +15152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15598,7 +15388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15635,7 +15424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15692,7 +15480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -15788,7 +15575,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -15824,7 +15610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -15941,7 +15726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -15978,7 +15762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -16015,7 +15798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -16172,7 +15954,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -16209,7 +15990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -16266,7 +16046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -16362,7 +16141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16398,7 +16176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16515,7 +16292,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16552,7 +16328,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16589,7 +16364,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16746,7 +16520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16783,7 +16556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16840,7 +16612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -16936,7 +16707,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -16972,7 +16742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17089,7 +16858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17126,7 +16894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17163,7 +16930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17320,7 +17086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17357,7 +17122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17414,7 +17178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -17510,7 +17273,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17546,7 +17308,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17663,7 +17424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17700,7 +17460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17737,7 +17496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17894,7 +17652,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17931,7 +17688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -17988,7 +17744,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -18124,7 +17879,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18160,7 +17914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18196,7 +17949,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18353,7 +18105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18390,7 +18141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18427,7 +18177,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18464,7 +18213,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18581,7 +18329,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18638,7 +18385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -18734,7 +18480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -18770,7 +18515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -18847,7 +18591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -18983,7 +18726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19019,7 +18761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19055,7 +18796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19212,7 +18952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19249,7 +18988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19286,7 +19024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19323,7 +19060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19560,7 +19296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19597,7 +19332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19654,7 +19388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -19750,7 +19483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -19786,7 +19518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -19903,7 +19634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -19940,7 +19670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -19977,7 +19706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -20134,7 +19862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -20171,7 +19898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -20228,7 +19954,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -20324,7 +20049,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20360,7 +20084,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20396,7 +20119,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20553,7 +20275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20590,7 +20311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20627,7 +20347,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20664,7 +20383,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20881,7 +20599,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -20918,7 +20635,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21075,7 +20791,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -21171,7 +20886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -21207,7 +20921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -21284,7 +20997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -21380,7 +21092,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -21416,7 +21127,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -21493,7 +21203,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -21589,7 +21298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21625,7 +21333,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21661,7 +21368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21818,7 +21524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21855,7 +21560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21892,7 +21596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -21929,7 +21632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22146,7 +21848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22183,7 +21884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22240,7 +21940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -22336,7 +22035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -22372,7 +22070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -22449,7 +22146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -22545,7 +22241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -22581,7 +22276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -22658,7 +22352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -22754,7 +22447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -22790,7 +22482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -22867,7 +22558,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -22963,7 +22653,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -22999,7 +22688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -23076,7 +22764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -23212,7 +22899,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23248,7 +22934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23284,7 +22969,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23441,7 +23125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23478,7 +23161,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23515,7 +23197,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23552,7 +23233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23789,7 +23469,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23826,7 +23505,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23883,7 +23561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -23979,7 +23656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -24015,7 +23691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -24092,7 +23767,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -24208,7 +23882,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -24244,7 +23917,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -24341,7 +24013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -24437,7 +24108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -24473,7 +24143,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -24550,7 +24219,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -24646,7 +24314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -24682,7 +24349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -24759,7 +24425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -24855,7 +24520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -24891,7 +24555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -24968,7 +24631,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -25064,7 +24726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25100,7 +24761,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25217,7 +24877,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25254,7 +24913,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25291,7 +24949,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25448,7 +25105,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25485,7 +25141,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25542,7 +25197,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -25597,7 +25251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -25653,7 +25306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -25690,7 +25342,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -25727,7 +25378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -25773,7 +25423,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -25810,7 +25459,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -25847,7 +25495,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -25883,7 +25530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -25920,7 +25566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -25977,7 +25622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -26034,7 +25678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -26071,7 +25714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -26147,7 +25789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -26204,7 +25845,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26280,7 +25920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26337,7 +25976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26394,7 +26032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26431,7 +26068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26468,7 +26104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26505,7 +26140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -26562,7 +26196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -26619,7 +26252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -26656,7 +26288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -26732,7 +26363,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -26789,7 +26419,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -26826,7 +26455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -26882,7 +26510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -26919,7 +26546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -26956,7 +26582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -26993,7 +26618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",

--- a/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-06.json.sarif
+++ b/src/Sarif.FunctionalTests/ConverterTestData/TSLint/TSLint-06.json.sarif
@@ -343,7 +343,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRuleFailingTestInput.ts",
@@ -380,7 +379,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRuleFailingTestInput.ts",
@@ -417,7 +415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRuleFailingTestInput.ts",
@@ -454,7 +451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRuleFailingTestInput.ts",
@@ -550,7 +546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRulePassingTestInput.ts",
@@ -587,7 +582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRulePassingTestInput.ts",
@@ -624,7 +618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRulePassingTestInput.ts",
@@ -661,7 +654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/ExportName/ExportNameRulePassingTestInput.ts",
@@ -838,7 +830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -894,7 +885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -931,7 +921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -968,7 +957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1005,7 +993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1042,7 +1029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1079,7 +1065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1116,7 +1101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1153,7 +1137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1190,7 +1173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1227,7 +1209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1264,7 +1245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1301,7 +1281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1338,7 +1317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1375,7 +1353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1412,7 +1389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesFailingTestInput.ts",
@@ -1508,7 +1484,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1545,7 +1520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1582,7 +1556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1619,7 +1592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1656,7 +1628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1693,7 +1664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1730,7 +1700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1767,7 +1736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoCookies/NoCookiesTestInput-error.ts",
@@ -1882,7 +1850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -1919,7 +1886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2036,7 +2002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2071,7 +2036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2108,7 +2072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2145,7 +2108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2182,7 +2144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2219,7 +2180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2256,7 +2216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2292,7 +2251,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2328,7 +2286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoFunctionConstructorWithStringArgsTestInput.ts",
@@ -2383,7 +2340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2420,7 +2376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2556,7 +2511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2593,7 +2547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2630,7 +2583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2667,7 +2619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2724,7 +2675,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2761,7 +2711,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -2798,7 +2747,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoOctalLiteral/NoOctalLiteralTestInput-passing.ts",
@@ -3075,7 +3023,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3532,7 +3479,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3569,7 +3515,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3905,7 +3850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3942,7 +3886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -3979,7 +3922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4016,7 +3958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4053,7 +3994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4090,7 +4030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4127,7 +4066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4164,7 +4102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4201,7 +4138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4238,7 +4174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4275,7 +4210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4312,7 +4246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4349,7 +4282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4386,7 +4318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4423,7 +4354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4460,7 +4390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4497,7 +4426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4534,7 +4462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4571,7 +4498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4608,7 +4534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4645,7 +4570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4682,7 +4606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4719,7 +4642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4756,7 +4678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4793,7 +4714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4830,7 +4750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4867,7 +4786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4904,7 +4822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4941,7 +4858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -4978,7 +4894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5015,7 +4930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5052,7 +4966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5089,7 +5002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5126,7 +5038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5163,7 +5074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5200,7 +5110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5237,7 +5146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5274,7 +5182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5311,7 +5218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5348,7 +5254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5385,7 +5290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5422,7 +5326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5459,7 +5362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5496,7 +5398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5533,7 +5434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5570,7 +5470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5607,7 +5506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5644,7 +5542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-any.ts",
@@ -5920,7 +5817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6497,7 +6393,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6534,7 +6429,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6870,7 +6764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6907,7 +6800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6944,7 +6836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -6981,7 +6872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7018,7 +6908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7055,7 +6944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7092,7 +6980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7129,7 +7016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7166,7 +7052,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7203,7 +7088,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7240,7 +7124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7277,7 +7160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7314,7 +7196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7351,7 +7232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7388,7 +7268,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7425,7 +7304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7462,7 +7340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7499,7 +7376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7536,7 +7412,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7573,7 +7448,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7610,7 +7484,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7647,7 +7520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7684,7 +7556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7721,7 +7592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7758,7 +7628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7795,7 +7664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7832,7 +7700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7869,7 +7736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7906,7 +7772,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7943,7 +7808,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -7980,7 +7844,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8017,7 +7880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8054,7 +7916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8091,7 +7952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8128,7 +7988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8165,7 +8024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8202,7 +8060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8239,7 +8096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8276,7 +8132,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8313,7 +8168,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8350,7 +8204,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8387,7 +8240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8424,7 +8276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8461,7 +8312,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8498,7 +8348,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8535,7 +8384,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8572,7 +8420,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8609,7 +8456,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8646,7 +8492,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8683,7 +8528,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8720,7 +8564,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8757,7 +8600,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8794,7 +8636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -8831,7 +8672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-as.ts",
@@ -9107,7 +8947,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -9584,7 +9423,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -9621,7 +9459,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -9957,7 +9794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -9994,7 +9830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10031,7 +9866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10068,7 +9902,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10105,7 +9938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10142,7 +9974,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10179,7 +10010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10216,7 +10046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10253,7 +10082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10290,7 +10118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10327,7 +10154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10364,7 +10190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10401,7 +10226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10438,7 +10262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10475,7 +10298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10512,7 +10334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10549,7 +10370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10586,7 +10406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10623,7 +10442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10660,7 +10478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10697,7 +10514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10734,7 +10550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10771,7 +10586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10808,7 +10622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10845,7 +10658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10882,7 +10694,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10919,7 +10730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10956,7 +10766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -10993,7 +10802,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11030,7 +10838,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11067,7 +10874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11104,7 +10910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11141,7 +10946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11178,7 +10982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11215,7 +11018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11252,7 +11054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11289,7 +11090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11326,7 +11126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11363,7 +11162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11400,7 +11198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11437,7 +11234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11474,7 +11270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11511,7 +11306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11548,7 +11342,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11585,7 +11378,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11622,7 +11414,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11659,7 +11450,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11696,7 +11486,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11733,7 +11522,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-boolean.ts",
@@ -11889,7 +11677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12245,7 +12032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12282,7 +12068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12319,7 +12104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12356,7 +12140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12393,7 +12176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12430,7 +12212,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12467,7 +12248,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12504,7 +12284,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12541,7 +12320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12578,7 +12356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12615,7 +12392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12652,7 +12428,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12689,7 +12464,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12726,7 +12500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12763,7 +12536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12800,7 +12572,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12837,7 +12608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12874,7 +12644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12911,7 +12680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12948,7 +12716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -12985,7 +12752,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13022,7 +12788,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13059,7 +12824,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13096,7 +12860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13133,7 +12896,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13170,7 +12932,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-break.ts",
@@ -13326,7 +13087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13682,7 +13442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13719,7 +13478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13756,7 +13514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13793,7 +13550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13830,7 +13586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13867,7 +13622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13904,7 +13658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13941,7 +13694,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -13978,7 +13730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14015,7 +13766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14052,7 +13802,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14089,7 +13838,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14126,7 +13874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14163,7 +13910,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14200,7 +13946,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14237,7 +13982,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14274,7 +14018,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14311,7 +14054,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14348,7 +14090,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14385,7 +14126,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14422,7 +14162,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14459,7 +14198,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14496,7 +14234,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14533,7 +14270,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14570,7 +14306,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-case.ts",
@@ -14726,7 +14461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15082,7 +14816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15119,7 +14852,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15156,7 +14888,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15193,7 +14924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15230,7 +14960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15267,7 +14996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15304,7 +15032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15341,7 +15068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15378,7 +15104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15415,7 +15140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15452,7 +15176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15489,7 +15212,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15526,7 +15248,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15563,7 +15284,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15600,7 +15320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15637,7 +15356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15674,7 +15392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15711,7 +15428,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15748,7 +15464,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15785,7 +15500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15822,7 +15536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15859,7 +15572,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15896,7 +15608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -15933,7 +15644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-catch.ts",
@@ -16029,7 +15739,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16265,7 +15974,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16302,7 +16010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16339,7 +16046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16376,7 +16082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16413,7 +16118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16450,7 +16154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16487,7 +16190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16524,7 +16226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16561,7 +16262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16598,7 +16298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16635,7 +16334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16672,7 +16370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16709,7 +16406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16746,7 +16442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16783,7 +16478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16820,7 +16514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-class.ts",
@@ -16977,7 +16670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17333,7 +17025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17370,7 +17061,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17407,7 +17097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17444,7 +17133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17481,7 +17169,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17518,7 +17205,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17555,7 +17241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17592,7 +17277,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17629,7 +17313,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17666,7 +17349,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17703,7 +17385,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17740,7 +17421,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17777,7 +17457,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17814,7 +17493,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17851,7 +17529,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17888,7 +17565,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17925,7 +17601,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17962,7 +17637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -17999,7 +17673,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18036,7 +17709,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18073,7 +17745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18110,7 +17781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18147,7 +17817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18184,7 +17853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-const.ts",
@@ -18420,7 +18088,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -18937,7 +18604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -18974,7 +18640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19270,7 +18935,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19307,7 +18971,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19344,7 +19007,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19381,7 +19043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19418,7 +19079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19455,7 +19115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19492,7 +19151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19529,7 +19187,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19566,7 +19223,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19603,7 +19259,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19640,7 +19295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19677,7 +19331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19714,7 +19367,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19751,7 +19403,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19788,7 +19439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19825,7 +19475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19862,7 +19511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19899,7 +19547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19936,7 +19583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -19973,7 +19619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20010,7 +19655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20047,7 +19691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20084,7 +19727,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20121,7 +19763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20158,7 +19799,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20195,7 +19835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20232,7 +19871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20269,7 +19907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20306,7 +19943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20343,7 +19979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20380,7 +20015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20417,7 +20051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20454,7 +20087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20491,7 +20123,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20528,7 +20159,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20565,7 +20195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20602,7 +20231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20639,7 +20267,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20676,7 +20303,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20713,7 +20339,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20750,7 +20375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20787,7 +20411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20824,7 +20447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20861,7 +20483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20898,7 +20519,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20935,7 +20555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -20972,7 +20591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -21009,7 +20627,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-constructor.ts",
@@ -21165,7 +20782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21521,7 +21137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21558,7 +21173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21595,7 +21209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21632,7 +21245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21669,7 +21281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21706,7 +21317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21743,7 +21353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21780,7 +21389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21817,7 +21425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21854,7 +21461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21891,7 +21497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21928,7 +21533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -21965,7 +21569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22002,7 +21605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22039,7 +21641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22076,7 +21677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22113,7 +21713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22150,7 +21749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22187,7 +21785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22224,7 +21821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22261,7 +21857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22298,7 +21893,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22335,7 +21929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22372,7 +21965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-continue.ts",
@@ -22528,7 +22120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -22884,7 +22475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -22921,7 +22511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -22958,7 +22547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -22995,7 +22583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23032,7 +22619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23069,7 +22655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23106,7 +22691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23143,7 +22727,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23180,7 +22763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23217,7 +22799,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23254,7 +22835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23291,7 +22871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23328,7 +22907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23365,7 +22943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23402,7 +22979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23439,7 +23015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23476,7 +23051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23513,7 +23087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23550,7 +23123,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23587,7 +23159,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23624,7 +23195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23661,7 +23231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23698,7 +23267,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -23735,7 +23303,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-debugger.ts",
@@ -24011,7 +23578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -24588,7 +24154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -24625,7 +24190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -24961,7 +24525,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -24998,7 +24561,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25035,7 +24597,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25072,7 +24633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25109,7 +24669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25146,7 +24705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25183,7 +24741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25220,7 +24777,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25257,7 +24813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25294,7 +24849,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25331,7 +24885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25368,7 +24921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25405,7 +24957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25442,7 +24993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25479,7 +25029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25516,7 +25065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25553,7 +25101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25590,7 +25137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25627,7 +25173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25664,7 +25209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25701,7 +25245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25738,7 +25281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25775,7 +25317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25812,7 +25353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25849,7 +25389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25886,7 +25425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25923,7 +25461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25960,7 +25497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -25997,7 +25533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26034,7 +25569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26071,7 +25605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26108,7 +25641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26145,7 +25677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26182,7 +25713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26219,7 +25749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26256,7 +25785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26293,7 +25821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26330,7 +25857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26367,7 +25893,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26404,7 +25929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26441,7 +25965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26478,7 +26001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26515,7 +26037,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26552,7 +26073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26589,7 +26109,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26626,7 +26145,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26663,7 +26181,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26700,7 +26217,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26737,7 +26253,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26774,7 +26289,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26811,7 +26325,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26848,7 +26361,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26885,7 +26397,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -26922,7 +26433,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-declare.ts",
@@ -27078,7 +26588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27434,7 +26943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27471,7 +26979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27508,7 +27015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27545,7 +27051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27582,7 +27087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27619,7 +27123,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27656,7 +27159,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27693,7 +27195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27730,7 +27231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27767,7 +27267,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27804,7 +27303,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27841,7 +27339,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27878,7 +27375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27915,7 +27411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27952,7 +27447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -27989,7 +27483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28026,7 +27519,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28063,7 +27555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28100,7 +27591,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28137,7 +27627,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28174,7 +27663,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28211,7 +27699,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28248,7 +27735,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28285,7 +27771,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-default.ts",
@@ -28441,7 +27926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28797,7 +28281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28834,7 +28317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28871,7 +28353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28908,7 +28389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28945,7 +28425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -28982,7 +28461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29019,7 +28497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29056,7 +28533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29093,7 +28569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29130,7 +28605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29167,7 +28641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29204,7 +28677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29241,7 +28713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29278,7 +28749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29315,7 +28785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29352,7 +28821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29389,7 +28857,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29426,7 +28893,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29463,7 +28929,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29500,7 +28965,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29537,7 +29001,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29574,7 +29037,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29611,7 +29073,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29648,7 +29109,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-delete.ts",
@@ -29804,7 +29264,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30160,7 +29619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30197,7 +29655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30234,7 +29691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30271,7 +29727,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30308,7 +29763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30345,7 +29799,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30382,7 +29835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30419,7 +29871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30456,7 +29907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30493,7 +29943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30530,7 +29979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30567,7 +30015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30604,7 +30051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30641,7 +30087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30678,7 +30123,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30715,7 +30159,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30752,7 +30195,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30789,7 +30231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30826,7 +30267,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30863,7 +30303,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30900,7 +30339,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30937,7 +30375,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -30974,7 +30411,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -31011,7 +30447,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -31048,7 +30483,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-do.ts",
@@ -31204,7 +30638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31560,7 +30993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31597,7 +31029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31634,7 +31065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31671,7 +31101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31708,7 +31137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31745,7 +31173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31782,7 +31209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31819,7 +31245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31856,7 +31281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31893,7 +31317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31930,7 +31353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -31967,7 +31389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32004,7 +31425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32041,7 +31461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32078,7 +31497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32115,7 +31533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32152,7 +31569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32189,7 +31605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32226,7 +31641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32263,7 +31677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32300,7 +31713,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32337,7 +31749,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32374,7 +31785,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32411,7 +31821,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-else.ts",
@@ -32567,7 +31976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -32923,7 +32331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -32960,7 +32367,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -32997,7 +32403,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33034,7 +32439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33071,7 +32475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33108,7 +32511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33145,7 +32547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33182,7 +32583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33219,7 +32619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33256,7 +32655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33293,7 +32691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33330,7 +32727,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33367,7 +32763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33404,7 +32799,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33441,7 +32835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33478,7 +32871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33515,7 +32907,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33552,7 +32943,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33589,7 +32979,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33626,7 +33015,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33663,7 +33051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33700,7 +33087,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33737,7 +33123,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33774,7 +33159,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-enum.ts",
@@ -33930,7 +33314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34286,7 +33669,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34323,7 +33705,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34360,7 +33741,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34397,7 +33777,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34434,7 +33813,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34471,7 +33849,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34508,7 +33885,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34545,7 +33921,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34582,7 +33957,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34619,7 +33993,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34656,7 +34029,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34693,7 +34065,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34730,7 +34101,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34767,7 +34137,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34804,7 +34173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34841,7 +34209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34878,7 +34245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34915,7 +34281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34952,7 +34317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -34989,7 +34353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35026,7 +34389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35063,7 +34425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35100,7 +34461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35137,7 +34497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35174,7 +34533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-export.ts",
@@ -35330,7 +34688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35686,7 +35043,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35723,7 +35079,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35760,7 +35115,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35797,7 +35151,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35834,7 +35187,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35871,7 +35223,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35908,7 +35259,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35945,7 +35295,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -35982,7 +35331,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36019,7 +35367,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36056,7 +35403,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36093,7 +35439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36130,7 +35475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36167,7 +35511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36204,7 +35547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36241,7 +35583,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36278,7 +35619,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36315,7 +35655,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36352,7 +35691,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36389,7 +35727,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36426,7 +35763,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36463,7 +35799,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36500,7 +35835,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36537,7 +35871,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-extends.ts",
@@ -36693,7 +36026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37050,7 +36382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37085,7 +36416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37122,7 +36452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37159,7 +36488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37196,7 +36524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37233,7 +36560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37270,7 +36596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37307,7 +36632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37344,7 +36668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37381,7 +36704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37418,7 +36740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37455,7 +36776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37492,7 +36812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37529,7 +36848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37566,7 +36884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37603,7 +36920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37640,7 +36956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37677,7 +36992,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37714,7 +37028,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37751,7 +37064,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37788,7 +37100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37825,7 +37136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37862,7 +37172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37899,7 +37208,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37936,7 +37244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -37973,7 +37280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-false.ts",
@@ -38129,7 +37435,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38485,7 +37790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38522,7 +37826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38559,7 +37862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38596,7 +37898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38633,7 +37934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38670,7 +37970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38707,7 +38006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38744,7 +38042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38781,7 +38078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38818,7 +38114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38855,7 +38150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38892,7 +38186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38929,7 +38222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -38966,7 +38258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39003,7 +38294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39040,7 +38330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39077,7 +38366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39114,7 +38402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39151,7 +38438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39188,7 +38474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39225,7 +38510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39262,7 +38546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39299,7 +38582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39336,7 +38618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-finally.ts",
@@ -39492,7 +38773,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -39848,7 +39128,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -39885,7 +39164,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -39922,7 +39200,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -39959,7 +39236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -39996,7 +39272,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40033,7 +39308,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40070,7 +39344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40107,7 +39380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40144,7 +39416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40181,7 +39452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40218,7 +39488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40255,7 +39524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40292,7 +39560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40329,7 +39596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40366,7 +39632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40403,7 +39668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40440,7 +39704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40477,7 +39740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40514,7 +39776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40551,7 +39812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40588,7 +39848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40625,7 +39884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40662,7 +39920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40699,7 +39956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-for.ts",
@@ -40975,7 +40231,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -41552,7 +40807,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -41589,7 +40843,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -41925,7 +41178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -41962,7 +41214,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -41999,7 +41250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42036,7 +41286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42073,7 +41322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42110,7 +41358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42147,7 +41394,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42184,7 +41430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42221,7 +41466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42258,7 +41502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42295,7 +41538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42332,7 +41574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42369,7 +41610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42406,7 +41646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42443,7 +41682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42480,7 +41718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42517,7 +41754,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42554,7 +41790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42591,7 +41826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42628,7 +41862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42665,7 +41898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42702,7 +41934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42739,7 +41970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42776,7 +42006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42813,7 +42042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42850,7 +42078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42887,7 +42114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42924,7 +42150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42961,7 +42186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -42998,7 +42222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43035,7 +42258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43072,7 +42294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43109,7 +42330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43146,7 +42366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43183,7 +42402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43220,7 +42438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43257,7 +42474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43294,7 +42510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43331,7 +42546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43368,7 +42582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43405,7 +42618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43442,7 +42654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43479,7 +42690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43516,7 +42726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43553,7 +42762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43590,7 +42798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43627,7 +42834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43664,7 +42870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43701,7 +42906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43738,7 +42942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43775,7 +42978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43812,7 +43014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43849,7 +43050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -43886,7 +43086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-from.ts",
@@ -44042,7 +43241,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44398,7 +43596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44435,7 +43632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44472,7 +43668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44509,7 +43704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44546,7 +43740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44583,7 +43776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44620,7 +43812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44657,7 +43848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44694,7 +43884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44731,7 +43920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44768,7 +43956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44805,7 +43992,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44842,7 +44028,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44879,7 +44064,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44916,7 +44100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44953,7 +44136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -44990,7 +44172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45027,7 +44208,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45064,7 +44244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45101,7 +44280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45138,7 +44316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45175,7 +44352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45212,7 +44388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45249,7 +44424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-function.ts",
@@ -45525,7 +44699,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46102,7 +45275,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46139,7 +45311,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46475,7 +45646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46512,7 +45682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46549,7 +45718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46586,7 +45754,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46623,7 +45790,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46660,7 +45826,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46697,7 +45862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46734,7 +45898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46771,7 +45934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46808,7 +45970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46845,7 +46006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46882,7 +46042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46919,7 +46078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46956,7 +46114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -46993,7 +46150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47030,7 +46186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47067,7 +46222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47104,7 +46258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47141,7 +46294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47178,7 +46330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47215,7 +46366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47252,7 +46402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47289,7 +46438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47326,7 +46474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47363,7 +46510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47400,7 +46546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47437,7 +46582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47474,7 +46618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47511,7 +46654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47548,7 +46690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47585,7 +46726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47622,7 +46762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47659,7 +46798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47696,7 +46834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47733,7 +46870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47770,7 +46906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47807,7 +46942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47844,7 +46978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47881,7 +47014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47918,7 +47050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47955,7 +47086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -47992,7 +47122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48029,7 +47158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48066,7 +47194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48103,7 +47230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48140,7 +47266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48177,7 +47302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48214,7 +47338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48251,7 +47374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48288,7 +47410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48325,7 +47446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48362,7 +47482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48399,7 +47518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48436,7 +47554,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-get.ts",
@@ -48592,7 +47709,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -48948,7 +48064,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -48985,7 +48100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49022,7 +48136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49059,7 +48172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49096,7 +48208,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49133,7 +48244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49170,7 +48280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49207,7 +48316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49244,7 +48352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49281,7 +48388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49318,7 +48424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49355,7 +48460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49392,7 +48496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49429,7 +48532,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49466,7 +48568,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49503,7 +48604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49540,7 +48640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49577,7 +48676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49614,7 +48712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49651,7 +48748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49688,7 +48784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49725,7 +48820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49762,7 +48856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49799,7 +48892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -49836,7 +48928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-if.ts",
@@ -50072,7 +49163,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50429,7 +49519,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50466,7 +49555,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50722,7 +49810,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50759,7 +49846,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50796,7 +49882,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50833,7 +49918,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50870,7 +49954,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50907,7 +49990,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50944,7 +50026,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -50981,7 +50062,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51018,7 +50098,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51055,7 +50134,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51092,7 +50170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51129,7 +50206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51166,7 +50242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51203,7 +50278,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51240,7 +50314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51277,7 +50350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51314,7 +50386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51351,7 +50422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51388,7 +50458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51425,7 +50494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51462,7 +50530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51499,7 +50566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51536,7 +50602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51573,7 +50638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51610,7 +50674,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51647,7 +50710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51684,7 +50746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51721,7 +50782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51758,7 +50818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51795,7 +50854,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51832,7 +50890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51869,7 +50926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51906,7 +50962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51943,7 +50998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -51980,7 +51034,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52017,7 +51070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52054,7 +51106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52091,7 +51142,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52128,7 +51178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52165,7 +51214,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52202,7 +51250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52239,7 +51286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52276,7 +51322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52313,7 +51358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52350,7 +51394,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-implements.ts",
@@ -52506,7 +51549,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -52862,7 +51904,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -52899,7 +51940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -52936,7 +51976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -52973,7 +52012,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53010,7 +52048,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53047,7 +52084,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53084,7 +52120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53121,7 +52156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53158,7 +52192,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53195,7 +52228,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53232,7 +52264,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53269,7 +52300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53306,7 +52336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53343,7 +52372,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53380,7 +52408,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53417,7 +52444,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53454,7 +52480,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53491,7 +52516,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53528,7 +52552,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53565,7 +52588,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53602,7 +52624,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53639,7 +52660,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53676,7 +52696,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53713,7 +52732,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-import.ts",
@@ -53869,7 +52887,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54225,7 +53242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54262,7 +53278,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54299,7 +53314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54336,7 +53350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54373,7 +53386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54410,7 +53422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54447,7 +53458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54484,7 +53494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54521,7 +53530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54558,7 +53566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54595,7 +53602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54632,7 +53638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54669,7 +53674,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54706,7 +53710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54743,7 +53746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54780,7 +53782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54817,7 +53818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54854,7 +53854,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54891,7 +53890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54928,7 +53926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -54965,7 +53962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -55002,7 +53998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -55039,7 +54034,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -55076,7 +54070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-in.ts",
@@ -55232,7 +54225,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55588,7 +54580,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55625,7 +54616,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55662,7 +54652,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55699,7 +54688,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55736,7 +54724,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55773,7 +54760,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55810,7 +54796,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55847,7 +54832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55884,7 +54868,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55921,7 +54904,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55958,7 +54940,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -55995,7 +54976,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56032,7 +55012,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56069,7 +55048,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56106,7 +55084,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56143,7 +55120,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56180,7 +55156,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56217,7 +55192,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56254,7 +55228,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56291,7 +55264,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56328,7 +55300,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56365,7 +55336,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56402,7 +55372,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56439,7 +55408,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-instanceof.ts",
@@ -56675,7 +55643,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57032,7 +55999,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57069,7 +56035,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57325,7 +56290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57362,7 +56326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57399,7 +56362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57436,7 +56398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57473,7 +56434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57510,7 +56470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57547,7 +56506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57584,7 +56542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57621,7 +56578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57658,7 +56614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57695,7 +56650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57732,7 +56686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57769,7 +56722,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57806,7 +56758,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57843,7 +56794,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57880,7 +56830,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57917,7 +56866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57954,7 +56902,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -57991,7 +56938,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58028,7 +56974,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58065,7 +57010,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58102,7 +57046,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58139,7 +57082,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58176,7 +57118,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58213,7 +57154,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58250,7 +57190,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58287,7 +57226,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58324,7 +57262,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58361,7 +57298,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58398,7 +57334,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58435,7 +57370,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58472,7 +57406,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58509,7 +57442,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58546,7 +57478,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58583,7 +57514,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58620,7 +57550,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58657,7 +57586,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58694,7 +57622,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58731,7 +57658,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58768,7 +57694,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58805,7 +57730,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58842,7 +57766,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58879,7 +57802,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58916,7 +57838,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -58953,7 +57874,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-interface.ts",
@@ -59189,7 +58109,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59546,7 +58465,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59583,7 +58501,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59839,7 +58756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59876,7 +58792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59913,7 +58828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59950,7 +58864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -59987,7 +58900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60024,7 +58936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60061,7 +58972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60098,7 +59008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60135,7 +59044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60172,7 +59080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60209,7 +59116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60246,7 +59152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60283,7 +59188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60320,7 +59224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60357,7 +59260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60394,7 +59296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60431,7 +59332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60468,7 +59368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60505,7 +59404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60542,7 +59440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60579,7 +59476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60616,7 +59512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60653,7 +59548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60690,7 +59584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60727,7 +59620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60764,7 +59656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60801,7 +59692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60838,7 +59728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60875,7 +59764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60912,7 +59800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60949,7 +59836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -60986,7 +59872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61023,7 +59908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61060,7 +59944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61097,7 +59980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61134,7 +60016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61171,7 +60052,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61208,7 +60088,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61245,7 +60124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61282,7 +60160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61319,7 +60196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61356,7 +60232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61393,7 +60268,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61430,7 +60304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61467,7 +60340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-let.ts",
@@ -61723,7 +60595,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62180,7 +61051,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62496,7 +61366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62533,7 +61402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62570,7 +61438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62607,7 +61474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62644,7 +61510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62681,7 +61546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62718,7 +61582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62755,7 +61618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62792,7 +61654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62829,7 +61690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62866,7 +61726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62903,7 +61762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62940,7 +61798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -62977,7 +61834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63014,7 +61870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63051,7 +61906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63088,7 +61942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63125,7 +61978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63162,7 +62014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63199,7 +62050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63236,7 +62086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63273,7 +62122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63310,7 +62158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63347,7 +62194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63384,7 +62230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63421,7 +62266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63458,7 +62302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63495,7 +62338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63532,7 +62374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63569,7 +62410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63606,7 +62446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63643,7 +62482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63680,7 +62518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63717,7 +62554,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63754,7 +62590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63791,7 +62626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63828,7 +62662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63865,7 +62698,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63902,7 +62734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63939,7 +62770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -63976,7 +62806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64013,7 +62842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64050,7 +62878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64087,7 +62914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64124,7 +62950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64161,7 +62986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64198,7 +63022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64235,7 +63058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64272,7 +63094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64309,7 +63130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64346,7 +63166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-module.ts",
@@ -64502,7 +63321,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -64858,7 +63676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -64895,7 +63712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -64932,7 +63748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -64969,7 +63784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65006,7 +63820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65043,7 +63856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65080,7 +63892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65117,7 +63928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65154,7 +63964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65191,7 +64000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65228,7 +64036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65265,7 +64072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65302,7 +64108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65339,7 +64144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65376,7 +64180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65413,7 +64216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65450,7 +64252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65487,7 +64288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65524,7 +64324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65561,7 +64360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65598,7 +64396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65635,7 +64432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65672,7 +64468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65709,7 +64504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-new.ts",
@@ -65865,7 +64659,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66221,7 +65014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66258,7 +65050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66295,7 +65086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66332,7 +65122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66369,7 +65158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66406,7 +65194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66443,7 +65230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66480,7 +65266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66517,7 +65302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66554,7 +65338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66591,7 +65374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66628,7 +65410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66665,7 +65446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66702,7 +65482,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66739,7 +65518,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66776,7 +65554,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66813,7 +65590,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66850,7 +65626,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66887,7 +65662,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66924,7 +65698,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66961,7 +65734,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -66998,7 +65770,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -67035,7 +65806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -67072,7 +65842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-null.ts",
@@ -67348,7 +66117,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -67825,7 +66593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -67862,7 +66629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68198,7 +66964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68235,7 +67000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68272,7 +67036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68309,7 +67072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68346,7 +67108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68383,7 +67144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68420,7 +67180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68457,7 +67216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68494,7 +67252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68531,7 +67288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68568,7 +67324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68605,7 +67360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68642,7 +67396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68679,7 +67432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68716,7 +67468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68753,7 +67504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68790,7 +67540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68827,7 +67576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68864,7 +67612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68901,7 +67648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68938,7 +67684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -68975,7 +67720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69012,7 +67756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69049,7 +67792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69086,7 +67828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69123,7 +67864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69160,7 +67900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69197,7 +67936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69234,7 +67972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69271,7 +68008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69308,7 +68044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69345,7 +68080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69382,7 +68116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69419,7 +68152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69456,7 +68188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69493,7 +68224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69530,7 +68260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69567,7 +68296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69604,7 +68332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69641,7 +68368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69678,7 +68404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69715,7 +68440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69752,7 +68476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69789,7 +68512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69826,7 +68548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69863,7 +68584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69900,7 +68620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69937,7 +68656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -69974,7 +68692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-number.ts",
@@ -70250,7 +68967,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -70827,7 +69543,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -70864,7 +69579,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71200,7 +69914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71237,7 +69950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71274,7 +69986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71311,7 +70022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71348,7 +70058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71385,7 +70094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71422,7 +70130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71459,7 +70166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71496,7 +70202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71533,7 +70238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71570,7 +70274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71607,7 +70310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71644,7 +70346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71681,7 +70382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71718,7 +70418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71755,7 +70454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71792,7 +70490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71829,7 +70526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71866,7 +70562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71903,7 +70598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71940,7 +70634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -71977,7 +70670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72014,7 +70706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72051,7 +70742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72088,7 +70778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72125,7 +70814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72162,7 +70850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72199,7 +70886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72236,7 +70922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72273,7 +70958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72310,7 +70994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72347,7 +71030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72384,7 +71066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72421,7 +71102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72458,7 +71138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72495,7 +71174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72532,7 +71210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72569,7 +71246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72606,7 +71282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72643,7 +71318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72680,7 +71354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72717,7 +71390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72754,7 +71426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72791,7 +71462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72828,7 +71498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72865,7 +71534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72902,7 +71570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72939,7 +71606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -72976,7 +71642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73013,7 +71678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73050,7 +71714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73087,7 +71750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73124,7 +71786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73161,7 +71822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-of.ts",
@@ -73397,7 +72057,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -73754,7 +72413,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -73791,7 +72449,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74047,7 +72704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74084,7 +72740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74121,7 +72776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74158,7 +72812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74195,7 +72848,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74232,7 +72884,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74269,7 +72920,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74306,7 +72956,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74343,7 +72992,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74380,7 +73028,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74417,7 +73064,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74454,7 +73100,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74491,7 +73136,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74528,7 +73172,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74565,7 +73208,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74602,7 +73244,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74639,7 +73280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74676,7 +73316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74713,7 +73352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74750,7 +73388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74787,7 +73424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74824,7 +73460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74861,7 +73496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74898,7 +73532,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74935,7 +73568,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -74972,7 +73604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75009,7 +73640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75046,7 +73676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75083,7 +73712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75120,7 +73748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75157,7 +73784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75194,7 +73820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75231,7 +73856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75268,7 +73892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75305,7 +73928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75342,7 +73964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75379,7 +74000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75416,7 +74036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75453,7 +74072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75490,7 +74108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75527,7 +74144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75564,7 +74180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75601,7 +74216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75638,7 +74252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75675,7 +74288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-package.ts",
@@ -75911,7 +74523,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76268,7 +74879,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76305,7 +74915,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76561,7 +75170,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76598,7 +75206,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76635,7 +75242,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76672,7 +75278,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76709,7 +75314,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76746,7 +75350,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76783,7 +75386,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76820,7 +75422,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76857,7 +75458,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76894,7 +75494,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76931,7 +75530,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -76968,7 +75566,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77005,7 +75602,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77042,7 +75638,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77079,7 +75674,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77116,7 +75710,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77153,7 +75746,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77190,7 +75782,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77227,7 +75818,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77264,7 +75854,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77301,7 +75890,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77338,7 +75926,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77375,7 +75962,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77412,7 +75998,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77449,7 +76034,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77486,7 +76070,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77523,7 +76106,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77560,7 +76142,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77597,7 +76178,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77634,7 +76214,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77671,7 +76250,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77708,7 +76286,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77745,7 +76322,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77782,7 +76358,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77819,7 +76394,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77856,7 +76430,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77893,7 +76466,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77930,7 +76502,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -77967,7 +76538,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78004,7 +76574,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78041,7 +76610,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78078,7 +76646,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78115,7 +76682,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78152,7 +76718,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78189,7 +76754,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-private.ts",
@@ -78425,7 +76989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -78782,7 +77345,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -78819,7 +77381,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79075,7 +77636,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79112,7 +77672,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79149,7 +77708,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79186,7 +77744,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79223,7 +77780,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79260,7 +77816,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79297,7 +77852,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79334,7 +77888,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79371,7 +77924,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79408,7 +77960,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79445,7 +77996,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79482,7 +78032,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79519,7 +78068,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79556,7 +78104,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79593,7 +78140,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79630,7 +78176,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79667,7 +78212,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79704,7 +78248,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79741,7 +78284,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79778,7 +78320,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79815,7 +78356,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79852,7 +78392,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79889,7 +78428,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79926,7 +78464,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -79963,7 +78500,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80000,7 +78536,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80037,7 +78572,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80074,7 +78608,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80111,7 +78644,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80148,7 +78680,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80185,7 +78716,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80222,7 +78752,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80259,7 +78788,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80296,7 +78824,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80333,7 +78860,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80370,7 +78896,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80407,7 +78932,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80444,7 +78968,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80481,7 +79004,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80518,7 +79040,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80555,7 +79076,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80592,7 +79112,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80629,7 +79148,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80666,7 +79184,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80703,7 +79220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-protected.ts",
@@ -80939,7 +79455,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81296,7 +79811,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81333,7 +79847,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81589,7 +80102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81626,7 +80138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81663,7 +80174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81700,7 +80210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81737,7 +80246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81774,7 +80282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81811,7 +80318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81848,7 +80354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81885,7 +80390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81922,7 +80426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81959,7 +80462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -81996,7 +80498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82033,7 +80534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82070,7 +80570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82107,7 +80606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82144,7 +80642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82181,7 +80678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82218,7 +80714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82255,7 +80750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82292,7 +80786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82329,7 +80822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82366,7 +80858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82403,7 +80894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82440,7 +80930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82477,7 +80966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82514,7 +81002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82551,7 +81038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82588,7 +81074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82625,7 +81110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82662,7 +81146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82699,7 +81182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82736,7 +81218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82773,7 +81254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82810,7 +81290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82847,7 +81326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82884,7 +81362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82921,7 +81398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82958,7 +81434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -82995,7 +81470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83032,7 +81506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83069,7 +81542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83106,7 +81578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83143,7 +81614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83180,7 +81650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83217,7 +81686,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-public.ts",
@@ -83473,7 +81941,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -83930,7 +82397,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84246,7 +82712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84283,7 +82748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84320,7 +82784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84357,7 +82820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84394,7 +82856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84431,7 +82892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84468,7 +82928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84505,7 +82964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84542,7 +83000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84579,7 +83036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84616,7 +83072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84653,7 +83108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84690,7 +83144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84727,7 +83180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84764,7 +83216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84801,7 +83252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84838,7 +83288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84875,7 +83324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84912,7 +83360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84949,7 +83396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -84986,7 +83432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85023,7 +83468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85060,7 +83504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85097,7 +83540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85134,7 +83576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85171,7 +83612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85208,7 +83648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85245,7 +83684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85282,7 +83720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85319,7 +83756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85356,7 +83792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85393,7 +83828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85430,7 +83864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85467,7 +83900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85504,7 +83936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85541,7 +83972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85578,7 +84008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85615,7 +84044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85652,7 +84080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85689,7 +84116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85726,7 +84152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85763,7 +84188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85800,7 +84224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85837,7 +84260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85874,7 +84296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85911,7 +84332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85948,7 +84368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -85985,7 +84404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -86022,7 +84440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -86059,7 +84476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -86096,7 +84512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-require.ts",
@@ -86252,7 +84667,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86608,7 +85022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86645,7 +85058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86682,7 +85094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86719,7 +85130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86756,7 +85166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86793,7 +85202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86830,7 +85238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86867,7 +85274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86904,7 +85310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86941,7 +85346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -86978,7 +85382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87015,7 +85418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87052,7 +85454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87089,7 +85490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87126,7 +85526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87163,7 +85562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87200,7 +85598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87237,7 +85634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87274,7 +85670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87311,7 +85706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87348,7 +85742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87385,7 +85778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87422,7 +85814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87459,7 +85850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-return.ts",
@@ -87735,7 +86125,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88312,7 +86701,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88349,7 +86737,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88685,7 +87072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88722,7 +87108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88759,7 +87144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88796,7 +87180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88833,7 +87216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88870,7 +87252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88907,7 +87288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88944,7 +87324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -88981,7 +87360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89018,7 +87396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89055,7 +87432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89092,7 +87468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89129,7 +87504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89166,7 +87540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89203,7 +87576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89240,7 +87612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89277,7 +87648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89314,7 +87684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89351,7 +87720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89388,7 +87756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89425,7 +87792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89462,7 +87828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89499,7 +87864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89536,7 +87900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89573,7 +87936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89610,7 +87972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89647,7 +88008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89684,7 +88044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89721,7 +88080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89758,7 +88116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89795,7 +88152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89832,7 +88188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89869,7 +88224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89906,7 +88260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89943,7 +88296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -89980,7 +88332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90017,7 +88368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90054,7 +88404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90091,7 +88440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90128,7 +88476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90165,7 +88512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90202,7 +88548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90239,7 +88584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90276,7 +88620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90313,7 +88656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90350,7 +88692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90387,7 +88728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90424,7 +88764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90461,7 +88800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90498,7 +88836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90535,7 +88872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90572,7 +88908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90609,7 +88944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90646,7 +88980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-set.ts",
@@ -90882,7 +89215,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91239,7 +89571,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91276,7 +89607,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91532,7 +89862,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91569,7 +89898,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91606,7 +89934,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91643,7 +89970,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91680,7 +90006,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91717,7 +90042,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91754,7 +90078,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91791,7 +90114,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91828,7 +90150,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91865,7 +90186,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91902,7 +90222,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91939,7 +90258,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -91976,7 +90294,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92013,7 +90330,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92050,7 +90366,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92087,7 +90402,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92124,7 +90438,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92161,7 +90474,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92198,7 +90510,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92235,7 +90546,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92272,7 +90582,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92309,7 +90618,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92346,7 +90654,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92383,7 +90690,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92420,7 +90726,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92457,7 +90762,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92494,7 +90798,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92531,7 +90834,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92568,7 +90870,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92605,7 +90906,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92642,7 +90942,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92679,7 +90978,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92716,7 +91014,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92753,7 +91050,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92790,7 +91086,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92827,7 +91122,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92864,7 +91158,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92901,7 +91194,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92938,7 +91230,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -92975,7 +91266,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93012,7 +91302,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93049,7 +91338,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93086,7 +91374,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93123,7 +91410,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93160,7 +91446,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-static.ts",
@@ -93436,7 +91721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -93913,7 +92197,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -93950,7 +92233,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94286,7 +92568,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94323,7 +92604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94360,7 +92640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94397,7 +92676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94434,7 +92712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94471,7 +92748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94508,7 +92784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94545,7 +92820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94582,7 +92856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94619,7 +92892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94656,7 +92928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94693,7 +92964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94730,7 +93000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94767,7 +93036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94804,7 +93072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94841,7 +93108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94878,7 +93144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94915,7 +93180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94952,7 +93216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -94989,7 +93252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95026,7 +93288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95063,7 +93324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95100,7 +93360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95137,7 +93396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95174,7 +93432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95211,7 +93468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95248,7 +93504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95285,7 +93540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95322,7 +93576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95359,7 +93612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95396,7 +93648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95433,7 +93684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95470,7 +93720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95507,7 +93756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95544,7 +93792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95581,7 +93828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95618,7 +93864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95655,7 +93900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95692,7 +93936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95729,7 +93972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95766,7 +94008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95803,7 +94044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95840,7 +94080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95877,7 +94116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95914,7 +94152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95951,7 +94188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -95988,7 +94224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -96025,7 +94260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -96062,7 +94296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-string.ts",
@@ -96218,7 +94451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96574,7 +94806,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96611,7 +94842,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96648,7 +94878,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96685,7 +94914,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96722,7 +94950,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96759,7 +94986,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96796,7 +95022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96833,7 +95058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96870,7 +95094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96907,7 +95130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96944,7 +95166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -96981,7 +95202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97018,7 +95238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97055,7 +95274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97092,7 +95310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97129,7 +95346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97166,7 +95382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97203,7 +95418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97240,7 +95454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97277,7 +95490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97314,7 +95526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97351,7 +95562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97388,7 +95598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97425,7 +95634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-super.ts",
@@ -97581,7 +95789,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -97937,7 +96144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -97974,7 +96180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98011,7 +96216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98048,7 +96252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98085,7 +96288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98122,7 +96324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98159,7 +96360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98196,7 +96396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98233,7 +96432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98270,7 +96468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98307,7 +96504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98344,7 +96540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98381,7 +96576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98418,7 +96612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98455,7 +96648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98492,7 +96684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98529,7 +96720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98566,7 +96756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98603,7 +96792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98640,7 +96828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98677,7 +96864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98714,7 +96900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98751,7 +96936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98788,7 +96972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -98825,7 +97008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-switch.ts",
@@ -99101,7 +97283,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -99578,7 +97759,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -99615,7 +97795,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -99951,7 +98130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -99988,7 +98166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100025,7 +98202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100062,7 +98238,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100099,7 +98274,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100136,7 +98310,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100173,7 +98346,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100210,7 +98382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100247,7 +98418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100284,7 +98454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100321,7 +98490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100358,7 +98526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100395,7 +98562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100432,7 +98598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100469,7 +98634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100506,7 +98670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100543,7 +98706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100580,7 +98742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100617,7 +98778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100654,7 +98814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100691,7 +98850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100728,7 +98886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100765,7 +98922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100802,7 +98958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100839,7 +98994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100876,7 +99030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100913,7 +99066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100950,7 +99102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -100987,7 +99138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101024,7 +99174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101061,7 +99210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101098,7 +99246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101135,7 +99282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101172,7 +99318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101209,7 +99354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101246,7 +99390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101283,7 +99426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101320,7 +99462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101357,7 +99498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101394,7 +99534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101431,7 +99570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101468,7 +99606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101505,7 +99642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101542,7 +99678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101579,7 +99714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101616,7 +99750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101653,7 +99786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101690,7 +99822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101727,7 +99858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-symbol.ts",
@@ -101883,7 +100013,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102239,7 +100368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102276,7 +100404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102313,7 +100440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102350,7 +100476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102387,7 +100512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102424,7 +100548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102461,7 +100584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102498,7 +100620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102535,7 +100656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102572,7 +100692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102609,7 +100728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102646,7 +100764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102683,7 +100800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102720,7 +100836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102757,7 +100872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102794,7 +100908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102831,7 +100944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102868,7 +100980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102905,7 +101016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102942,7 +101052,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -102979,7 +101088,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -103016,7 +101124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -103053,7 +101160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -103090,7 +101196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-this.ts",
@@ -103246,7 +101351,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103602,7 +101706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103639,7 +101742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103676,7 +101778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103713,7 +101814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103750,7 +101850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103787,7 +101886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103824,7 +101922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103861,7 +101958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103898,7 +101994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103935,7 +102030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -103972,7 +102066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104009,7 +102102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104046,7 +102138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104083,7 +102174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104120,7 +102210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104157,7 +102246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104194,7 +102282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104231,7 +102318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104268,7 +102354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104305,7 +102390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104342,7 +102426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104379,7 +102462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104416,7 +102498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104453,7 +102534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-throw.ts",
@@ -104609,7 +102689,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -104965,7 +103044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105002,7 +103080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105039,7 +103116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105076,7 +103152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105113,7 +103188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105150,7 +103224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105187,7 +103260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105224,7 +103296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105261,7 +103332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105298,7 +103368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105335,7 +103404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105372,7 +103440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105409,7 +103476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105446,7 +103512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105483,7 +103548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105520,7 +103584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105557,7 +103620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105594,7 +103656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105631,7 +103692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105668,7 +103728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105705,7 +103764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105742,7 +103800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105779,7 +103836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105816,7 +103872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-true.ts",
@@ -105972,7 +104027,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106328,7 +104382,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106365,7 +104418,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106402,7 +104454,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106439,7 +104490,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106476,7 +104526,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106513,7 +104562,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106550,7 +104598,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106587,7 +104634,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106624,7 +104670,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106661,7 +104706,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106698,7 +104742,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106735,7 +104778,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106772,7 +104814,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106809,7 +104850,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106846,7 +104886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106883,7 +104922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106920,7 +104958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106957,7 +104994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -106994,7 +105030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107031,7 +105066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107068,7 +105102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107105,7 +105138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107142,7 +105174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107179,7 +105210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107216,7 +105246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-try.ts",
@@ -107492,7 +105521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108069,7 +106097,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108106,7 +106133,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108442,7 +106468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108479,7 +106504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108516,7 +106540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108553,7 +106576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108590,7 +106612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108627,7 +106648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108664,7 +106684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108701,7 +106720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108738,7 +106756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108775,7 +106792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108812,7 +106828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108849,7 +106864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108886,7 +106900,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108923,7 +106936,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108960,7 +106972,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -108997,7 +107008,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109034,7 +107044,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109071,7 +107080,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109108,7 +107116,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109145,7 +107152,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109182,7 +107188,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109219,7 +107224,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109256,7 +107260,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109293,7 +107296,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109330,7 +107332,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109367,7 +107368,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109404,7 +107404,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109441,7 +107440,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109478,7 +107476,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109515,7 +107512,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109552,7 +107548,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109589,7 +107584,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109626,7 +107620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109663,7 +107656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109700,7 +107692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109737,7 +107728,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109774,7 +107764,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109811,7 +107800,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109848,7 +107836,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109885,7 +107872,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109922,7 +107908,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109959,7 +107944,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -109996,7 +107980,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110033,7 +108016,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110070,7 +108052,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110107,7 +108088,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110144,7 +108124,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110181,7 +108160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110218,7 +108196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110255,7 +108232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110292,7 +108268,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110329,7 +108304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110366,7 +108340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110403,7 +108376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-type.ts",
@@ -110559,7 +108531,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -110915,7 +108886,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -110952,7 +108922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -110989,7 +108958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111026,7 +108994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111063,7 +109030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111100,7 +109066,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111137,7 +109102,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111174,7 +109138,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111211,7 +109174,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111248,7 +109210,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111285,7 +109246,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111322,7 +109282,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111359,7 +109318,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111396,7 +109354,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111433,7 +109390,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111470,7 +109426,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111507,7 +109462,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111544,7 +109498,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111581,7 +109534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111618,7 +109570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111655,7 +109606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111692,7 +109642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111729,7 +109678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111766,7 +109714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-typeof.ts",
@@ -111922,7 +109869,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112358,7 +110304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112395,7 +110340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112432,7 +110376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112469,7 +110412,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112506,7 +110448,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112543,7 +110484,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112580,7 +110520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112617,7 +110556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112654,7 +110592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112691,7 +110628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112728,7 +110664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112765,7 +110700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112802,7 +110736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112839,7 +110772,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112876,7 +110808,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112913,7 +110844,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112950,7 +110880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -112987,7 +110916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113024,7 +110952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113061,7 +110988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113098,7 +111024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113135,7 +111060,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113172,7 +111096,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113209,7 +111132,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113246,7 +111168,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113283,7 +111204,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113320,7 +111240,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113357,7 +111276,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113394,7 +111312,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-var.ts",
@@ -113550,7 +111467,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -113906,7 +111822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -113943,7 +111858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -113980,7 +111894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114017,7 +111930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114054,7 +111966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114091,7 +112002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114128,7 +112038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114165,7 +112074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114202,7 +112110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114239,7 +112146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114276,7 +112182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114313,7 +112218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114350,7 +112254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114387,7 +112290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114424,7 +112326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114461,7 +112362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114498,7 +112398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114535,7 +112434,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114572,7 +112470,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114609,7 +112506,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114646,7 +112542,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114683,7 +112578,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114720,7 +112614,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114757,7 +112650,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-void.ts",
@@ -114913,7 +112805,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115269,7 +113160,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115306,7 +113196,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115343,7 +113232,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115380,7 +113268,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115417,7 +113304,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115454,7 +113340,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115491,7 +113376,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115528,7 +113412,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115565,7 +113448,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115602,7 +113484,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115639,7 +113520,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115676,7 +113556,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115713,7 +113592,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115750,7 +113628,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115787,7 +113664,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115824,7 +113700,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115861,7 +113736,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115898,7 +113772,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115935,7 +113808,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -115972,7 +113844,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116009,7 +113880,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116046,7 +113916,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116083,7 +113952,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116120,7 +113988,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116157,7 +114024,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-while.ts",
@@ -116313,7 +114179,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116669,7 +114534,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116706,7 +114570,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116743,7 +114606,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116780,7 +114642,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116817,7 +114678,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116854,7 +114714,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116891,7 +114750,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116928,7 +114786,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -116965,7 +114822,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117002,7 +114858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117039,7 +114894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117076,7 +114930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117113,7 +114966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117150,7 +115002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117187,7 +115038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117224,7 +115074,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117261,7 +115110,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117298,7 +115146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117335,7 +115182,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117372,7 +115218,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117409,7 +115254,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117446,7 +115290,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117483,7 +115326,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117520,7 +115362,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117557,7 +115398,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-with.ts",
@@ -117793,7 +115633,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118150,7 +115989,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118187,7 +116025,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118443,7 +116280,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118480,7 +116316,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118517,7 +116352,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118554,7 +116388,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118591,7 +116424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118628,7 +116460,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118665,7 +116496,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118702,7 +116532,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118739,7 +116568,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118776,7 +116604,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118813,7 +116640,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118850,7 +116676,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118887,7 +116712,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118924,7 +116748,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118961,7 +116784,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -118998,7 +116820,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119035,7 +116856,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119072,7 +116892,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119109,7 +116928,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119146,7 +116964,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119183,7 +117000,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119220,7 +117036,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119257,7 +117072,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119294,7 +117108,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119331,7 +117144,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119368,7 +117180,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119405,7 +117216,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119442,7 +117252,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119479,7 +117288,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119516,7 +117324,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119553,7 +117360,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119590,7 +117396,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119627,7 +117432,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119664,7 +117468,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119701,7 +117504,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119738,7 +117540,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119775,7 +117576,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119812,7 +117612,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119849,7 +117648,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119886,7 +117684,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119923,7 +117720,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119960,7 +117756,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -119997,7 +117792,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -120034,7 +117828,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -120071,7 +117864,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoReservedKeywords/NoReservedKeywordsTestInput-yield.ts",
@@ -120167,7 +117959,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120302,7 +118093,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120358,7 +118148,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120395,7 +118184,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120432,7 +118220,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120469,7 +118256,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120506,7 +118292,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120543,7 +118328,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-functions.ts",
@@ -120640,7 +118424,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120775,7 +118558,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120831,7 +118613,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120868,7 +118649,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120905,7 +118685,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120942,7 +118721,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -120979,7 +118757,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -121016,7 +118793,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-any-variables.ts",
@@ -121191,7 +118967,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121247,7 +119022,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121284,7 +119058,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121321,7 +119094,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121358,7 +119130,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121395,7 +119166,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121432,7 +119202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-functions.ts",
@@ -121608,7 +119377,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121645,7 +119413,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121682,7 +119449,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121719,7 +119485,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121756,7 +119521,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121793,7 +119557,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121830,7 +119593,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -121867,7 +119629,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-literals.ts",
@@ -122042,7 +119803,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122098,7 +119858,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122135,7 +119894,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122172,7 +119930,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122209,7 +119966,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122246,7 +120002,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122283,7 +120038,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-string-variables.ts",
@@ -122419,7 +120173,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122456,7 +120209,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122493,7 +120245,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122530,7 +120281,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122567,7 +120317,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122604,7 +120353,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122641,7 +120389,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122678,7 +120425,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122715,7 +120461,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122752,7 +120497,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122789,7 +120533,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122826,7 +120569,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122863,7 +120605,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122900,7 +120641,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -122937,7 +120677,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutFailingTestInput-walker-error.ts",
@@ -123093,7 +120832,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -123128,7 +120866,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error.ts",
@@ -123185,7 +120922,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123222,7 +120958,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123259,7 +120994,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123296,7 +121030,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123413,7 +121146,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123470,7 +121202,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123505,7 +121236,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123542,7 +121272,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123579,7 +121308,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123616,7 +121344,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123653,7 +121380,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123690,7 +121416,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123727,7 +121452,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123764,7 +121488,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123801,7 +121524,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123838,7 +121560,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123875,7 +121596,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123912,7 +121632,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123949,7 +121668,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -123986,7 +121704,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -124023,7 +121740,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -124060,7 +121776,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -124097,7 +121812,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error3.ts",
@@ -124233,7 +121947,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124270,7 +121983,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124307,7 +122019,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124344,7 +122055,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124381,7 +122091,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124418,7 +122127,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124455,7 +122163,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124492,7 +122199,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124529,7 +122235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124566,7 +122271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124603,7 +122307,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124640,7 +122343,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124677,7 +122379,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124714,7 +122415,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124751,7 +122451,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error4.ts",
@@ -124788,7 +122487,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -124905,7 +122603,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -124940,7 +122637,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -124977,7 +122673,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125014,7 +122709,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125051,7 +122745,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125088,7 +122781,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125125,7 +122817,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125162,7 +122853,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125199,7 +122889,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125236,7 +122925,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125273,7 +122961,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125310,7 +122997,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125347,7 +123033,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125384,7 +123069,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoStringBasedSetTimeout/NoStringBasedSetTimeoutTestInput-error5.ts",
@@ -125481,7 +123165,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125516,7 +123199,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125553,7 +123235,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125590,7 +123271,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125627,7 +123307,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125664,7 +123343,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125761,7 +123439,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125798,7 +123475,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125835,7 +123511,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125872,7 +123547,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/NoUnnecessarySemicolonsTestInput.ts",
@@ -125946,7 +123620,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/references.ts",
@@ -125983,7 +123656,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/references.ts",
@@ -126020,7 +123692,6 @@
           ],
           "fixes": [
             {
-              "description": "",
               "fileChanges": [
                 {
                   "uri": "file:///C:/a2/_work/6/s/SecureApp/ts/test-data/references.ts",


### PR DESCRIPTION
Please read the description of Bug #663.

The fix is one line. It induces a change to a single unit test. Six of the 11 TSLint functional test data files formerly included lines `"description": ""` in their `fix` objects; those lines no longer appear.