### PR TITLE
Fix #774 adjust fix offsets

### DIFF
--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FixModelTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FixModelTests.cs
@@ -50,14 +50,12 @@ namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
 
             dummy.FixLedger.Count.Should().Be(1);
             SortedList<int, int> offsets = dummy.FixLedger[dummy.FileChanges[0].FilePath.ToLower()].Offsets;
-            offsets.Count.Should().Be(4);
+            offsets.Count.Should().Be(3);
 
-            offsets.Keys[0].Should().Be(0);
-            offsets.Keys[1].Should().Be(191);
-            offsets.Keys[2].Should().Be(199);
-            offsets.Keys[3].Should().Be(233);
-
-            offsets[0].Should().Be(3);
+            offsets.Keys[0].Should().Be(191);
+            offsets.Keys[1].Should().Be(199);
+            offsets.Keys[2].Should().Be(233);
+            
             offsets[191].Should().Be(1);
             offsets[199].Should().Be(1);
             offsets[233].Should().Be(0);

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FixModelTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Models/FixModelTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.Sarif.Viewer.Models;
+using Xunit;
+
+namespace Microsoft.Sarif.Viewer.VisualStudio.UnitTests
+{
+    public class FixModelTests
+    {
+        private DummyFixModel InitializeDummyFixModel()
+        {
+            var fileSystem = new DummyFileSystem();
+            fileSystem.WriteAllBytes("index.html", File.ReadAllBytes(@"TestData\FixModel\index.html"));
+
+            var fixModel = new DummyFixModel("Test dummy", fileSystem);
+
+            var replacements = new List<ReplacementModel>();
+            replacements.Add(new ReplacementModel() { Offset = 191, DeletedLength = 0, InsertedString = "\"" });
+            replacements.Add(new ReplacementModel() { Offset = 199, DeletedLength = 0, InsertedString = "\"" });
+            replacements.Add(new ReplacementModel() { Offset = 233, DeletedLength = 3, InsertedString = "img" });
+            replacements.ForEach(rm => rm.InsertedBytes = Encoding.UTF8.GetBytes(rm.InsertedString));
+
+            var changeModel = new FileChangeModel() { FilePath = @"C:\source\index.html" };
+            replacements.ForEach(r => changeModel.Replacements.Add(r));
+            fixModel.FileChanges.Add(changeModel);
+
+            return fixModel;
+        }
+
+        [Fact]
+        public void FixModel_ApplyFix()
+        {
+            // Arrange
+            DummyFixModel dummy = InitializeDummyFixModel();
+
+            // Act
+            dummy.ApplyFix(dummy);
+
+            // Assert
+            byte[] actual = dummy.FileSystem.ReadAllBytes("index.html");
+            byte[] expected = File.ReadAllBytes(@"TestData\FixModel\index_fixed.html");
+            actual.Should().Equal(expected);
+
+            dummy.FixLedger.Count.Should().Be(1);
+            SortedList<int, int> offsets = dummy.FixLedger[dummy.FileChanges[0].FilePath.ToLower()].Offsets;
+            offsets.Count.Should().Be(4);
+
+            offsets.Keys[0].Should().Be(0);
+            offsets.Keys[1].Should().Be(191);
+            offsets.Keys[2].Should().Be(199);
+            offsets.Keys[3].Should().Be(233);
+
+            offsets[0].Should().Be(3);
+            offsets[191].Should().Be(1);
+            offsets[199].Should().Be(1);
+            offsets[233].Should().Be(0);
+        }
+
+        private class DummyFixModel : FixModel
+        {
+            public IFileSystem FileSystem { get; private set; }
+
+            public Dictionary<string, FixOffsetList> FixLedger
+            {
+                get { return s_sourceFileFixLedger; }
+            }
+
+            public DummyFixModel(string description, IFileSystem fileSystem) : base(description, fileSystem)
+            {
+                FileSystem = fileSystem;
+            }
+
+            internal override void LoadFixLedger()
+            {
+                s_sourceFileFixLedger = new Dictionary<string, FixOffsetList>();
+            }
+
+            internal override void SaveFixLedger() { }
+        }
+
+        private class DummyFileSystem : IFileSystem
+        {
+            private DateTime _lastWriteTime;
+
+            public byte[] _testFileBytes { get; set; }
+
+            public bool FileExists(string path)
+            {
+                return true;
+            }
+
+            public DateTime GetLastWriteTime(string path)
+            {
+                return _lastWriteTime;
+            }
+
+            public byte[] ReadAllBytes(string path)
+            {
+                return _testFileBytes;
+            }
+
+            public void WriteAllBytes(string path, byte[] bytes)
+            {
+                _testFileBytes = bytes;
+            }
+
+            public void SetLastWriteTime(string path, DateTime lastWriteTime)
+            {
+                _lastWriteTime = lastWriteTime;
+            }
+
+            #region Not implemented
+            public string GetFullPath(string path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string[] ReadAllLines(string path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ReadAllText(string path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ReadAllText(string path, Encoding encoding)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetAttributes(string path, FileAttributes fileAttributes)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void WriteAllText(string path, string contents)
+            {
+                throw new NotImplementedException();
+            }
+            #endregion
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/Sarif.Viewer.VisualStudio.UnitTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ErrorList\SarifSnapshotTests.cs" />
     <Compile Include="Models\CallTreeCollectionTests.cs" />
     <Compile Include="Models\CallTreeTests.cs" />
+    <Compile Include="Models\FixModelTests.cs" />
     <Compile Include="ProjectNameCacheTests.cs" />
     <Compile Include="TelemetryProviderTests.cs" />
     <Compile Include="TestUtilities.cs" />
@@ -100,6 +101,16 @@
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestData\FixModel\index.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TestData\FixModel\index_fixed.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TelemetryProviderTests.cs
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TelemetryProviderTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ApplicationInsights.Channel;

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index.html
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index.html
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index.html
@@ -1,0 +1,12 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>FixModel test source file</title>
+</head>
+<body>
+    <span class=TitleBig>The quick brown fox</span>
+    <IMG src="fox.jpg"/>
+</body>
+</html>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index_fixed.html
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index_fixed.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index_fixed.html
+++ b/src/Sarif.Viewer.VisualStudio.UnitTests/TestData/FixModel/index_fixed.html
@@ -1,0 +1,12 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>FixModel test source file</title>
+</head>
+<body>
+    <span class="TitleBig">The quick brown fox</span>
+    <img src="fox.jpg"/>
+</body>
+</html>

--- a/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
@@ -209,16 +209,6 @@ namespace Microsoft.Sarif.Viewer.Models
                 {
                     // Create a new dictionary entry for this file
                     list = new FixOffsetList();
-
-                    // Account for the BOM if it's present
-                    if (bytes.Count > 2 &&
-                        bytes[0] == 0xEF &&
-                        bytes[1] == 0xBB &&
-                        bytes[2] == 0xBF)
-                    {
-                        list.Offsets.Add(0, 3);
-                    }
-
                     s_sourceFileFixLedger.Add(path, list);
                 }
                 else

--- a/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
@@ -190,6 +190,7 @@ namespace Microsoft.Sarif.Viewer.Models
 
                 foreach (ReplacementModel replacement in sortedReplacements)
                 {
+                    // Sum all of the changes that have been made up to this location
                     // and add to this replacement's offset
                     int offset = list.Where(kvp => kvp.Key < replacement.Offset)
                                      .Sum(kvp => kvp.Value) + replacement.Offset;

--- a/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Sarif.Viewer.Models
                 // Sum all of the changes that have been made up to the first replacement location
                 ReplacementModel rm = sortedReplacements.First();
                 int delta = list.Offsets.Where(kvp => kvp.Key < rm.Offset)
-                                            .Sum(kvp => kvp.Value);
+                                        .Sum(kvp => kvp.Value);
 
                 foreach (ReplacementModel replacement in sortedReplacements)
                 {

--- a/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixModel.cs
@@ -4,12 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
@@ -165,7 +161,16 @@ namespace Microsoft.Sarif.Viewer.Models
 
                 // Delete/Insert the bytes for each replacement.
                 List<byte> bytes = File.ReadAllBytes(filePath).ToList();
+
                 int offsetDelta = 0;
+
+                // Account for the BOM if it's present
+                // Don't remove it because that may be undesirable to the user
+                if (bytes.Count > 2 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+                {
+                    offsetDelta = 3;
+                }
+
                 foreach (ReplacementModel replacment in sortedReplacements)
                 {
                     int offset = replacment.Offset + offsetDelta;
@@ -190,4 +195,3 @@ namespace Microsoft.Sarif.Viewer.Models
         }
     }
 }
-

--- a/src/Sarif.Viewer.VisualStudio/Models/FixOffsetList.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixOffsetList.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Sarif.Viewer.Models
+{
+    internal class FixOffsetList
+    {
+        public DateTime LastModified { get; set; }
+        public SortedList<int, int> Offsets { get; private set; }
+
+        public FixOffsetList()
+        {
+            Offsets = new SortedList<int, int>();
+            LastModified = DateTime.Now;
+        }
+    }
+}

--- a/src/Sarif.Viewer.VisualStudio/Models/FixOffsetList.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/FixOffsetList.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Sarif.Viewer.Models
 {
-    internal class FixOffsetList
+    public class FixOffsetList
     {
         public DateTime LastModified { get; set; }
         public SortedList<int, int> Offsets { get; private set; }

--- a/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
+++ b/src/Sarif.Viewer.VisualStudio/Sarif.Viewer.VisualStudio.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Models\CallTree.cs" />
     <Compile Include="Models\CallTreeNode.cs" />
     <Compile Include="Models\FileDetailsModel.cs" />
+    <Compile Include="Models\FixOffsetList.cs" />
     <Compile Include="Models\InvocationModel.cs" />
     <Compile Include="Models\ReplacementModel.cs" />
     <Compile Include="Models\FileChangeModel.cs" />

--- a/src/Sarif.Viewer.VisualStudio/Sarif/Fix.extensions.cs
+++ b/src/Sarif.Viewer.VisualStudio/Sarif/Fix.extensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Sarif.Viewer.Sarif
                 return null;
             }
 
-            FixModel model = new FixModel(fix.Description);
+            FixModel model = new FixModel(fix.Description, new FileSystem());
 
             if (fix.FileChanges != null)
             {

--- a/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
+++ b/src/Sarif.Viewer.VisualStudio/SdkUiUtilities.cs
@@ -162,9 +162,9 @@ namespace Microsoft.Sarif.Viewer
         {
             IsolatedStorageFile store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);
 
-            using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(storageFileName, FileMode.Create, store))
+            using (IsolatedStorageFileStream stream = new IsolatedStorageFileStream(storageFileName, FileMode.Create, store))
             {
-                using (StreamWriter writer = new StreamWriter(isoStream))
+                using (StreamWriter writer = new StreamWriter(stream))
                 {
                     writer.Write(JsonConvert.SerializeObject(t, Formatting.Indented));
                 }

--- a/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
+++ b/src/Sarif.Viewer.VisualStudio/ViewModels/ViewModelLocator.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Sarif.Viewer.ViewModels
             });
             viewModel.Stacks.Add(stack1);
 
-            FixModel fix1 = new FixModel("Replace *.Close() with *.Dispose().");
+            FixModel fix1 = new FixModel("Replace *.Close() with *.Dispose().", new FileSystem());
             FileChangeModel fileChange11 = new FileChangeModel();
             fileChange11.FilePath = @"D:\GitHub\NuGet.Services.Metadata\src\Ng\Catalog2Dnx.cs";
             fileChange11.Replacements.Add(new ReplacementModel()

--- a/src/Sarif/FileSystem.cs
+++ b/src/Sarif/FileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Text;
 
@@ -42,6 +43,16 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string GetFullPath(string path)
         {
             return Path.GetFullPath(path);
+        }
+
+        /// <summary>
+        /// Returns the date and time the specified file or directory was last written to.
+        /// </summary>
+        /// <param name="path">The file or directory for which to obtain write date and time information.</param>
+        /// <returns>A DateTime structure set to the date and time that the specified file or directory was last written to.</returns>
+        public DateTime GetLastWriteTime(string path)
+        {
+            return File.GetLastWriteTime(path);
         }
 
         /// <summary>
@@ -103,6 +114,31 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string ReadAllText(string path, Encoding encoding)
         {
             return File.ReadAllText(path, encoding);
+        }
+
+        /// <summary>
+        /// Sets the date and time that the specified file was last written to.
+        /// </summary>
+        /// <param name="path">The file for which to set the date and time information.</param>
+        /// <param name="lastWriteTime">A DateTime containing the value to set for the last write date and time of path. This value is expressed in local time.</param>
+        public void SetLastWriteTime(string path, DateTime lastWriteTime)
+        {
+            File.SetLastWriteTime(path, lastWriteTime);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">
+        /// The file to write to.
+        /// </param>
+        /// <param name="bytes">
+        /// The bytes to write to the file.
+        /// </param>
+        public void WriteAllBytes(string path, byte[] bytes)
+        {
+            File.WriteAllBytes(path, bytes);
         }
 
         /// <summary>

--- a/src/Sarif/IFileSystem.cs
+++ b/src/Sarif/IFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Text;
 
@@ -38,6 +39,17 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The fully qualified location of <paramref name="path"/>, such as "C:\MyFile.txt".
         /// </returns>
         string GetFullPath(string path);
+
+        /// <summary>
+        /// Returns the date and time the specified file or directory was last written to.
+        /// </summary>
+        /// <param name="path">
+        /// The file or directory for which to obtain write date and time information.
+        /// </param>
+        /// <returns>
+        /// A DateTime structure set to the date and time that the specified file or directory was last written to.
+        /// </returns>
+        DateTime GetLastWriteTime(string path);
 
         /// <summary>
         /// Opens a binary file, reads all contents into a byte array, and then closes the file.
@@ -87,6 +99,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A string containing all text in the file.
         /// </returns>
         string ReadAllText(string path, Encoding encoding);
+
+        /// <summary>
+        /// Sets the date and time that the specified file was last written to.
+        /// </summary>
+        /// <param name="path">The file for which to set the date and time information.</param>
+        /// <param name="lastWriteTime">A DateTime containing the value to set for the last write date and time of path. This value is expressed in local time.</param>
+        void SetLastWriteTime(string path, DateTime lastWriteTime);
+
+        /// <summary>
+        /// Creates a new file, writes the specified bytes to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">
+        /// The file to write to.
+        /// </param>
+        /// <param name="bytes">
+        /// The bytes to write to the file.
+        /// </param>
+        void WriteAllBytes(string path, byte[] bytes);
 
         /// <summary>
         /// Creates a new file, writes the specified string to the file, and then closes the file.


### PR DESCRIPTION
Adjusts replacement offsets to account for prior changes. Persists the change ledger in isolated storage. Does *not* support two instances of VS making changes simultaneously.