### PR TITLE
Refactor: Inject dependencies into CodeAnalysisResultsManager

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CommonDialogFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/CommonDialogFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer
+{
+    public class CommonDialogFactory : ICommonDialogFactory
+    {
+        public IOpenFileDialog CreateOpenFileDialog()
+        {
+            return new RealOpenFileDialog();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/ICommonDialogFactory.cs
+++ b/src/Sarif.Viewer.VisualStudio/ICommonDialogFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer
+{
+    public interface ICommonDialogFactory
+    {
+        IOpenFileDialog CreateOpenFileDialog();
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/IKeyboard.cs
+++ b/src/Sarif.Viewer.VisualStudio/IKeyboard.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace Microsoft.Sarif.Viewer
+{
+    public interface IKeyboard
+    {
+        IInputElement FocusedElement { get; }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/IOpenFileDialog.cs
+++ b/src/Sarif.Viewer.VisualStudio/IOpenFileDialog.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sarif.Viewer
+{
+    public interface IOpenFileDialog
+    {
+        string Title { get; set; }
+
+        string Filter { get; set; }
+
+        bool RestoreDirectory { get; set; }
+
+        string FileName { get; }
+
+        bool? ShowDialog();
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/RealKeyboard.cs
+++ b/src/Sarif.Viewer.VisualStudio/RealKeyboard.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Windows;
+using System.Windows.Input;
+
+namespace Microsoft.Sarif.Viewer
+{
+    internal class RealKeyboard : IKeyboard
+    {
+        public IInputElement FocusedElement => Keyboard.FocusedElement;
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/RealOpenFileDialog.cs
+++ b/src/Sarif.Viewer.VisualStudio/RealOpenFileDialog.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32;
+
+namespace Microsoft.Sarif.Viewer
+{
+    internal class RealOpenFileDialog : IOpenFileDialog
+    {
+        private readonly OpenFileDialog _dialog;
+
+        internal RealOpenFileDialog()
+        {
+            _dialog = new OpenFileDialog();
+        }
+
+        public string Title
+        {
+            get => _dialog.Title;
+
+            set { _dialog.Title = value; }
+        }
+
+        public string Filter
+        {
+            get => _dialog.Filter;
+
+            set { _dialog.Filter = value; }
+        }
+
+        public bool RestoreDirectory
+        {
+            get => _dialog.RestoreDirectory;
+
+            set { _dialog.RestoreDirectory = value; }
+        }
+
+        public string FileName => _dialog.FileName;
+
+        public bool? ShowDialog()
+        {
+            return _dialog.ShowDialog();
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -58,6 +58,9 @@
     <Compile Include="Converters\ObjectToVisibilityConverter.cs" />
     <Compile Include="DelegateCommand.cs" />
     <Compile Include="DelegateCommandBase.cs" />
+    <Compile Include="IKeyboard.cs" />
+    <Compile Include="IOpenFileDialog.cs" />
+    <Compile Include="ICommonDialogFactory.cs" />
     <Compile Include="IToolWindow.cs" />
     <Compile Include="KeyValuePairPropertyDescriptor.cs" />
     <Compile Include="Models\CallTreeCollection.cs" />
@@ -68,7 +71,10 @@
     <Compile Include="Models\ReplacementModel.cs" />
     <Compile Include="Models\FileChangeModel.cs" />
     <Compile Include="Models\FixModel.cs" />
+    <Compile Include="CommonDialogFactory.cs" />
     <Compile Include="ProjectNameCache.cs" />
+    <Compile Include="RealKeyboard.cs" />
+    <Compile Include="RealOpenFileDialog.cs" />
     <Compile Include="Resource1.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -104,5 +104,34 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             return File.ReadAllText(path, encoding);
         }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">
+        /// The file to write to.
+        /// </param>
+        /// <param name="contents">
+        /// The string to write to the file.
+        /// </param>
+        public void WriteAllText(string path, string contents)
+        {
+            File.WriteAllText(path, contents);
+        }
+
+        /// <summary>
+        /// Sets the specified <see cref="FileAttributes"/> of the file on the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path to the file.
+        /// </param>
+        /// <param name="fileAttributes">
+        /// A bitwise combination of the enumeration values.
+        /// </param>
+        public void SetAttributes(string path, FileAttributes fileAttributes)
+        {
+            File.SetAttributes(path, fileAttributes);
+        }
     }
 }

--- a/src/Sarif/IFileSystem.cs
+++ b/src/Sarif/IFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -86,5 +87,28 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A string containing all text in the file.
         /// </returns>
         string ReadAllText(string path, Encoding encoding);
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">
+        /// The file to write to.
+        /// </param>
+        /// <param name="contents">
+        /// The string to write to the file.
+        /// </param>
+        void WriteAllText(string path, string contents);
+
+        /// <summary>
+        /// Sets the specified <see cref="FileAttributes"/> of the file on the specified path.
+        /// </summary>
+        /// <param name="path">
+        /// The path to the file.
+        /// </param>
+        /// <param name="fileAttributes">
+        /// A bitwise combination of the enumeration values.
+        /// </param>
+        void SetAttributes(string path, FileAttributes fileAttributes);
     }
 }


### PR DESCRIPTION
This is Step 1 of my plan for fixing Bug #623, and getting `CodeAnalysisResultManager` under test in the process. There will be four PRs, as follows:

1.	Inject dependencies into `CodeAnalysisResultManager`. <= THIS PR
2.	Write unit tests for `CodeAnalysisResultManager.GetRebaselinedFileName`.
3.	Fix Bug #623 (and add unit test).
4.	Perform further refactoring on `CodeAnalysisResultManager.GetRebaselinedFileName`.

The idea behind Step 4 is that after Step 3, we’ll still have this really nasty method, but now we’ll be able to safely refactor it.
