### PR TITLE
Fix multitool package

### DIFF
--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -77,8 +77,6 @@ call BuildPackages.cmd %Configuration% %Platform% %NuGetOutputDirectory% %Versio
 ::Create layout directory of assemblies that need to be signed
 call CreateLayoutDirectory.cmd .\bld\bin\ %Configuration% %Platform%
 
-goto Exit
-
 @REM Run all multitargeting xunit tests
 call :RunMultitargetingTests Sarif Unit                 || goto :ExitFailed
 call :RunMultitargetingTests Sarif Functional           || goto :ExitFailed

--- a/BuildAndTest.cmd
+++ b/BuildAndTest.cmd
@@ -77,6 +77,8 @@ call BuildPackages.cmd %Configuration% %Platform% %NuGetOutputDirectory% %Versio
 ::Create layout directory of assemblies that need to be signed
 call CreateLayoutDirectory.cmd .\bld\bin\ %Configuration% %Platform%
 
+goto Exit
+
 @REM Run all multitargeting xunit tests
 call :RunMultitargetingTests Sarif Unit                 || goto :ExitFailed
 call :RunMultitargetingTests Sarif Functional           || goto :ExitFailed

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -14,12 +14,11 @@ call :BuildNuGetPackage Sarif.Converters %Version% || goto :ExitFailed
 ::Build pre-release packages
 call :BuildNuGetPackage Sarif.Driver    %Version%-beta || goto :ExitFailed
 
-::Build Multitool with dependencies included
-::call :BuildNuGetPackage Sarif.Multitool %Version%-beta || goto :ExitFailed
+::Build Multitool package from nuspec
 echo .
 echo Building Sarif.Multitool package...
-echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
-.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
+echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
+.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
 if "%ERRORLEVEL%" NEQ "0" (echo Sarif.Multitool NuGet package creation FAILED.)
 Exit /B %ERRORLEVEL%
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -18,8 +18,8 @@ call :BuildNuGetPackage Sarif.Driver    %Version%-beta || goto :ExitFailed
 ::call :BuildNuGetPackage Sarif.Multitool %Version%-beta || goto :ExitFailed
 echo .
 echo Building Sarif.Multitool package...
-echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version%-beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
-.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version%-beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
+echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
+.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
 if "%ERRORLEVEL%" NEQ "0" (echo Sarif.Multitool NuGet package creation FAILED.)
 Exit /B %ERRORLEVEL%
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -15,7 +15,7 @@ call :BuildNuGetPackageFromCsproj Sarif.Converters %Version% || goto :ExitFailed
 call :BuildNuGetPackageFromCsproj Sarif.Driver    %Version%-beta || goto :ExitFailed
 
 ::Build Multitool package from nuspec
-call :BuildNuGetPackageFromNuspec Sarif.Multitool %Version% beta || goto :ExitFailed
+call BuildNuGetPackageFromNuspec Sarif.Multitool %Version% beta || goto :ExitFailed
 
 goto Exit
 
@@ -30,12 +30,12 @@ Exit /B %ERRORLEVEL%
 
 :BuildNuGetPackageFromNuspec
 set NuGetProject=%1
-set PackOptions=-Symbols -Properties configuration=%Configuration%;version=%2 -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
-set Suffix=%3
+set PackOptions=-Symbols -Properties configuration=%Configuration%;version=%Version% -Verbosity Quiet
+set Suffix=%2
 if "%Suffix%" NEQ "" (
 set Suffix=-Suffix %Suffix%
 )
-.nuget\NuGet.exe pack .\src\Nuget\%NuGetProject%.nuspec %PackOptions% %Suffix%
+.nuget\NuGet.exe pack .\src\Nuget\%NuGetProject%.nuspec %PackOptions% %Suffix% -BasePath .\ -OutputDirectory %NuGetOutputDirectory%
 if "%ERRORLEVEL%" NEQ "0" (echo %NuGetProject% NuGet package creation FAILED.)
 Exit /B %ERRORLEVEL%
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -8,28 +8,34 @@ set NuGetOutputDirectory=%3
 set Version=%4
 
 ::Build release packages
-call :BuildNuGetPackage Sarif            %Version% || goto :ExitFailed
-call :BuildNuGetPackage Sarif.Converters %Version% || goto :ExitFailed
+call :BuildNuGetPackageFromCsproj Sarif            %Version% || goto :ExitFailed
+call :BuildNuGetPackageFromCsproj Sarif.Converters %Version% || goto :ExitFailed
 
 ::Build pre-release packages
-call :BuildNuGetPackage Sarif.Driver    %Version%-beta || goto :ExitFailed
+call :BuildNuGetPackageFromCsproj Sarif.Driver    %Version%-beta || goto :ExitFailed
 
 ::Build Multitool package from nuspec
-echo .
-echo Building Sarif.Multitool package...
-echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
-.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties configuration=%Configuration%;version=%Version% -Suffix beta -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
-if "%ERRORLEVEL%" NEQ "0" (echo Sarif.Multitool NuGet package creation FAILED.)
-Exit /B %ERRORLEVEL%
+call BuildNuGetPackageFromNuspec Sarif.Multitool %Version% beta || goto :ExitFailed
 
 goto Exit
 
-:BuildNuGetPackage
+:BuildNuGetPackageFromCsproj
 set NuGetProject=%1
 set PackOptions=--configuration %Configuration% --no-build -p:Platform=%Platform% -o %NuGetOutputDirectory% --include-source --include-symbols -p:PackageVersion=%2
 echo .
 echo dotnet pack %~p0src\%NuGetProject%\%NuGetProject%.csproj %PackOptions%
 dotnet pack %~p0src\%NuGetProject%\%NuGetProject%.csproj %PackOptions%
+if "%ERRORLEVEL%" NEQ "0" (echo %NuGetProject% NuGet package creation FAILED.)
+Exit /B %ERRORLEVEL%
+
+:BuildNuGetPackageFromNuspec
+set NuGetProject=%1
+set PackOptions=-Symbols -Properties configuration=%Configuration%;version=%Version% -Verbosity Quiet
+set Suffix=%2
+if "%Suffix%" NEQ "" (
+set Suffix=-Suffix %Suffix%
+)
+.nuget\NuGet.exe pack .\src\Nuget\%NuGetProject%.nuspec %PackOptions% %Suffix% -BasePath .\ -OutputDirectory %NuGetOutputDirectory%
 if "%ERRORLEVEL%" NEQ "0" (echo %NuGetProject% NuGet package creation FAILED.)
 Exit /B %ERRORLEVEL%
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -15,7 +15,7 @@ call :BuildNuGetPackageFromCsproj Sarif.Converters %Version% || goto :ExitFailed
 call :BuildNuGetPackageFromCsproj Sarif.Driver    %Version%-beta || goto :ExitFailed
 
 ::Build Multitool package from nuspec
-call BuildNuGetPackageFromNuspec Sarif.Multitool %Version% beta || goto :ExitFailed
+call :BuildNuGetPackageFromNuspec Sarif.Multitool %Version% beta || goto :ExitFailed
 
 goto Exit
 
@@ -30,12 +30,12 @@ Exit /B %ERRORLEVEL%
 
 :BuildNuGetPackageFromNuspec
 set NuGetProject=%1
-set PackOptions=-Symbols -Properties configuration=%Configuration%;version=%Version% -Verbosity Quiet
-set Suffix=%2
+set PackOptions=-Symbols -Properties configuration=%Configuration%;version=%2 -Verbosity Quiet -BasePath .\ -OutputDirectory .\bld\bin\Nuget
+set Suffix=%3
 if "%Suffix%" NEQ "" (
 set Suffix=-Suffix %Suffix%
 )
-.nuget\NuGet.exe pack .\src\Nuget\%NuGetProject%.nuspec %PackOptions% %Suffix% -BasePath .\ -OutputDirectory %NuGetOutputDirectory%
+.nuget\NuGet.exe pack .\src\Nuget\%NuGetProject%.nuspec %PackOptions% %Suffix%
 if "%ERRORLEVEL%" NEQ "0" (echo %NuGetProject% NuGet package creation FAILED.)
 Exit /B %ERRORLEVEL%
 

--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -13,7 +13,15 @@ call :BuildNuGetPackage Sarif.Converters %Version% || goto :ExitFailed
 
 ::Build pre-release packages
 call :BuildNuGetPackage Sarif.Driver    %Version%-beta || goto :ExitFailed
-call :BuildNuGetPackage Sarif.Multitool %Version%-beta || goto :ExitFailed
+
+::Build Multitool with dependencies included
+::call :BuildNuGetPackage Sarif.Multitool %Version%-beta || goto :ExitFailed
+echo .
+echo Building Sarif.Multitool package...
+echo .nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version%-beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
+.nuget\NuGet.exe pack .\src\Nuget\Sarif.Multitool.nuspec -Symbols -Properties id=Sarif.Multitool;configuration=%Configuration%;version=%Version%-beta -Verbosity Quiet -BasePath .\bld\bin -OutputDirectory .\bld\bin\Nuget
+if "%ERRORLEVEL%" NEQ "0" (echo Sarif.Multitool NuGet package creation FAILED.)
+Exit /B %ERRORLEVEL%
 
 goto Exit
 

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -21,7 +21,7 @@
 	  <!-- NOTE: the exclude attribute must be on a single line -->
     <file src="bld\bin\AnyCPU_$configuration$\**\*"
           target="lib"
-          exclude="**\*Multitool*;**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
+          exclude="**\*Multitool*;**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Castle.Core.dll;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
 
     <!-- Restore the netstandard assemblies from the package cache -->
     <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netcoreapp2.0" />

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>.NET Static Analysis Results Interchange Format (SARIF) Multitool</title>
+    <authors>Microsoft Corporation</authors>
+    <owners>Michael C. Fanning, Larry Golding</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>.NET utility for working with the Static Analysis Results Interchange Format v1.0.0.</description>
+    <releaseNotes>Version $version$ of the .NET SARIF Multitool (for SARIF v1.0.0)</releaseNotes>
+    <copyright>Copyright Microsoft 2015</copyright>
+    <licenseUrl>https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/microsoft/sarif-sdk</projectUrl>
+    <tags>sarifmultitool</tags>
+  </metadata>
+  <files>
+	<!-- NOTE: the exclude attribute must be on a single line -->
+    <file src="AnyCPU_$configuration$\**\*"
+          target="lib"
+		  exclude="**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
+				   
+    <!-- Restore the netstandard assemblies from the package cache -->
+    <file src="..\..\src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netcoreapp2.0" />
+    <file src="..\..\src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netstandard2.0" />
+    <file src="..\..\src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netcoreapp2.0" />
+    <file src="..\..\src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netstandard2.0" />
+    <file src="..\..\src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netcoreapp2.0" />
+    <file src="..\..\src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netstandard2.0" />
+    
+    <file src="..\..\src\ReleaseHistory.md" />        
+    <file src="..\..\src\Sarif.Multitool\**\*.cs" target="src" />
+  </files>
+</package>

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -6,12 +6,12 @@
     <title>Microsoft SARIF Multitool (includes SARIF SDK)</title>
     <authors>Microsoft Corporation</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>SARIF-based classes and utilities for building static analysis drivers. Includes the SARIF SDK.</description>
+    <description>Multi-purpose command line tool for analyzing and manipulating SARIF files</description>
     <releaseNotes>Version $version$ of the .NET SARIF Multitool (for SARIF v1.0.0)</releaseNotes>
     <copyright>Copyright Microsoft 2015</copyright>
     <licenseUrl>https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/microsoft/sarif-sdk</projectUrl>
-    <tags>command line driver utilities static analysis sarif framework utils driver.utilities</tags>
+    <tags>SARIF command line static analysis</tags>
   </metadata>
   <files>
 	  <!-- NOTE: the exclude attribute must be on a single line -->

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -1,34 +1,37 @@
 ﻿<?xml version="1.0"?>
-<package >
+<package>
   <metadata>
-    <id>$id$</id>
+    <id>Sarif.Multitool</id>
     <version>$version$</version>
-    <title>.NET Static Analysis Results Interchange Format (SARIF) Multitool</title>
+    <title>Microsoft SARIF Multitool (includes SARIF SDK)</title>
     <authors>Microsoft Corporation</authors>
-    <owners>Michael C. Fanning, Larry Golding</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>.NET utility for working with the Static Analysis Results Interchange Format v1.0.0.</description>
+    <description>SARIF-based classes and utilities for building static analysis drivers. Includes the SARIF SDK.</description>
     <releaseNotes>Version $version$ of the .NET SARIF Multitool (for SARIF v1.0.0)</releaseNotes>
     <copyright>Copyright Microsoft 2015</copyright>
     <licenseUrl>https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/microsoft/sarif-sdk</projectUrl>
-    <tags>sarifmultitool</tags>
+    <tags>command line driver utilities static analysis sarif framework utils driver.utilities</tags>
   </metadata>
   <files>
-	<!-- NOTE: the exclude attribute must be on a single line -->
-    <file src="AnyCPU_$configuration$\**\*"
+    <file src="bld\bin\AnyCPU_$configuration$\**\*Multitool*"
+          target="tools"
+          exclude="**\*Tests*"/>
+
+	  <!-- NOTE: the exclude attribute must be on a single line -->
+    <file src="bld\bin\AnyCPU_$configuration$\**\*"
           target="lib"
-		  exclude="**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
-				   
+          exclude="**\*Multitool*;**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
+
     <!-- Restore the netstandard assemblies from the package cache -->
-    <file src="..\..\src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netcoreapp2.0" />
-    <file src="..\..\src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netstandard2.0" />
-    <file src="..\..\src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netcoreapp2.0" />
-    <file src="..\..\src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netstandard2.0" />
-    <file src="..\..\src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netcoreapp2.0" />
-    <file src="..\..\src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netstandard2.0" />
-    
-    <file src="..\..\src\ReleaseHistory.md" />        
-    <file src="..\..\src\Sarif.Multitool\**\*.cs" target="src" />
+    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netcoreapp2.0" />
+    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netstandard2.0" />
+    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netcoreapp2.0" />
+    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netstandard2.0" />
+    <file src="src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netcoreapp2.0" />
+    <file src="src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netstandard2.0" />
+
+    <file src="src\ReleaseHistory.md" />        
+    <file src="src\Sarif.Multitool\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -14,22 +14,18 @@
     <tags>command line driver utilities static analysis sarif framework utils driver.utilities</tags>
   </metadata>
   <files>
-    <file src="bld\bin\AnyCPU_$configuration$\**\*Multitool*"
-          target="tools"
-          exclude="**\*Tests*"/>
-
 	  <!-- NOTE: the exclude attribute must be on a single line -->
     <file src="bld\bin\AnyCPU_$configuration$\**\*"
-          target="lib"
-          exclude="**\*Multitool*;**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Castle.Core.dll;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
+          target="tools"
+          exclude="**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Castle.Core.dll;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
 
     <!-- Restore the netstandard assemblies from the package cache -->
-    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netcoreapp2.0" />
-    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="lib\netstandard2.0" />
-    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netcoreapp2.0" />
-    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.dll" target="lib\netstandard2.0" />
-    <file src="src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netcoreapp2.0" />
-    <file src="src\packages\newtonsoft.json\*\lib\netstandard1.3\Newtonsoft.Json.dll" target="lib\netstandard2.0" />
+    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.dll" target="tools\netcoreapp2.0" />
+    <file src="src\packages\CommandLineParser.*\tools\netstandard1.5\CommandLine.dll" target="tools\netstandard2.0" />
+    <file src="src\packages\CsvHelper.*\tools\netstandard1.3\CsvHelper.dll" target="tools\netcoreapp2.0" />
+    <file src="src\packages\CsvHelper.*\tools\netstandard1.3\CsvHelper.dll" target="tools\netstandard2.0" />
+    <file src="src\packages\newtonsoft.json\*\tools\netstandard1.3\Newtonsoft.Json.dll" target="tools\netcoreapp2.0" />
+    <file src="src\packages\newtonsoft.json\*\tools\netstandard1.3\Newtonsoft.Json.dll" target="tools\netstandard2.0" />
 
     <file src="src\ReleaseHistory.md" />        
     <file src="src\Sarif.Multitool\**\*.cs" target="src" />

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -14,8 +14,6 @@
     <StartupObject></StartupObject>
   </PropertyGroup>
 
-  <!--NuGet metadata located in src\Nuget\Sarif.Multitool.nuspec-->
-
   <ItemGroup>
     <Compile Remove="Rules\**" />
     <EmbeddedResource Remove="Rules\**" />

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -14,20 +14,7 @@
     <StartupObject></StartupObject>
   </PropertyGroup>
 
-  <!--NuGet Config-->
-  <PropertyGroup>
-    <IsTool>true</IsTool>
-    <PackageId>Sarif.Multitool</PackageId>
-    <Title>Microsoft SARIF Multitool (includes SARIF SDK)</Title>
-    <Authors>Microsoft Corporation</Authors>
-    <Description>SARIF-based classes and utilities for building static analysis drivers. Includes the SARIF SDK.</Description>
-    <PackageReleaseNotes>Version $(Version) of the .NET SARIF SDK (for SARIF v1.0.0)</PackageReleaseNotes>
-    <Copyright>Copyright Microsoft 2015</Copyright>
-    <PackageLicenseUrl>https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/microsoft/sarif-sdk</PackageProjectUrl>
-    <PackageTags>command line driver utilities static analysis sarif framework utils driver.utilities</PackageTags>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-  </PropertyGroup>
+  <!--NuGet metadata located in src\Nuget\Sarif.Multitool.nuspec-->
 
   <ItemGroup>
     <Compile Remove="Rules\**" />


### PR DESCRIPTION
Build the Sarif.Multitool standalone NuGet package using a nuspec manifest so we can include all of the dependent reference assemblies.