### PR TITLE
 Refactor: Extract CodeAnalysisResultManager.GetCommonSuffix

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -548,17 +548,12 @@ namespace Microsoft.Sarif.Viewer
         // until they differ or until we reach the beginning.
         private static string GetCommonSuffix(string firstPath, string secondPath)
         {
-            // If the paths have different file names, they have no common suffix.
-            string commonSuffix = Path.GetFileName(firstPath);
-            if (!Path.GetFileName(secondPath).Equals(commonSuffix, StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
+            string commonSuffix = null;
 
-            int firstSuffixOffset = firstPath.Length - commonSuffix.Length;
-            int secondSuffixOffset = secondPath.Length - commonSuffix.Length;
+            int firstSuffixOffset = firstPath.Length;
+            int secondSuffixOffset = secondPath.Length;
 
-            while (secondSuffixOffset >= 0 && firstSuffixOffset >= 0)
+            while (firstSuffixOffset >= 0 && secondSuffixOffset >= 0)
             {
                 firstSuffixOffset = firstPath.LastIndexOf('\\', firstSuffixOffset - 1);
                 secondSuffixOffset = secondPath.LastIndexOf('\\', secondSuffixOffset - 1);

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -563,7 +563,7 @@ namespace Microsoft.Sarif.Viewer
                 firstSuffixOffset = firstPath.LastIndexOf('\\', firstSuffixOffset - 1);
                 secondSuffixOffset = secondPath.LastIndexOf('\\', secondSuffixOffset - 1);
 
-                if (secondSuffixOffset == -1 || firstSuffixOffset == -1)
+                if (firstSuffixOffset == -1 || secondSuffixOffset == -1)
                 {
                     break;
                 }

--- a/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeAnalysisResultManager.cs
@@ -544,7 +544,7 @@ namespace Microsoft.Sarif.Viewer
             return resolvedPath;
         }
 
-        // Find the common suffix between two paths by walking both paths backwards until
+        // Find the common suffix between two paths by walking both paths backwards
         // until they differ or until we reach the beginning.
         private static string GetCommonSuffix(string firstPath, string secondPath)
         {


### PR DESCRIPTION
The main purpose of this PR is to extract the method `GetCommonSuffix`, the logic of which originally appeared inline in `GetRebaselinedFileName`. Also, the original code had a comment claiming that it found a common suffix, and in effect that's what it did, but the common suffix itself never appeared in the code, which made it harder to understand. The new, extracted method differs from the original, inlined logic in that it really does “surface” the common suffix to the reader.

Also, I changed the signature of `PromptForResolvedPath` to avoid use of an `out` parameter. Code with `out` parameters is generally harder to understand than code with a simple return value. This also simplifies the method itself.