### PR TITLE
Fix #771 Fixes tab file paths are not rebased

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -479,6 +479,17 @@ namespace Microsoft.Sarif.Viewer
                     }
                 }
             }
+
+            foreach (FixModel fixModel in Fixes)
+            {
+                foreach (FileChangeModel fileChangeModel in fixModel.FileChanges)
+                {
+                    if (fileChangeModel.FilePath.Equals(originalPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        fileChangeModel.FilePath = remappedPath;
+                    }
+                }
+            }
         }
 
         internal void AttachToDocument(string documentName, long docCookie, IVsWindowFrame pFrame)


### PR DESCRIPTION
Add code to update file paths in the FixModels that are bound to the Fixes tab.