### PR TITLE
Fix #667: Generate SARIF OM files with correct license

### DIFF
--- a/src/Sarif/Autogenerated/AlgorithmKind.cs
+++ b/src/Sarif/Autogenerated/AlgorithmKind.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/AnnotatedCodeLocation.cs
+++ b/src/Sarif/Autogenerated/AnnotatedCodeLocation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/AnnotatedCodeLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AnnotatedCodeLocationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/AnnotatedCodeLocationImportance.cs
+++ b/src/Sarif/Autogenerated/AnnotatedCodeLocationImportance.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/AnnotatedCodeLocationKind.cs
+++ b/src/Sarif/Autogenerated/AnnotatedCodeLocationKind.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/Annotation.cs
+++ b/src/Sarif/Autogenerated/Annotation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/AnnotationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/AnnotationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/BaselineState.cs
+++ b/src/Sarif/Autogenerated/BaselineState.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/CodeFlow.cs
+++ b/src/Sarif/Autogenerated/CodeFlow.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/CodeFlowEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ExceptionData.cs
+++ b/src/Sarif/Autogenerated/ExceptionData.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExceptionDataEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FileChange.cs
+++ b/src/Sarif/Autogenerated/FileChange.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FileChangeEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FileChangeEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FileData.cs
+++ b/src/Sarif/Autogenerated/FileData.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FileDataEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FileDataEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Fix.cs
+++ b/src/Sarif/Autogenerated/Fix.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FixEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FixEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FormattedRuleMessage.cs
+++ b/src/Sarif/Autogenerated/FormattedRuleMessage.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/FormattedRuleMessageEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/FormattedRuleMessageEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Hash.cs
+++ b/src/Sarif/Autogenerated/Hash.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/HashEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/HashEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/IRule.cs
+++ b/src/Sarif/Autogenerated/IRule.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ISarifNode.cs
+++ b/src/Sarif/Autogenerated/ISarifNode.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/Invocation.cs
+++ b/src/Sarif/Autogenerated/Invocation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/InvocationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Location.cs
+++ b/src/Sarif/Autogenerated/Location.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/LocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LocationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/LogicalLocation.cs
+++ b/src/Sarif/Autogenerated/LogicalLocation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/LogicalLocationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Notification.cs
+++ b/src/Sarif/Autogenerated/Notification.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/NotificationLevel.cs
+++ b/src/Sarif/Autogenerated/NotificationLevel.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Region.cs
+++ b/src/Sarif/Autogenerated/Region.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/RegionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RegionEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Replacement.cs
+++ b/src/Sarif/Autogenerated/Replacement.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReplacementEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Result.cs
+++ b/src/Sarif/Autogenerated/Result.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ResultEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResultEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ResultLevel.cs
+++ b/src/Sarif/Autogenerated/ResultLevel.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/Rule.cs
+++ b/src/Sarif/Autogenerated/Rule.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/RuleConfiguration.cs
+++ b/src/Sarif/Autogenerated/RuleConfiguration.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/RuleEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RuleEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/Run.cs
+++ b/src/Sarif/Autogenerated/Run.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SarifLog.cs
+++ b/src/Sarif/Autogenerated/SarifLog.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SarifLogEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SarifNodeKind.cs
+++ b/src/Sarif/Autogenerated/SarifNodeKind.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SarifVersion.cs
+++ b/src/Sarif/Autogenerated/SarifVersion.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/Stack.cs
+++ b/src/Sarif/Autogenerated/Stack.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/StackEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/StackFrame.cs
+++ b/src/Sarif/Autogenerated/StackFrame.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/SuppressionStates.cs
+++ b/src/Sarif/Autogenerated/SuppressionStates.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/TaintKind.cs
+++ b/src/Sarif/Autogenerated/TaintKind.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CodeDom.Compiler;
 

--- a/src/Sarif/Autogenerated/Tool.cs
+++ b/src/Sarif/Autogenerated/Tool.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/Autogenerated/ToolEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ToolEqualityComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.CodeDom.Compiler;

--- a/src/Sarif/CopyrightNotice.txt
+++ b/src/Sarif/CopyrightNotice.txt
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft.  All Rights Reserved.
-// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 


### PR DESCRIPTION
Modified `src\Sarif\CopyrightNotice.txt` to contain the same copyright notice as the rest of the source files in the SDK.