### PR TITLE
Stay attached to doc and maintain highlighting

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/SarifTableControlEventProcessorProvider.cs
@@ -46,9 +46,6 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 SarifErrorListItem sarifResult;
                 ListView errorList = (ListView)e.SelectionChangedEventArgs.Source;
 
-                // Remove all source code highlighting
-                CodeAnalysisResultManager.Instance.DetachFromAllDocuments();
-
                 if (errorList.SelectedItems.Count != 1)
                 {
                     // There's more, or less, than one selected item. Clear the SARIF Explorer.
@@ -77,6 +74,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 else
                 {
                     SarifViewerPackage.SarifToolWindow.Control.DataContext = null;
+                }
+
+                if (sarifResult.Locations?.Count > 0)
+                {
+                    sarifResult.Locations[0].ApplyDefaultSourceFileHighlighting();
                 }
 
                 base.PreprocessSelectionChanged(e);


### PR DESCRIPTION
This prevents the null ref when a fix is applied but the error list item hasn't been double-clicked. This also highlights violations when a fix is available, and the error list selection changes.