### PR TITLE
Fix #581: Resolve dependencies of plug-ins

### DIFF
--- a/src/Sarif.Converters.UnitTests/ToolFormatConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/ToolFormatConverterTests.cs
@@ -160,9 +160,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                 // provides the converter with a delegate which simulates the failure to load the
                 // plugin assembly.
                 const string Message = "Something went dreadfully wrong.";
-                AssemblyLoadFileDelegate assemblyLoadFileDelegate = path => throw new BadImageFormatException(Message);
+                AssemblyLoadFromDelegate assemblyLoadFromDelegate = path => throw new BadImageFormatException(Message);
 
-                var converter = new ToolFormatConverter(assemblyLoadFileDelegate);
+                var converter = new ToolFormatConverter(assemblyLoadFromDelegate);
 
                 Action action = () => converter.ConvertToStandardFormat(
                     ToolName,

--- a/src/Sarif.Converters/PluginConverterFactory.cs
+++ b/src/Sarif.Converters/PluginConverterFactory.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
-    public delegate Assembly AssemblyLoadFileDelegate(string path);
+    public delegate Assembly AssemblyLoadFromDelegate(string path);
 
     // Factory class for creating a converter from a specified plug-in assembly.
     internal class PluginConverterFactory : ConverterFactory
@@ -17,13 +17,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         // This field is internal, rather than private, for test purposes.
         internal readonly string pluginAssemblyPath;
 
-        private readonly AssemblyLoadFileDelegate assemblyLoadFileDelegate;
+        private readonly AssemblyLoadFromDelegate assemblyLoadFromDelegate;
 
         internal PluginConverterFactory(
             string pluginAssemblyPath,
-            AssemblyLoadFileDelegate assemblyLoadFileDelegate = null)
+            AssemblyLoadFromDelegate assemblyLoadFromDelegate = null)
         {
-            this.assemblyLoadFileDelegate = assemblyLoadFileDelegate ?? Assembly.LoadFile;
+            this.assemblyLoadFromDelegate = assemblyLoadFromDelegate ?? Assembly.LoadFrom;
             this.pluginAssemblyPath = pluginAssemblyPath;
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 throw new ArgumentException(message, nameof(this.pluginAssemblyPath));
             }
 
-            Assembly pluginAssembly = this.assemblyLoadFileDelegate(this.pluginAssemblyPath);
+            Assembly pluginAssembly = this.assemblyLoadFromDelegate(this.pluginAssemblyPath);
             Type[] pluginTypes = pluginAssembly
                 .GetTypes()
                 .Where(t => IsConverterClassForToolFormat(t, toolFormat))

--- a/src/Sarif.Converters/ToolFormatConverter.cs
+++ b/src/Sarif.Converters/ToolFormatConverter.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     /// </summary>
     public class ToolFormatConverter
     {
-        private readonly AssemblyLoadFileDelegate assemblyLoadFileDelegate;
+        private readonly AssemblyLoadFromDelegate assemblyLoadFromDelegate;
 
-        public ToolFormatConverter(AssemblyLoadFileDelegate assemblyLoadFileDelegate = null)
+        public ToolFormatConverter(AssemblyLoadFromDelegate assemblyLoadFromDelegate = null)
         {
-            this.assemblyLoadFileDelegate = assemblyLoadFileDelegate;
+            this.assemblyLoadFromDelegate = assemblyLoadFromDelegate;
         }
 
         /// <summary>Converts a tool log file into the SARIF format.</summary>
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             ConverterFactory factory = new BuiltInConverterFactory();
             if (!string.IsNullOrWhiteSpace(pluginAssemblyPath))
             {
-                factory = new PluginConverterFactory(pluginAssemblyPath, this.assemblyLoadFileDelegate)
+                factory = new PluginConverterFactory(pluginAssemblyPath, this.assemblyLoadFromDelegate)
                 {
                     Next = factory,
                 };


### PR DESCRIPTION
This is the second of two changes to address suggestions made by @michealfanning on the pull request where I introduced the pluging model for converters (PR #580). The first change was PR #685.

In this change, we address a problem that occurs when you run the `Sarif.Multitool convert` command with the `--plugin-assembly-path` option, and supply a plugin which

1. is not in the same directory as the conversion tool executable, and
2. itself depends on assemblies that are present in the plugin's directory, but are _not_ present in the conversion tool directory.

In that case, when the conversion tool loaded the plugin, the CLR would attempt to resolve the plugin's dependencies, and it would fail because those dependencies are not on the assembly search path.

The article [Best Practices for Assembly Loading](https://docs.microsoft.com/en-us/dotnet/framework/deployment/best-practices-for-assembly-loading) explains the problem.

The problem was that we were loading the plugin assembly with `Assembly.LoadFile`. As a result, the assembly was not loaded into any "load context", and its dependencies were not automatically found.

The fix is to load the plugin assembly with `Assembly.LoadFrom`. This causes the plugin to be loaded into the "load from context", and causes the plugin's dependencies to be automatically loaded from the same context.