### PR TITLE
Fix #502: Spec violation: Driver framework doesn't emit empty results array

### DIFF
--- a/src/Sarif.Driver.UnitTests/SarifHelpers.cs
+++ b/src/Sarif.Driver.UnitTests/SarifHelpers.cs
@@ -13,12 +13,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             ValidateTool(run.Tool);
 
-            if (run.Results != null)
+            Assert.NotNull(run.Results);
+            foreach (Result result in run.Results)
             {
-                foreach (Result result in run.Results)
-                {
-                    resultAction(result);
-                }
+                resultAction(result);
             }
 
             if (run.ToolNotifications != null)
@@ -32,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public static void ValidateTool(Tool tool)
         {
-            Assert.Equal("Sarif", tool.Name);
             // TODO version, etc
         }
     }

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -316,8 +316,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                         LoggingOptions loggingOptions;
                         loggingOptions = analyzeOptions.ConvertToLoggingOptions();
 
-                        aggregatingLogger.Loggers.Add(
-                                new SarifLogger(
+                        var sarifLogger = new SarifLogger(
                                     analyzeOptions.OutputFilePath,
                                     loggingOptions,
                                     null, 
@@ -325,7 +324,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                                     targets,
                                     Prerelease,
                                     invocationTokensToRedact: GenerateSensitiveTokensList(),
-                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog));
+                                    invocationPropertiesToLog: analyzeOptions.InvocationPropertiesToLog);
+                        sarifLogger.AnalysisStarted();
+                        aggregatingLogger.Loggers.Add(sarifLogger);
                     },
                     (ex) =>
                     {


### PR DESCRIPTION
`SarifLogger.AnalysisStarted` opens the `results` array in the JSON output. But at the point where the driver calls `AggregatingLogger.AnalysisStarted` (AnalyzeCommandBase.cs, Line 72), the `AggregatingLogger` doesn't yet contain a `SarifLogger`. The `SarifLogger` isn't created until the call to `InitializeOutputFile` (Line 97). So `SarifLogger.AnalysisStarted` was never called, and the `results` array was never opened.

If the analysis tool detected and logged a result, then the `SarifLogger` would lazily open the `results` array. But if the analysis tool did not detect any results, the resulting log file would not contain a `results` array, which violates the SARIF spec.

The fix is to call `AnalysisStarted` on the `SarifLogger` as soon as we create it. We could instead have had the `SarifLogger`'s ctor open the `results` array, but I'm not comfortable with the ctor writing to the output file. I'm open to pushback on this.

The unit test that should have caught this was `AnalyzeCommandBaseTests.AnalyzeCommand_EndToEndAnalysisWithNoIssues`. The reason it didn't was that the helper function `SarifHelpers.ValidateRun` allowed `run.Results` to be `null`. I fixed that, and now that test fails without this fix, and passes when I introduce the fix.

Also:
- I removed a line from `SarifHelpers.ValidateTool` which caused the test to fail. In VS, at least, `tool.Name` was `"testHost"`, not `"Sarif"`. I don't know how this could ever have passed.