### PR TITLE
Fix #776: Fix preview shows error message

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
+++ b/src/Sarif.Viewer.VisualStudio/Resources.Designer.cs
@@ -79,6 +79,24 @@ namespace Microsoft.Sarif.Viewer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Original.
+        /// </summary>
+        internal static string FixPreviewWindow_OriginalFileTitle {
+            get {
+                return ResourceManager.GetString("FixPreviewWindow_OriginalFileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix Preview.
+        /// </summary>
+        internal static string FixPreviewWindow_PreviewFixedFileTitle {
+            get {
+                return ResourceManager.GetString("FixPreviewWindow_PreviewFixedFileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SARIF Explorer found no results in analysis log &apos;{0}&apos;..
         /// </summary>
         internal static string NoResults_DialogMessage {

--- a/src/Sarif.Viewer.VisualStudio/Resources.resx
+++ b/src/Sarif.Viewer.VisualStudio/Resources.resx
@@ -124,6 +124,12 @@
     <value>The file '{0}' couldn't be opened by Visual Studio. Would you like to open the containing folder?</value>
     <comment>{0} will be the name of the file that couldn't be opened</comment>
   </data>
+  <data name="FixPreviewWindow_OriginalFileTitle" xml:space="preserve">
+    <value>Original</value>
+  </data>
+  <data name="FixPreviewWindow_PreviewFixedFileTitle" xml:space="preserve">
+    <value>Fix Preview</value>
+  </data>
   <data name="NoResults_DialogMessage" xml:space="preserve">
     <value>SARIF Explorer found no results in analysis log '{0}'.</value>
     <comment>{0} will be the name of the file that was opened</comment>


### PR DESCRIPTION
File path parameters passed to ExecuteCommand needed quotes. Also added titles for the diff panes.