### PR TITLE
Fix #666: File, Open doesn't bring Error List into view

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Sarif.Viewer.ErrorList
 
             log = JsonConvert.DeserializeObject<SarifLog>(logText, settings);
             ProcessSarifLog(log, filePath, solution);
+
+            SarifTableDataSource.Instance.BringToFront();
         }
 
         internal static void ProcessSarifLog(SarifLog sarifLog, string logFilePath, Solution solution)

--- a/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
+++ b/src/Sarif.Viewer.VisualStudio/OpenLogFileCommands.cs
@@ -249,8 +249,6 @@ namespace Microsoft.Sarif.Viewer
             }
 
             ErrorListService.ProcessLogFile(logFile, SarifViewerPackage.Dte.Solution, toolFormat);
-
-            SarifTableDataSource.Instance.BringToFront();
         }
 
         bool IsSarifProtocol(string path)


### PR DESCRIPTION
**The symptom**

If you did **File**, **Open** on a `.sarif` file, but the Error List Window was not already visible, the Error List Window would not be made visible. In contrast, if you did **Tools**, **Open Static Analysis Log File**, **Open SARIF File**, the Error List Window _would_ be made visible.

**The explanation**

The `ProvideEditorExtension` attribute on the `SarifViewerPackage` class registers the `SarifEditorFactory` class as the handler for **File**, **Open** on files with the `.sarif` extension. The `SarifEditorFactory` class, in turn, implements the `IVSEditorFactory` interface, and its implementation of that interface's `CreateEditorInstance` method is what reads the SARIF log file and populates the Error List Window, by calling `ErrorListService.ProcessLogFile`.

However, `SarifEditorFactory.CreateEditorInstance` was _not_ calling the method `SarifDataTableSource.Instance.BringToFront` (which in turn calls `SarifViewerPackage.Dte.ExecuteCommand("View.ErrorList")`), so the Error List Window would not appear if it was not already visible. In contrast, the the method `OpenLogFileCommands.MenuItemCallback`, which handles the **Tools**, **Open Static Analysis Log File** command, _did_ follow the call to `ErrorListService.ProcessLogFile` with a call to `SarifDataTableSource.Instance.BringToFront`.

**The solution**

I considered two options:
1. Add a call to `SarifDataTableSource.Instance.BringToFront` at the end of `SarifEditorFactory.CreateEditorInstance`.
2. Have `ErrorListService.ProcessLogFile` itself call `SarifDataTableSource.Instance.BringToFront`.

I chose option #&#8203;2, for these reasons:
- It's more maintainable. If we add another code path that opens a `.sarif` file, we don't have to remember to call both `ErrorListService.ProcessLogFile` and `SarifDataTableSource.Instance.BringToFront`.
- The act of bringing the Error List Window into view seems more closely related to the `ErrorListService` class than to the `SarifEditorFactory` class.

**Testing**

Neither the `SarifEditorFactory` class nor the `ErrorListService` class is unit testable. We should discuss whether to take this opportunity to improve that, so I can add a test for this change.