### PR TITLE
Add TC-approved rule.help to the schema.

### DIFF
--- a/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
+++ b/src/Sarif.Driver.UnitTests/ExceptionRaisingRule.cs
@@ -27,6 +27,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public Uri HelpUri { get; set; }
 
+        public string Help => null;
+
         public string Id
         {
             get

--- a/src/Sarif.Driver/Sdk/SkimmerBase.cs
+++ b/src/Sarif.Driver/Sdk/SkimmerBase.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         abstract public Uri HelpUri { get;  }
 
+        abstract public string Help { get; }
+
         private IDictionary<string, string> messageFormats;
 
         abstract protected ResourceManager ResourceManager { get; }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
@@ -74,9 +74,13 @@ namespace Microsoft.Sarif.Viewer.Sarif
                         helpUri = new Uri(RuleMetadata[ruleId]["url"].Value<string>());
                     }
 
+                    // PREfast rules don't have or need a "help" property; they all have online documentation.
+                    // The rule.help property is only useful in scenarios where there's no online documentation.
+                    string help = null;
+
                     if (ruleName != null || helpUri != null)
                     {
-                        rule = new Rule(ruleId, ruleName, null, null, null, RuleConfiguration.Unknown, ResultLevel.Warning, helpUri, null);
+                        rule = new Rule(ruleId, ruleName, null, null, null, RuleConfiguration.Unknown, ResultLevel.Warning, helpUri, help, null);
                     }
                 }
             }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Run.extensions.cs
@@ -74,13 +74,19 @@ namespace Microsoft.Sarif.Viewer.Sarif
                         helpUri = new Uri(RuleMetadata[ruleId]["url"].Value<string>());
                     }
 
-                    // PREfast rules don't have or need a "help" property; they all have online documentation.
-                    // The rule.help property is only useful in scenarios where there's no online documentation.
-                    string help = null;
-
                     if (ruleName != null || helpUri != null)
                     {
-                        rule = new Rule(ruleId, ruleName, null, null, null, RuleConfiguration.Unknown, ResultLevel.Warning, helpUri, help, null);
+                        rule = new Rule(
+                            ruleId,
+                            ruleName,
+                            shortDescription: null,
+                            fullDescription: null,
+                            messageFormats: null,
+                            configuration: RuleConfiguration.Unknown,
+                            defaultLevel: ResultLevel.Warning,
+                            helpUri: helpUri,
+                            help: null, // PREfast rules don't need a "help" property; they all have online documentation.
+                            properties: null);
                     }
                 }
             }

--- a/src/Sarif/Autogenerated/IRule.cs
+++ b/src/Sarif/Autogenerated/IRule.cs
@@ -53,5 +53,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A URI where the primary documentation for the rule can be found.
         /// </summary>
         Uri HelpUri { get; }
+
+        /// <summary>
+        /// Provides the primary documentation for the rule, useful when there is no on-line documentation.
+        /// </summary>
+        string Help { get; }
     }
 }

--- a/src/Sarif/Autogenerated/IRule.cs
+++ b/src/Sarif/Autogenerated/IRule.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         Uri HelpUri { get; }
 
         /// <summary>
-        /// Provides the primary documentation for the rule, useful when there is no on-line documentation.
+        /// Provides the primary documentation for the rule, useful when there is no online documentation.
         /// </summary>
         string Help { get; }
     }

--- a/src/Sarif/Autogenerated/Rule.cs
+++ b/src/Sarif/Autogenerated/Rule.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri HelpUri { get; set; }
 
         /// <summary>
-        /// Provides the primary documentation for the rule, useful when there is no on-line documentation.
+        /// Provides the primary documentation for the rule, useful when there is no online documentation.
         /// </summary>
         [DataMember(Name = "help", IsRequired = false, EmitDefaultValue = false)]
         public string Help { get; set; }

--- a/src/Sarif/Autogenerated/Rule.cs
+++ b/src/Sarif/Autogenerated/Rule.cs
@@ -81,6 +81,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         public Uri HelpUri { get; set; }
 
         /// <summary>
+        /// Provides the primary documentation for the rule, useful when there is no on-line documentation.
+        /// </summary>
+        [DataMember(Name = "help", IsRequired = false, EmitDefaultValue = false)]
+        public string Help { get; set; }
+
+        /// <summary>
         /// Key/value pairs that provide additional information about the rule.
         /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
@@ -120,12 +126,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="helpUri">
         /// An initialization value for the <see cref="P: HelpUri" /> property.
         /// </param>
+        /// <param name="help">
+        /// An initialization value for the <see cref="P: Help" /> property.
+        /// </param>
         /// <param name="properties">
         /// An initialization value for the <see cref="P: Properties" /> property.
         /// </param>
-        public Rule(string id, string name, string shortDescription, string fullDescription, IDictionary<string, string> messageFormats, RuleConfiguration configuration, ResultLevel defaultLevel, Uri helpUri, IDictionary<string, SerializedPropertyInfo> properties)
+        public Rule(string id, string name, string shortDescription, string fullDescription, IDictionary<string, string> messageFormats, RuleConfiguration configuration, ResultLevel defaultLevel, Uri helpUri, string help, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(id, name, shortDescription, fullDescription, messageFormats, configuration, defaultLevel, helpUri, properties);
+            Init(id, name, shortDescription, fullDescription, messageFormats, configuration, defaultLevel, helpUri, help, properties);
         }
 
         /// <summary>
@@ -144,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Id, other.Name, other.ShortDescription, other.FullDescription, other.MessageFormats, other.Configuration, other.DefaultLevel, other.HelpUri, other.Properties);
+            Init(other.Id, other.Name, other.ShortDescription, other.FullDescription, other.MessageFormats, other.Configuration, other.DefaultLevel, other.HelpUri, other.Help, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -165,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Rule(this);
         }
 
-        private void Init(string id, string name, string shortDescription, string fullDescription, IDictionary<string, string> messageFormats, RuleConfiguration configuration, ResultLevel defaultLevel, Uri helpUri, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(string id, string name, string shortDescription, string fullDescription, IDictionary<string, string> messageFormats, RuleConfiguration configuration, ResultLevel defaultLevel, Uri helpUri, string help, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Id = id;
             Name = name;
@@ -183,6 +192,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 HelpUri = new Uri(helpUri.OriginalString, helpUri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
             }
 
+            Help = help;
             if (properties != null)
             {
                 Properties = new Dictionary<string, SerializedPropertyInfo>(properties);

--- a/src/Sarif/Autogenerated/RuleEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RuleEqualityComparer.cs
@@ -85,6 +85,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.Help != right.Help)
+            {
+                return false;
+            }
+
             if (!object.ReferenceEquals(left.Properties, right.Properties))
             {
                 if (left.Properties == null || right.Properties == null || left.Properties.Count != right.Properties.Count)
@@ -161,6 +166,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.HelpUri != null)
                 {
                     result = (result * 31) + obj.HelpUri.GetHashCode();
+                }
+
+                if (obj.Help != null)
+                {
+                    result = (result * 31) + obj.Help.GetHashCode();
                 }
 
                 if (obj.Properties != null)

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -904,6 +904,11 @@
           "format": "uri"
         },
 
+        "help": {
+          "description": "Provides the primary documentation for the rule, useful when there is no on-line documentation.",
+          "type": "string"
+        },
+
         "properties": {
           "description": "Key/value pairs that provide additional information about the rule.",
           "type": "object",

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -905,7 +905,7 @@
         },
 
         "help": {
-          "description": "Provides the primary documentation for the rule, useful when there is no on-line documentation.",
+          "description": "Provides the primary documentation for the rule, useful when there is no online documentation.",
           "type": "string"
         },
 


### PR DESCRIPTION
The SARIF TC approved the addition of a `help` property to the `rule` object. This property contains help text for the rule, and is useful when there is no online documentation for the rule (for example, when an analysis tool allows developers to author their own rules, for which there is no online documentation).

The primary change is in Sarif.schema.json. That leads to changes in three of the SARIF OM files that the build process auto-generates from the schema. Finally, a few source files need to be updated to take account of the new property.