### PR TITLE
Fix for the platform specific skimmers message

### DIFF
--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                     }
                     else
                     {
-                        Warnings.LogUnsupportedPlatformForRule(context, skimmer.Name, currentOS, skimmer.SupportedPlatforms);
+                        Warnings.LogUnsupportedPlatformForRule(context, skimmer.Name, skimmer.SupportedPlatforms, currentOS);
                     }
                 }
             }


### PR DESCRIPTION
Message is currently backwards ("Can only run on 'CurrentOs', unsupported on '(actual supported platforms)'").