### PR TITLE
Fix #786: Show error list items for config & tool notifications

### DIFF
--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -130,8 +130,11 @@ namespace Microsoft.Sarif.Viewer.ErrorList
             {
                 foreach (Notification toolNotification in run.ToolNotifications)
                 {
-                    var sarifError = new SarifErrorListItem(run, toolNotification, logFilePath, projectNameCache);
-                    sarifErrors.Add(sarifError);
+                    if (toolNotification.Level != NotificationLevel.Note)
+                    {
+                        var sarifError = new SarifErrorListItem(run, toolNotification, logFilePath, projectNameCache);
+                        sarifErrors.Add(sarifError);
+                    }
                 }
             }
 

--- a/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
+++ b/src/Sarif.Viewer.VisualStudio/ErrorList/ErrorListService.cs
@@ -117,6 +117,24 @@ namespace Microsoft.Sarif.Viewer.ErrorList
                 }
             }
 
+            if (run.ConfigurationNotifications != null)
+            {
+                foreach (Notification configurationNotification in run.ConfigurationNotifications)
+                {
+                    var sarifError = new SarifErrorListItem(run, configurationNotification, logFilePath, projectNameCache);
+                    sarifErrors.Add(sarifError);
+                }
+            }
+
+            if (run.ToolNotifications != null)
+            {
+                foreach (Notification toolNotification in run.ToolNotifications)
+                {
+                    var sarifError = new SarifErrorListItem(run, toolNotification, logFilePath, projectNameCache);
+                    sarifErrors.Add(sarifError);
+                }
+            }
+
             foreach (var error in sarifErrors)
             {
                 CodeAnalysisResultManager.Instance.SarifErrors.Add(error);

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -122,10 +122,8 @@ namespace Microsoft.Sarif.Viewer
             Message = notification.Message;
             ShortMessage = notification.Message;
             LogFilePath = logFilePath;
+            FileName = notification.PhysicalLocation?.Uri.LocalPath ?? run.Tool.FullName;
             ProjectName = projectNameCache.GetName(FileName);
-            FileName = notification.PhysicalLocation != null ?
-                notification.PhysicalLocation.Uri.LocalPath :
-                run.Tool.FullName;
 
             Locations.Add(new AnnotatedCodeLocationModel() { FilePath = FileName });
 

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
         }
+
         public SarifErrorListItem(Run run, Notification notification, string logFilePath, ProjectNameCache projectNameCache) : this()
         {
             IRule rule;

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -114,10 +114,33 @@ namespace Microsoft.Sarif.Viewer
                 }
             }
         }
+        public SarifErrorListItem(Run run, Notification notification, string logFilePath, ProjectNameCache projectNameCache) : this()
+        {
+            IRule rule;
+            string ruleId = notification.RuleId ?? notification.Id;
+            run.TryGetRule(ruleId, notification.RuleKey, out rule);
+            Message = notification.Message;
+            ShortMessage = notification.Message;
+            LogFilePath = logFilePath;
+            FileName = notification.PhysicalLocation.Uri.LocalPath;
+            ProjectName = projectNameCache.GetName(FileName);
+
+            Tool = run.Tool.ToToolModel();
+            Rule = rule.ToRuleModel(ruleId);
+            Invocation = run.Invocation.ToInvocationModel();
+
+            if (String.IsNullOrWhiteSpace(run.Id))
+            {
+                WorkingDirectory = Path.Combine(Path.GetTempPath(), run.GetHashCode().ToString());
+            }
+            else
+            {
+                WorkingDirectory = Path.Combine(Path.GetTempPath(), run.Id);
+            }
+        }
 
         [Browsable(false)]
         public string MimeType { get; set; }
-
 
         [Browsable(false)]
         public Region Region { get; set; }
@@ -392,7 +415,6 @@ namespace Microsoft.Sarif.Viewer
         {
             return Message;
         }
-
 
         [Browsable(false)]
         public ResultTextMarker LineMarker

--- a/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
+++ b/src/Sarif.Viewer.VisualStudio/Models/SarifErrorListItem.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Sarif.Viewer
 
         internal SarifErrorListItem()
         {
-            _locations = new AnnotatedCodeLocationCollection(String.Empty);
-            _relatedLocations = new AnnotatedCodeLocationCollection(String.Empty);
+            _locations = new AnnotatedCodeLocationCollection(string.Empty);
+            _relatedLocations = new AnnotatedCodeLocationCollection(string.Empty);
             _callTrees = new CallTreeCollection();
             _stacks = new ObservableCollection<StackCollection>();
             _fixes = new ObservableCollection<FixModel>();
@@ -62,7 +62,7 @@ namespace Microsoft.Sarif.Viewer
             Rule = rule.ToRuleModel(result.RuleId);
             Invocation = run.Invocation.ToInvocationModel();
 
-            if (String.IsNullOrWhiteSpace(run.Id))
+            if (string.IsNullOrWhiteSpace(run.Id))
             {
                 WorkingDirectory = Path.Combine(Path.GetTempPath(), run.GetHashCode().ToString());
             }
@@ -122,14 +122,19 @@ namespace Microsoft.Sarif.Viewer
             Message = notification.Message;
             ShortMessage = notification.Message;
             LogFilePath = logFilePath;
-            FileName = notification.PhysicalLocation.Uri.LocalPath;
             ProjectName = projectNameCache.GetName(FileName);
+            FileName = notification.PhysicalLocation != null ?
+                notification.PhysicalLocation.Uri.LocalPath :
+                run.Tool.FullName;
+
+            Locations.Add(new AnnotatedCodeLocationModel() { FilePath = FileName });
 
             Tool = run.Tool.ToToolModel();
             Rule = rule.ToRuleModel(ruleId);
+            Rule.DefaultLevel = notification.Level.ToString();
             Invocation = run.Invocation.ToInvocationModel();
 
-            if (String.IsNullOrWhiteSpace(run.Id))
+            if (string.IsNullOrWhiteSpace(run.Id))
             {
                 WorkingDirectory = Path.Combine(Path.GetTempPath(), run.GetHashCode().ToString());
             }


### PR DESCRIPTION
Excluding tool notifications where level=="info", such as "run started" etc. If you disagree, testify!