### PR TITLE
Fix #523: Generalize a logged message

### DIFF
--- a/src/Sarif/Notes.cs
+++ b/src/Sarif/Notes.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             Debug.Assert(context.TargetUri != null);
 
-            // '{0}' was not evaluated for check '{1}' as the analysis
-            // is not relevant based on observed metadata: {2}.
+            // '{0}' was not evaluated for check '{1}' because the analysis
+            // is not relevant for the following reason: {2}.
             context.Logger.Log(context.Rule,
                 RuleUtilities.BuildResult(ResultLevel.NotApplicable, context, null,
                     nameof(SdkResources.NotApplicable_InvalidMetadata),

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was not evaluated for check &apos;{1}&apos; as the analysis is not relevant based on observed metadata: {2}..
+        ///   Looks up a localized string similar to &apos;{0}&apos; was not evaluated for check &apos;{1}&apos; because the analysis is not relevant for the following reason: {2}..
         /// </summary>
         internal static string NotApplicable_InvalidMetadata {
             get {

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -145,7 +145,7 @@
     <value>'{0}' was not analyzed as it does not appear to be a valid file type for analysis.</value>
   </data>
   <data name="NotApplicable_InvalidMetadata" xml:space="preserve">
-    <value>'{0}' was not evaluated for check '{1}' as the analysis is not relevant based on observed metadata: {2}.</value>
+    <value>'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}.</value>
   </data>
   <data name="MSG_AnalysisCompletedSuccessfully" xml:space="preserve">
     <value>Analysis completed successfully.</value>


### PR DESCRIPTION
One of the messages logged by the SDK is specific to BinSkim. Rephrase it to be more generally applicable.

@michaelcfanning This is pretty old; I don't remember why I thought it was specific to BinSkim. Maybe because it referred to metadata in a managed assembly? Anyway, please take a look.