### PR TITLE
Fix #623: Path rebase fails if path mentioned in SARIF file differs from resolved path only in drive letter

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -155,5 +155,83 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Should().BeEmpty();
         }
+
+        [Fact]
+        public void CodeAnalysisResultManager_GetRebaselinedFileName_WhenUserDoesNotSelectRebaselinedPath_UsesPathFromLogFile()
+        {
+            // Arrange.
+            const string FileNameInLogFile = @"C:\Code\sarif-sdk\src\Sarif\Notes.cs";
+
+            // The user does not select a file in the File Open dialog:
+            this.openFileDialogResult = false;
+
+            var target = new CodeAnalysisResultManager(
+                null,                               // This test never touches the file system.
+                this.keyboard,
+                this.commonDialogFactory);
+
+            // Act.
+            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+
+            // Assert.
+            rebaselinedFileName.Should().Be(FileNameInLogFile);
+
+            Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
+            remappedPathPrefixes.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CodeAnalysisResultManager_GetRebaselinedFileName_WhenRebaselinedPathDiffersOnlyInDriveLetter_ReturnsRebaselinedPath()
+        {
+            // Arrange.
+            const string FileNameInLogFile = @"C:\Code\sarif-sdk\src\Sarif\Notes.cs";
+            const string RebaselinedFileName = @"D:\Code\sarif-sdk\src\Sarif\Notes.cs";
+
+            this.openFileDialogFileName = RebaselinedFileName;
+            this.openFileDialogResult = true;
+
+            var target = new CodeAnalysisResultManager(
+                null,                               // This test never touches the file system.
+                this.keyboard,
+                this.commonDialogFactory);
+
+            // Act.
+            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+
+            // Assert.
+            rebaselinedFileName.Should().Be(RebaselinedFileName);
+
+            Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
+            remappedPathPrefixes.Length.Should().Be(1);
+            remappedPathPrefixes[0].Item1.Should().Be(@"C:");
+            remappedPathPrefixes[0].Item2.Should().Be(@"D:");
+        }
+
+        [Fact]
+        public void CodeAnalysisResultManager_GetRebaselinedFileName_WhenRebaselinedPathHasMoreComponents_ReturnsRebaselinedPath()
+        {
+            // Arrange.
+            const string FileNameInLogFile = @"C:\Code\sarif-sdk\src\Sarif\Notes.cs";
+            const string RebaselinedFileName = @"C:\Users\Mary\Code\sarif-sdk\src\Sarif\Notes.cs";
+
+            this.openFileDialogFileName = RebaselinedFileName;
+            this.openFileDialogResult = true;
+
+            var target = new CodeAnalysisResultManager(
+                null,                               // This test never touches the file system.
+                this.keyboard,
+                this.commonDialogFactory);
+
+            // Act.
+            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+
+            // Assert.
+            rebaselinedFileName.Should().Be(RebaselinedFileName);
+
+            Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
+            remappedPathPrefixes.Length.Should().Be(1);
+            remappedPathPrefixes[0].Item1.Should().Be(@"C:");
+            remappedPathPrefixes[0].Item2.Should().Be(@"C:\Users\Mary");
+        }
     }
 }

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/CodeAnalysisResultManagerTests.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 this.commonDialogFactory);
 
             // Act.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(RebaselinedFileName);
+            actualRebaselinedFileName.Should().Be(RebaselinedFileName);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Length.Should().Be(1);
@@ -116,10 +116,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
             this.mockOpenFileDialog.Verify(ofd => ofd.ShowDialog(), Times.Once());
 
             // Act: Rebaseline a second file with the same prefix.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: SecondFileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: SecondFileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(SecondRebaselinedFileName);
+            actualRebaselinedFileName.Should().Be(SecondRebaselinedFileName);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Length.Should().Be(1);
@@ -147,10 +147,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 this.commonDialogFactory);
 
             // Act.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(FileNameInLogFile);
+            actualRebaselinedFileName.Should().Be(FileNameInLogFile);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Should().BeEmpty();
@@ -171,10 +171,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 this.commonDialogFactory);
 
             // Act.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(FileNameInLogFile);
+            actualRebaselinedFileName.Should().Be(FileNameInLogFile);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Should().BeEmpty();
@@ -196,10 +196,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 this.commonDialogFactory);
 
             // Act.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(RebaselinedFileName);
+            actualRebaselinedFileName.Should().Be(RebaselinedFileName);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Length.Should().Be(1);
@@ -223,10 +223,10 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
                 this.commonDialogFactory);
 
             // Act.
-            string rebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
+            string actualRebaselinedFileName = target.GetRebaselinedFileName(uriBaseId: null, fileName: FileNameInLogFile);
 
             // Assert.
-            rebaselinedFileName.Should().Be(RebaselinedFileName);
+            actualRebaselinedFileName.Should().Be(RebaselinedFileName);
 
             Tuple<string, string>[] remappedPathPrefixes = target.GetRemappedPathPrefixes();
             remappedPathPrefixes.Length.Should().Be(1);

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -456,6 +456,11 @@ namespace Microsoft.Sarif.Viewer
                 int nextResolvedOffset = resolvedPath.LastIndexOf('\\', resolvedOffset - 1);
                 int nextFullPathOffset = fullPath.LastIndexOf('\\', fullPathOffset - 1);
 
+                if (nextResolvedOffset == -1 || nextFullPathOffset == -1)
+                {
+                    break;
+                }
+
                 string resolvedTail = resolvedPath.Substring(nextResolvedOffset);
                 string fullPathTail = fullPath.Substring(nextFullPathOffset);
 


### PR DESCRIPTION
This is Step 3 of my plan to fix Bug #623, and get `CodeAnalysisResultManager` under test in the process. There will be four PRs, as follows:

1.	Inject dependencies into `CodeAnalysisResultManager`. **DONE** PR #670
2.	Write unit tests for `CodeAnalysisResultManager.GetRebaselinedFileName`. **DONE** PR #671
3.	Fix Bug #623 (and add unit test). **<= THIS PR**
4.	Perform further refactoring on `CodeAnalysisResultManager.GetRebaselinedFileName`.

It turns out that the bug was more general, as you will see by the last of the three unit tests I added.