### PR TITLE
Schema changes for OASIS #61, #69, #72

### DIFF
--- a/src/Sarif.Converters/PREFastConverter.cs
+++ b/src/Sarif.Converters/PREFastConverter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var resultsFileUri = new Uri($"{defect.SFA.FilePath}{defect.SFA.FileName}", UriKind.Relative);
-            var physicalLocation = new PhysicalLocation(uri: resultsFileUri, uriBaseId: null, region: region);
+            var physicalLocation = new PhysicalLocation(id: 0, uri: resultsFileUri, uriBaseId: null, region: region);
             var location = new Location()
             {
                 ResultFile = physicalLocation,
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 };
 
                 var uri = new Uri($"{sfa.FilePath}{sfa.FileName}", UriKind.Relative);
-                var fileLocation = new PhysicalLocation(uri: uri, uriBaseId: null, region: region);
+                var fileLocation = new PhysicalLocation(id: 0, uri: uri, uriBaseId: null, region: region);
                 var annotatedCodeLocation = new AnnotatedCodeLocation
                 {
                     PhysicalLocation = fileLocation,

--- a/src/Sarif.Converters/PylintConverter.cs
+++ b/src/Sarif.Converters/PylintConverter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
 
             var fileUri = new Uri($"{defect.FilePath}", UriKind.RelativeOrAbsolute);
-            var physicalLocation = new PhysicalLocation(uri: fileUri, uriBaseId: null, region: region);
+            var physicalLocation = new PhysicalLocation(id: 0, uri: fileUri, uriBaseId: null, region: region);
 
             var location = new Location
             {

--- a/src/Sarif.Converters/TSLintConverter.cs
+++ b/src/Sarif.Converters/TSLintConverter.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             Uri analysisTargetUri = new Uri(entry.Name, UriKind.Relative);
 
-            PhysicalLocation analysisTarget = new PhysicalLocation(uri: analysisTargetUri, uriBaseId: null, region: region);
+            PhysicalLocation analysisTarget = new PhysicalLocation(id: 0, uri: analysisTargetUri, uriBaseId: null, region: region);
             Location location = new Location()
             {
                 AnalysisTarget = analysisTarget

--- a/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
+++ b/src/Sarif.FunctionalTests/SpecExamples/Comprehensive.sarif
@@ -183,9 +183,13 @@
               "frames": [
                 {
                   "message": "Exception thrown.",
-                  "uri": "file:///home/buildAgent/src/collections/list.h",
-                  "line": 110,
-                  "column": 15,
+                  "physicalLocation": {
+                    "uri": "file:///home/buildAgent/src/collections/list.h",
+                    "region": {
+                      "startLine": 110,
+                      "startColumn":  15
+                    }
+                  },
                   "module": "platform",
                   "threadId": 52,
                   "fullyQualifiedLogicalName": "collections::list:add_core",
@@ -194,9 +198,13 @@
                   "parameters": [ "null", "0", "14" ]
                 },
                 {
-                  "uri": "file:///home/buildAgent/src/collections/list.h",
-                  "line": 43,
-                  "column": 15,
+                  "physicalLocation": {
+                    "uri": "file:///home/buildAgent/src/collections/list.h",
+                    "region": {
+                      "startLine": 43,
+                      "startColumn": 15
+                    }
+                  },
                   "module": "platform",
                   "threadId": 52,
                   "fullyQualifiedLogicalName": "collections::list:add",
@@ -205,9 +213,13 @@
                   "parameters": [ "14" ]
                 },
                 {
-                  "uri": "file:///home/buildAgent/src/application/main.cpp",
-                  "line": 28,
-                  "column": 9,
+                  "physicalLocation": {
+                    "uri": "file:///home/buildAgent/src/application/main.cpp",
+                    "region": {
+                      "startLine": 28,
+                      "startColumn": 9
+                    }
+                  },
                   "module": "application",
                   "threadId": 52,
                   "fullyQualifiedLogicalName": "main",

--- a/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Sarif.UnitTests/Writers/ResultLogJsonWriterTests.cs
@@ -263,14 +263,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                                     {
                                         Module = "a.dll",
                                         FullyQualifiedLogicalName = "N1.N2.C.M1",
-                                        Line = 10
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                            Region = new Region
+                                            {
+                                                StartLine = 10
+                                            }
+                                        }
                                     },
 
                                     new StackFrame
                                     {
                                         Module = "a.dll",
                                         FullyQualifiedLogicalName = "N1.N2.C.M2",
-                                        Line = 6
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                            Region = new Region
+                                            {
+                                                StartLine = 6
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -304,12 +316,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 ""stack"": {
                   ""frames"": [
                     {
-                      ""line"": 10,
+                      ""physicalLocation"": {
+                        ""region"": {
+                          ""startLine"": 10
+                        }
+                      },
                       ""module"": ""a.dll"",
                       ""fullyQualifiedLogicalName"": ""N1.N2.C.M1""
                     },
                     {
-                      ""line"": 6,
+                      ""physicalLocation"": {
+                        ""region"": {
+                          ""startLine"": 6
+                        }
+                      },
                       ""module"": ""a.dll"",
                       ""fullyQualifiedLogicalName"": ""N1.N2.C.M2""
                     }

--- a/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
+++ b/src/Sarif.UnitTests/Writers/SarifLoggerTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                                 {
                                     new StackFrame
                                     {
-                                        Uri = new Uri(@"file:///file4.cpp")
+                                        PhysicalLocation = new PhysicalLocation { Uri = new Uri(@"file:///file4.cpp") }
                                     }
                                 }
                             }

--- a/src/Sarif.Viewer.VisualStudio/Sarif/StackFrame.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/StackFrame.extensions.cs
@@ -3,12 +3,6 @@
 
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Sarif.Viewer.Models;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Sarif.Viewer.Sarif
 {
@@ -19,13 +13,22 @@ namespace Microsoft.Sarif.Viewer.Sarif
             StackFrameModel model = new StackFrameModel();
 
             model.Address = stackFrame.Address;
-            model.Column = stackFrame.Column;
             model.FullyQualifiedLogicalName = stackFrame.FullyQualifiedLogicalName;
-            model.Line = stackFrame.Line;
             model.Message = stackFrame.Message;
             model.Module = stackFrame.Module;
             model.Offset = stackFrame.Offset;
-            model.FilePath = stackFrame.Uri.ToPath();
+
+            PhysicalLocation physicalLocation = stackFrame.PhysicalLocation;
+            if (physicalLocation != null)
+            {
+                model.FilePath = physicalLocation.Uri.ToPath();
+                Region region = physicalLocation.Region;
+                if (region != null)
+                {
+                    model.Line = region.StartLine;
+                    model.Column = region.StartColumn;
+                }
+            }
 
             return model;
         }

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -32,6 +32,12 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         /// <summary>
+        /// Value that distinguishes this physical location from all other physical locations in this run object.
+        /// </summary>
+        [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
+        public int Id { get; set; }
+
+        /// <summary>
         /// The location of the file as a valid URI.
         /// </summary>
         [DataMember(Name = "uri", IsRequired = false, EmitDefaultValue = false)]
@@ -59,6 +65,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalLocation" /> class from the supplied values.
         /// </summary>
+        /// <param name="id">
+        /// An initialization value for the <see cref="P: Id" /> property.
+        /// </param>
         /// <param name="uri">
         /// An initialization value for the <see cref="P: Uri" /> property.
         /// </param>
@@ -68,9 +77,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="region">
         /// An initialization value for the <see cref="P: Region" /> property.
         /// </param>
-        public PhysicalLocation(Uri uri, string uriBaseId, Region region)
+        public PhysicalLocation(int id, Uri uri, string uriBaseId, Region region)
         {
-            Init(uri, uriBaseId, region);
+            Init(id, uri, uriBaseId, region);
         }
 
         /// <summary>
@@ -89,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Uri, other.UriBaseId, other.Region);
+            Init(other.Id, other.Uri, other.UriBaseId, other.Region);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -110,8 +119,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new PhysicalLocation(this);
         }
 
-        private void Init(Uri uri, string uriBaseId, Region region)
+        private void Init(int id, Uri uri, string uriBaseId, Region region)
         {
+            Id = id;
             if (uri != null)
             {
                 Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);

--- a/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocationEqualityComparer.cs
@@ -27,6 +27,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.Id != right.Id)
+            {
+                return false;
+            }
+
             if (left.Uri != right.Uri)
             {
                 return false;
@@ -55,6 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             int result = 17;
             unchecked
             {
+                result = (result * 31) + obj.Id.GetHashCode();
                 if (obj.Uri != null)
                 {
                     result = (result * 31) + obj.Uri.GetHashCode();

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -465,6 +465,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (node != null)
             {
+                node.PhysicalLocation = VisitNullChecked(node.PhysicalLocation);
             }
 
             return node;

--- a/src/Sarif/Autogenerated/StackFrame.cs
+++ b/src/Sarif/Autogenerated/StackFrame.cs
@@ -45,28 +45,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string RichMessage { get; set; }
 
         /// <summary>
-        /// The uri of the source code file to which this stack frame refers.
+        /// The physical location to which this stack frame refers.
         /// </summary>
-        [DataMember(Name = "uri", IsRequired = false, EmitDefaultValue = false)]
-        public Uri Uri { get; set; }
-
-        /// <summary>
-        /// A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.
-        /// </summary>
-        [DataMember(Name = "uriBaseId", IsRequired = false, EmitDefaultValue = false)]
-        public string UriBaseId { get; set; }
-
-        /// <summary>
-        /// The line of the location to which this stack frame refers.
-        /// </summary>
-        [DataMember(Name = "line", IsRequired = false, EmitDefaultValue = false)]
-        public int Line { get; set; }
-
-        /// <summary>
-        /// The line of the location to which this stack frame refers.
-        /// </summary>
-        [DataMember(Name = "column", IsRequired = false, EmitDefaultValue = false)]
-        public int Column { get; set; }
+        [DataMember(Name = "physicalLocation", IsRequired = false, EmitDefaultValue = false)]
+        public PhysicalLocation PhysicalLocation { get; set; }
 
         /// <summary>
         /// The name of the module that contains the code of this stack frame.
@@ -132,17 +114,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="richMessage">
         /// An initialization value for the <see cref="P: RichMessage" /> property.
         /// </param>
-        /// <param name="uri">
-        /// An initialization value for the <see cref="P: Uri" /> property.
-        /// </param>
-        /// <param name="uriBaseId">
-        /// An initialization value for the <see cref="P: UriBaseId" /> property.
-        /// </param>
-        /// <param name="line">
-        /// An initialization value for the <see cref="P: Line" /> property.
-        /// </param>
-        /// <param name="column">
-        /// An initialization value for the <see cref="P: Column" /> property.
+        /// <param name="physicalLocation">
+        /// An initialization value for the <see cref="P: PhysicalLocation" /> property.
         /// </param>
         /// <param name="module">
         /// An initialization value for the <see cref="P: Module" /> property.
@@ -168,9 +141,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P: Properties" /> property.
         /// </param>
-        public StackFrame(string message, string richMessage, Uri uri, string uriBaseId, int line, int column, string module, int threadId, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
+        public StackFrame(string message, string richMessage, PhysicalLocation physicalLocation, string module, int threadId, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(message, richMessage, uri, uriBaseId, line, column, module, threadId, fullyQualifiedLogicalName, logicalLocationKey, address, offset, parameters, properties);
+            Init(message, richMessage, physicalLocation, module, threadId, fullyQualifiedLogicalName, logicalLocationKey, address, offset, parameters, properties);
         }
 
         /// <summary>
@@ -189,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Message, other.RichMessage, other.Uri, other.UriBaseId, other.Line, other.Column, other.Module, other.ThreadId, other.FullyQualifiedLogicalName, other.LogicalLocationKey, other.Address, other.Offset, other.Parameters, other.Properties);
+            Init(other.Message, other.RichMessage, other.PhysicalLocation, other.Module, other.ThreadId, other.FullyQualifiedLogicalName, other.LogicalLocationKey, other.Address, other.Offset, other.Parameters, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -210,18 +183,15 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new StackFrame(this);
         }
 
-        private void Init(string message, string richMessage, Uri uri, string uriBaseId, int line, int column, string module, int threadId, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(string message, string richMessage, PhysicalLocation physicalLocation, string module, int threadId, string fullyQualifiedLogicalName, string logicalLocationKey, int address, int offset, IEnumerable<string> parameters, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Message = message;
             RichMessage = richMessage;
-            if (uri != null)
+            if (physicalLocation != null)
             {
-                Uri = new Uri(uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
+                PhysicalLocation = new PhysicalLocation(physicalLocation);
             }
 
-            UriBaseId = uriBaseId;
-            Line = line;
-            Column = column;
             Module = module;
             ThreadId = threadId;
             FullyQualifiedLogicalName = fullyQualifiedLogicalName;

--- a/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/StackFrameEqualityComparer.cs
@@ -38,22 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (left.Uri != right.Uri)
-            {
-                return false;
-            }
-
-            if (left.UriBaseId != right.UriBaseId)
-            {
-                return false;
-            }
-
-            if (left.Line != right.Line)
-            {
-                return false;
-            }
-
-            if (left.Column != right.Column)
+            if (!PhysicalLocation.ValueComparer.Equals(left.PhysicalLocation, right.PhysicalLocation))
             {
                 return false;
             }
@@ -154,18 +139,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                     result = (result * 31) + obj.RichMessage.GetHashCode();
                 }
 
-                if (obj.Uri != null)
+                if (obj.PhysicalLocation != null)
                 {
-                    result = (result * 31) + obj.Uri.GetHashCode();
+                    result = (result * 31) + obj.PhysicalLocation.ValueGetHashCode();
                 }
 
-                if (obj.UriBaseId != null)
-                {
-                    result = (result * 31) + obj.UriBaseId.GetHashCode();
-                }
-
-                result = (result * 31) + obj.Line.GetHashCode();
-                result = (result * 31) + obj.Column.GetHashCode();
                 if (obj.Module != null)
                 {
                     result = (result * 31) + obj.Module.GetHashCode();

--- a/src/Sarif/Core/Stack.cs
+++ b/src/Sarif/Core/Stack.cs
@@ -125,8 +125,14 @@ namespace Microsoft.CodeAnalysis.Sarif
                         string fileName = match.Groups[3].Value;
                         int lineNumber = int.Parse(match.Groups[4].Value);
 
-                        stackFrame.Uri = new Uri(fileName);
-                        stackFrame.Line = lineNumber;
+                        stackFrame.PhysicalLocation = new PhysicalLocation
+                        {
+                            Uri = new Uri(fileName),
+                            Region = new Region
+                            {
+                                StartLine = lineNumber
+                            }
+                        };
                     }
                 }
                 stack.Frames.Add(stackFrame);

--- a/src/Sarif/Core/StackFrame.cs
+++ b/src/Sarif/Core/StackFrame.cs
@@ -40,9 +40,15 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (fileName != null)
             {
-                stackFrame.Uri = new Uri(fileName);
-                stackFrame.Line = dotNetStackFrame.GetFileLineNumber();
-                stackFrame.Column = dotNetStackFrame.GetFileColumnNumber();
+                stackFrame.PhysicalLocation = new PhysicalLocation
+                {
+                    Uri = new Uri(fileName),
+                    Region = new Region
+                    {
+                        StartLine = dotNetStackFrame.GetFileLineNumber(),
+                        StartColumn = dotNetStackFrame.GetFileColumnNumber()
+                    }
+                };
             }
 
             if (ilOffset != -1)
@@ -62,12 +68,16 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             string result = AT + this.FullyQualifiedLogicalName;
 
-            if (this.Uri != null)
+            if (this.PhysicalLocation?.Uri != null)
             {
-                string lineNumber = this.Line.ToString(CultureInfo.InvariantCulture);
-                string fileName = this.Uri.LocalPath;
+                string fileName = this.PhysicalLocation.Uri.LocalPath;
+                result += IN + fileName;
 
-                result += IN + fileName + LINE + " " + lineNumber;
+                if (this.PhysicalLocation?.Region != null)
+                {
+                    string lineNumber = this.PhysicalLocation.Region.StartLine.ToString(CultureInfo.InvariantCulture);
+                    result += LINE + " " + lineNumber;
+                }
             }
 
             return result;

--- a/src/Sarif/Schemata/Sarif.schema.json
+++ b/src/Sarif/Schemata/Sarif.schema.json
@@ -651,6 +651,11 @@
       "type": "object",
       "properties": {
 
+        "id": {
+          "description": "Value that distinguishes this physical location from all other physical locations in this run object.",
+          "type": "integer"
+        },
+
         "uri": {
           "description": "The location of the file as a valid URI.",
           "type": "string",
@@ -1143,25 +1148,9 @@
           "type": "string"
         },
 
-        "uri": {
-          "description": "The uri of the source code file to which this stack frame refers.",
-          "type": "string",
-          "format": "uri"
-        },
-
-        "uriBaseId": {
-          "description": "A string that identifies the conceptual base for the 'uri' property (if it is relative), e.g.,'$(SolutionDir)' or '%SRCROOT%'.",
-          "type": "string"
-        },
-
-        "line": {
-          "description": "The line of the location to which this stack frame refers.",
-          "type": "integer"
-        },
-
-        "column": {
-          "description": "The line of the location to which this stack frame refers.",
-          "type": "integer"
+        "physicalLocation": {
+          "description": "The physical location to which this stack frame refers.",
+          "$ref": "#/definitions/physicalLocation"
         },
 
         "module": {
@@ -1268,7 +1257,8 @@
 
         "language": {
           "description": "The tool language (expressed as an ISO 649 two-letter lowercase culture code) and region (expressed as an ISO 3166 two-letter uppercase subculture code associated with a country or region).",
-          "type": "string"
+          "type": "string",
+          "default": "en-US"
         },
 
         "properties": {

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-
 using Microsoft.CodeAnalysis.Sarif.Readers;
-
 using Newtonsoft.Json;
-using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.Sarif.Writers
 {
@@ -300,7 +298,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 {
                     foreach (StackFrame frame in stack.Frames)
                     {
-                        CaptureFile(frame.Uri);
+                        CaptureFile(frame.PhysicalLocation?.Uri);
                     }
                 }
             }


### PR DESCRIPTION
Implement schema changes for the following issues in the OASIS SARIF TC repo:

- [Issue #61](https://github.com/oasis-tcs/sarif-spec/issues/61): Provide a format for embedded links in plain text messages

    The only schema change is the addition of `physicalLocation.id`.

- [Issue #69](https://github.com/oasis-tcs/sarif-spec/issues/69): Provide a `physicalLocation` property on `stackFrame`

    Remove the four "loose" properties on `stackFrame` that are subsumed by `physicalLocation`.

- [Issue #72](https://github.com/oasis-tcs/sarif-spec/issues/72): `tool.language` property needs a default value

    Set default to `"en-US"`.

The schema changes are described in the document [Schema changes between SARIF v1 and v2](https://github.com/oasis-tcs/sarif-spec/blob/master/Documents/Schema%20changes%20between%20SARIF%20v1%20and%20v2.md).  In that document, please see the sections for Issue #&nbsp;61,  Issue #&nbsp;69,  and Issue #&nbsp;72. 