### PR TITLE
Fix #679: Region tooltip does not display region values

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
+++ b/src/Sarif.Viewer.VisualStudio/CodeLocationObject.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using System.ComponentModel;
 
 namespace Microsoft.Sarif.Viewer
 {
@@ -37,7 +37,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        internal Region Region
+        public Region Region
         {
             get
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Sarif.Viewer
             }
         }
 
-        internal virtual string FilePath
+        public virtual string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/Models/AnnotatedCodeLocationModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/AnnotatedCodeLocationModel.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        internal override string FilePath
+        public override string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/StackFrameModel.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
-using Microsoft.CodeAnalysis.Sarif;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
@@ -101,7 +95,7 @@ namespace Microsoft.Sarif.Viewer.Models
             }
         }
 
-        internal override string FilePath
+        public override string FilePath
         {
             get
             {

--- a/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
@@ -3,10 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:Microsoft.Sarif.Viewer.Views"
-             xmlns:viewer="clr-namespace:Microsoft.Sarif.Viewer"
-             xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
-             xmlns:models="clr-namespace:Microsoft.Sarif.Viewer.Models"
              xmlns:viewModels="clr-namespace:Microsoft.Sarif.Viewer.ViewModels"
              xmlns:converters="clr-namespace:Microsoft.Sarif.Viewer.Converters"
              xmlns:controls="clr-namespace:Microsoft.Sarif.Viewer.Controls"
@@ -28,6 +24,23 @@
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Fixes.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Information.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <ToolTip x:Key="LocationToolTip"
+                     DataContext="{Binding Path=PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                <WrapPanel Orientation="Horizontal">
+                    <TextBlock>
+                        <Run Text="{Binding FilePath, Mode=OneWay}" />
+                    </TextBlock>
+                    <TextBlock Visibility="{Binding Region.StartLine, Converter={StaticResource int32ToVisibilityConverter}}">
+                        <Run Text=" Line" />
+                        <Run Text="{Binding Region.StartLine, Mode=OneWay}" />
+                    </TextBlock>
+                    <TextBlock Visibility="{Binding Region.StartColumn, Converter={StaticResource int32ToVisibilityConverter}}">
+                        <Run Text=" Col" />
+                        <Run Text="{Binding Region.StartColumn, Mode=OneWay}" />
+                    </TextBlock>
+                </WrapPanel>
+            </ToolTip>
         </ResourceDictionary>
 
     </UserControl.Resources>
@@ -75,22 +88,8 @@
                                Margin="7 0 7 1"/>
                     <DockPanel DockPanel.Dock="Left" 
                                DataContext="{Binding Locations[0]}"
-                               HorizontalAlignment="Stretch">
-                        <DockPanel.ToolTip>
-                            <WrapPanel Orientation="Horizontal">
-                                <TextBlock>
-                                    <Run Text="{Binding FilePath, Mode=OneWay}" />
-                                </TextBlock>
-                                <TextBlock Visibility="{Binding Region.StartLine, Converter={StaticResource int32ToVisibilityConverter}}">
-                                    <Run Text=" Line" />
-                                    <Run Text="{Binding Region.StartLine, Mode=OneWay}" />
-                                </TextBlock>
-                                <TextBlock Visibility="{Binding Region.StartColumn, Converter={StaticResource int32ToVisibilityConverter}}">
-                                    <Run Text=" Col" />
-                                    <Run Text="{Binding Region.StartColumn, Mode=OneWay}" />
-                                </TextBlock>
-                            </WrapPanel>
-                        </DockPanel.ToolTip>
+                               HorizontalAlignment="Stretch"
+                               ToolTip="{StaticResource LocationToolTip}">
                         <TextBlock DockPanel.Dock="Left"
                                    Foreground="Gray"
                                    VerticalAlignment="Bottom"

--- a/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
+++ b/src/Sarif.Viewer.VisualStudio/Views/CodeLocations.xaml
@@ -24,23 +24,6 @@
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Fixes.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Microsoft.Sarif.Viewer;component/Themes/Information.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-            <ToolTip x:Key="LocationToolTip"
-                     DataContext="{Binding Path=PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
-                <WrapPanel Orientation="Horizontal">
-                    <TextBlock>
-                        <Run Text="{Binding FilePath, Mode=OneWay}" />
-                    </TextBlock>
-                    <TextBlock Visibility="{Binding Region.StartLine, Converter={StaticResource int32ToVisibilityConverter}}">
-                        <Run Text=" Line" />
-                        <Run Text="{Binding Region.StartLine, Mode=OneWay}" />
-                    </TextBlock>
-                    <TextBlock Visibility="{Binding Region.StartColumn, Converter={StaticResource int32ToVisibilityConverter}}">
-                        <Run Text=" Col" />
-                        <Run Text="{Binding Region.StartColumn, Mode=OneWay}" />
-                    </TextBlock>
-                </WrapPanel>
-            </ToolTip>
         </ResourceDictionary>
 
     </UserControl.Resources>
@@ -88,8 +71,25 @@
                                Margin="7 0 7 1"/>
                     <DockPanel DockPanel.Dock="Left" 
                                DataContext="{Binding Locations[0]}"
-                               HorizontalAlignment="Stretch"
-                               ToolTip="{StaticResource LocationToolTip}">
+                               HorizontalAlignment="Stretch">
+                        <DockPanel.ToolTip>
+                            <ToolTip
+                                DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                <WrapPanel Orientation="Horizontal">
+                                    <TextBlock>
+                                        <Run Text="{Binding FilePath, Mode=OneWay}" />
+                                    </TextBlock>
+                                    <TextBlock Visibility="{Binding Region.StartLine, Converter={StaticResource int32ToVisibilityConverter}}">
+                                        <Run Text=" Line" />
+                                        <Run Text="{Binding Region.StartLine, Mode=OneWay}" />
+                                    </TextBlock>
+                                    <TextBlock Visibility="{Binding Region.StartColumn, Converter={StaticResource int32ToVisibilityConverter}}">
+                                        <Run Text=" Col" />
+                                        <Run Text="{Binding Region.StartColumn, Mode=OneWay}" />
+                                    </TextBlock>
+                                </WrapPanel>
+                            </ToolTip>
+                        </DockPanel.ToolTip>
                         <TextBlock DockPanel.Dock="Left"
                                    Foreground="Gray"
                                    VerticalAlignment="Bottom"


### PR DESCRIPTION
There were two distinct problems:

1. As stated in the bug, the `ToolTip` was attempting to use the `DataContext` from the `DockPanel` to which it was attached. But a `ToolTip` is not a part of the visual tree of the object to which it is attached, so this doesn't work. The Stack Overflow item https://stackoverflow.com/questions/2212171/wpf-tooltip-binding shows a technique for working around this.

2. Even with the `ToolTips`'s data context correctly set, the data was still not displayed, because the properties to which the UI was bound were not public.