### PR TITLE
Fix #700: Viewer: COMException from VS when opening PFX task document

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open File.
+        /// </summary>
+        internal static string FileOpenFail_DialogCaption {
+            get {
+                return ResourceManager.GetString("FileOpenFail_DialogCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; couldn&apos;t be opened by Visual Studio. Would you like to open the containing folder?.
+        /// </summary>
+        internal static string FileOpenFail_DialogMessage {
+            get {
+                return ResourceManager.GetString("FileOpenFail_DialogMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Return.
         /// </summary>
         internal static string ReturnMessage {

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -117,6 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FileOpenFail_DialogCaption" xml:space="preserve">
+    <value>Open File</value>
+  </data>
+  <data name="FileOpenFail_DialogMessage" xml:space="preserve">
+    <value>The file '{0}' couldn't be opened by Visual Studio. Would you like to open the containing folder?</value>
+    <comment>{0} will be the name of the file that couldn't be opened</comment>
+  </data>
   <data name="ReturnMessage" xml:space="preserve">
     <value>Return</value>
     <comment>Displayed on a call tree "CallReturn" node</comment>

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -571,8 +571,8 @@ namespace Microsoft.Sarif.Viewer
             catch (COMException)
             {
                 string fname = Path.GetFileName(file);
-                if (MessageBox.Show($"The file '{fname}' couldn't be opened by Visual Studio. Would you like to open the containing folder?",
-                                    "Open File",
+                if (MessageBox.Show(string.Format(Resources.FileOpenFail_DialogMessage, fname),
+                                    Resources.FileOpenFail_DialogCaption,
                                     MessageBoxButtons.YesNo,
                                     MessageBoxIcon.Exclamation) == DialogResult.Yes)
                 {

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -551,19 +551,35 @@ namespace Microsoft.Sarif.Viewer
                 return null;
             }
 
-            if (usePreviewPane)
+            try
             {
-                // The scope below ensures that if a document is not yet open, it is opened in the preview pane.
-                // For documents that are already open, they will remain in their current pane, which may be the preview
-                // pane or the full editor pane.
-                using (new NewDocumentStateScope(__VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate, Microsoft.VisualStudio.VSConstants.NewDocumentStateReason.Navigation))
+                if (usePreviewPane)
+                {
+                    // The scope below ensures that if a document is not yet open, it is opened in the preview pane.
+                    // For documents that are already open, they will remain in their current pane, which may be the preview
+                    // pane or the full editor pane.
+                    using (new NewDocumentStateScope(__VSNEWDOCUMENTSTATE.NDS_Provisional | __VSNEWDOCUMENTSTATE.NDS_NoActivate, Microsoft.VisualStudio.VSConstants.NewDocumentStateReason.Navigation))
+                    {
+                        return OpenDocumentInCurrentScope(provider, file);
+                    }
+                }
+                else
                 {
                     return OpenDocumentInCurrentScope(provider, file);
                 }
             }
-            else
+            catch (COMException)
             {
-                return OpenDocumentInCurrentScope(provider, file);
+                string fname = Path.GetFileName(file);
+                if (MessageBox.Show($"The file '{fname}' couldn't be opened by Visual Studio. Would you like to open the containing folder?",
+                                    "Open File",
+                                    MessageBoxButtons.YesNo,
+                                    MessageBoxIcon.Exclamation) == DialogResult.Yes)
+                {
+                    System.Diagnostics.Process.Start(Path.GetDirectoryName(file));
+                }
+
+                return null;
             }
         }
 


### PR DESCRIPTION
Handle file-open failure and give the user the option to open the folder instead.