### PR TITLE
Dev/evmaus ms/baseline

### DIFF
--- a/src/Sarif.Multitool/BaselineCommand.cs
+++ b/src/Sarif.Multitool/BaselineCommand.cs
@@ -44,6 +44,5 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
             return 0;
         }
-
     }
 }

--- a/src/Sarif.Multitool/BaselineCommand.cs
+++ b/src/Sarif.Multitool/BaselineCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis.Sarif.Baseline;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
@@ -17,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             {
                 SarifLog baselineFile = MultitoolFileHelpers.ReadSarifFile(baselineOptions.BaselineFilePath);
                 SarifLog currentFile = MultitoolFileHelpers.ReadSarifFile(baselineOptions.CurrentFilePath);
-                if(baselineFile.Runs.Count != 1 || currentFile.Runs.Count != 1)
+                if (baselineFile.Runs.Count != 1 || currentFile.Runs.Count != 1)
                 {
                     throw new ArgumentException("Invalid sarif logs, we can only baseline logs with a single run in them.");
                 }

--- a/src/Sarif.Multitool/BaselineCommand.cs
+++ b/src/Sarif.Multitool/BaselineCommand.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.Sarif.Baseline;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+    class BaselineCommand
+    {
+        public static int Run(BaselineOptions baselineOptions)
+        {
+            try
+            {
+                SarifLog baselineFile = MultitoolFileHelpers.ReadSarifFile(baselineOptions.BaselineFilePath);
+                SarifLog currentFile = MultitoolFileHelpers.ReadSarifFile(baselineOptions.CurrentFilePath);
+                if(baselineFile.Runs.Count != 1 || currentFile.Runs.Count != 1)
+                {
+                    throw new ArgumentException("Invalid sarif logs, we can only baseline logs with a single run in them.");
+                }
+
+                ISarifLogBaseliner baseliner = SarifLogBaselinerFactory.CreateSarifLogBaseliner(baselineOptions.BaselineType);
+
+                Run diffedRun = baseliner.CreateBaselinedRun(baselineFile.Runs.First(), currentFile.Runs.First());
+                
+                SarifLog output = currentFile.DeepClone();
+                output.Runs = new List<Run>();
+                output.Runs.Add(diffedRun);
+
+                var formatting = baselineOptions.PrettyPrint
+                        ? Newtonsoft.Json.Formatting.Indented
+                        : Newtonsoft.Json.Formatting.None;
+                
+                MultitoolFileHelpers.WriteSarifFile(output, baselineOptions.OutputFilePath, formatting);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.ToString());
+                return 1;
+            }
+
+            return 0;
+        }
+
+    }
+}

--- a/src/Sarif.Multitool/BaselineOptions.cs
+++ b/src/Sarif.Multitool/BaselineOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Option(
             't',
             "baseline-type",
-            HelpText = "Type of baseline to do.  Currently support:  Strict, ",
+            HelpText = "Type of baseline to do.  Currently support:  Strict,Default ",
             Default = Baseline.SarifBaselineType.Strict)]
         public Baseline.SarifBaselineType BaselineType { get; internal set; }
 

--- a/src/Sarif.Multitool/BaselineOptions.cs
+++ b/src/Sarif.Multitool/BaselineOptions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CommandLine;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool
+{
+
+    [Verb("baseline", HelpText = "Create a baseline between two sarif logs")]
+    class BaselineOptions : MultitoolOptionsBase
+    {
+        [Option(
+            'b',
+            "baseline",
+            HelpText = "Path to a Sarif Log containing a single run representing the baseline file",
+            Required = true)]
+        public string BaselineFilePath { get; internal set; }
+
+        [Option(
+            'c',
+            "current",
+            HelpText = "Path to a Sarif Log containing a single run, representing the current results",
+            Required = true)]
+        public string CurrentFilePath { get; internal set; }
+
+        [Option(
+            't',
+            "baseline-type",
+            HelpText = "Type of baseline to do.  Currently support:  Strict, ",
+            Default = Baseline.SarifBaselineType.Strict)]
+        public Baseline.SarifBaselineType BaselineType { get; internal set; }
+
+        [Option('o', 
+            "output-file-path", 
+            HelpText = "Output File Path to put the baselined sarif log", 
+            Default = "baselined-log.sarif")]
+        public string OutputFilePath { get; internal set; }
+    }
+}

--- a/src/Sarif.Multitool/BaselineOptions.cs
+++ b/src/Sarif.Multitool/BaselineOptions.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using CommandLine;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-
     [Verb("baseline", HelpText = "Create a baseline between two sarif logs")]
     class BaselineOptions : MultitoolOptionsBase
     {
@@ -29,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         [Option(
             't',
             "baseline-type",
-            HelpText = "Type of baseline to do.  Currently support:  Strict,Default ",
+            HelpText = "Type of baseline to do.  Currently support:  Strict,Standard ",
             Default = Baseline.SarifBaselineType.Strict)]
         public Baseline.SarifBaselineType BaselineType { get; internal set; }
 

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -17,17 +17,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
         public static int Main(string[] args)
         {
             return Parser.Default.ParseArguments<
-                ConvertOptions, 
+                ConvertOptions,
                 RewriteOptions,
                 MergeOptions,
                 RebaseUriOptions,
-                AbsoluteUriOptions>(args)
+                AbsoluteUriOptions,
+                BaselineOptions>(args)
               .MapResult(
                 (ConvertOptions convertOptions) => ConvertCommand.Run(convertOptions),
                 (RewriteOptions rewriteOptions) => RewriteCommand.Run(rewriteOptions),
                 (MergeOptions mergeOptions) => MergeCommand.Run(mergeOptions),
                 (RebaseUriOptions rebaseOptions) => RebaseUriCommand.Run(rebaseOptions),
                 (AbsoluteUriOptions absoluteUriOptions) => AbsoluteUriCommand.Run(absoluteUriOptions),
+                (BaselineOptions baselineOptions) => BaselineCommand.Run(baselineOptions),
                 errs => 1);
         }
     }

--- a/src/Sarif.UnitTests/Baseline/DefaultBaselineUnitTests.cs
+++ b/src/Sarif.UnitTests/Baseline/DefaultBaselineUnitTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    public class DefaultBaselineUnitTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public DefaultBaselineUnitTests(ITestOutputHelper outputHelper)
+        {
+            output = outputHelper;
+        }
+
+
+        private ISarifLogBaseliner defaultBaseliner = SarifLogBaselinerFactory.CreateSarifLogBaseliner(SarifBaselineType.Standard);
+
+
+        [Fact]
+        public void DefaultBaseline_SameResults_AllExisting()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+
+            Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Existing);
+            result.Results.Should().HaveCount(baseline.Results.Count());
+        }
+
+        [Fact]
+        public void DefaultBaseline_NewResultAdded_New()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results.Add(RandomSarifLogGenerator.GenerateFakeResults(random, new List<string>() { "NEWTESTRESULT" }, new List<Uri>() { new Uri(@"c:\test\testfile") }, 1).First());
+
+            Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
+
+            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+        }
+
+        [Fact]
+        public void DefaultBaseline_RemovedResult_Absent()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results.RemoveAt(0);
+
+            Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
+            
+            result.Results.Should().HaveCount(baseline.Results.Count());
+        }
+
+        [Fact]
+        public void DefaultBaseline_ChangedResultOnThumbprint_AbsentAndNew()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, 5);
+            Run next = baseline.DeepClone();
+            next.Results[0].ToolFingerprintContribution = "New fingerprint";
+
+            Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
+
+            result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
+            
+
+            result.Results.Should().HaveCount(baseline.Results.Count() + 1);
+        }
+
+
+        [Fact]
+        public void DefaultBaseline_ChangedResultOnNonTrackedField_Existing()
+        {
+
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results[0].Message = "new message";
+
+            Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
+            
+            result.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Existing);
+            result.Results.Should().HaveCount(baseline.Results.Count());
+        }
+    }
+}

--- a/src/Sarif.UnitTests/Baseline/DefaultBaselineUnitTests.cs
+++ b/src/Sarif.UnitTests/Baseline/DefaultBaselineUnitTests.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,11 +18,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
         {
             output = outputHelper;
         }
-
-
+        
         private ISarifLogBaseliner defaultBaseliner = SarifLogBaselinerFactory.CreateSarifLogBaseliner(SarifBaselineType.Standard);
-
-
+        
         [Fact]
         public void DefaultBaseline_SameResults_AllExisting()
         {
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-
             result.Results.Should().HaveCount(baseline.Results.Count() + 1);
         }
 
@@ -60,7 +59,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            
             result.Results.Should().HaveCount(baseline.Results.Count());
         }
 
@@ -75,14 +73,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = defaultBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            
-
             result.Results.Should().HaveCount(baseline.Results.Count() + 1);
         }
-
-
+        
         [Fact]
         public void DefaultBaseline_ChangedResultOnNonTrackedField_Existing()
         {

--- a/src/Sarif.UnitTests/Baseline/StrictBaselineUnitTests.cs
+++ b/src/Sarif.UnitTests/Baseline/StrictBaselineUnitTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    public class StrictBaselineUnitTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public StrictBaselineUnitTests(ITestOutputHelper outputHelper)
+        {
+            output = outputHelper;
+        }
+
+        private ISarifLogBaseliner strictBaseliner = SarifLogBaselinerFactory.CreateSarifLogBaseliner(SarifBaselineType.Strict);
+
+        [Fact]
+        public void StrictBaseline_SameResults_AllExisting()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, Result.ValueComparer, random.Next(100)+5);
+            Run next = baseline.DeepClone();
+
+            Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Should().OnlyContain(r => r.BaselineState == BaselineState.Existing);
+            result.Results.Should().HaveCount(baseline.Results.Count());
+        }
+
+        [Fact]
+        public void StrictBaseline_NewResultAdded_New()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, Result.ValueComparer, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results.Add(RandomSarifLogGenerator.GenerateFakeResults(random, new List<string>() { "NEWTESTRESULT" }, new List<Uri>() { new Uri(@"c:\test\testfile") }, 1).First());
+
+            Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
+
+            result.Results.Should().HaveCount(baseline.Results.Count()+1);
+        }
+
+        [Fact]
+        public void StrictBaseline_RemovedResult_Absent()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, Result.ValueComparer, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results.RemoveAt(0);
+
+            Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
+
+            int dupes = baseline.Results.Where(r => baseline.Results.Where(s => Result.ValueComparer.Equals(r, s)).Count() != 1).Count();
+            if (dupes == 0)
+            {
+                result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
+            }
+            result.Results.Should().HaveCount(baseline.Results.Count());
+        }
+    
+
+        [Fact]
+        public void StrictBaseline_ChangedResult_AbsentAndNew()
+        {
+            Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            random = new Random(181968016);
+            Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, Result.ValueComparer, random.Next(100) + 5);
+            Run next = baseline.DeepClone();
+            next.Results[0].RuleId += "V2";
+            
+            Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
+
+            result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
+
+            result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
+            
+            result.Results.Should().HaveCount(baseline.Results.Count()+1);
+        }
+    }
+}

--- a/src/Sarif.UnitTests/Baseline/StrictBaselineUnitTests.cs
+++ b/src/Sarif.UnitTests/Baseline/StrictBaselineUnitTests.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using FluentAssertions;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline
 {
@@ -46,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-
             result.Results.Should().HaveCount(baseline.Results.Count()+1);
         }
 
@@ -60,11 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
             Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
 
-            int dupes = baseline.Results.Where(r => baseline.Results.Where(s => Result.ValueComparer.Equals(r, s)).Count() != 1).Count();
-            if (dupes == 0)
-            {
-                result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            }
+            result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
             result.Results.Should().HaveCount(baseline.Results.Count());
         }
     
@@ -81,9 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run result = strictBaseliner.CreateBaselinedRun(baseline, next);
 
             result.Results.Where(r => r.BaselineState == BaselineState.New).Should().ContainSingle();
-
             result.Results.Where(r => r.BaselineState == BaselineState.Absent).Should().ContainSingle();
-            
             result.Results.Should().HaveCount(baseline.Results.Count()+1);
         }
     }

--- a/src/Sarif.UnitTests/Processors/Log/SarifLogExtensionTests.cs
+++ b/src/Sarif.UnitTests/Processors/Log/SarifLogExtensionTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
         public void TestMerge_WorksAsExpected()
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
-            random = new Random(335662505);
             List<SarifLog> logs = new List<SarifLog>();
             List<SarifLog> secondLogSet = new List<SarifLog>();
             int count = random.Next(10) + 1;

--- a/src/Sarif.UnitTests/Processors/Log/SarifLogExtensionTests.cs
+++ b/src/Sarif.UnitTests/Processors/Log/SarifLogExtensionTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
         public void TestMerge_WorksAsExpected()
         {
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
+            random = new Random(335662505);
             List<SarifLog> logs = new List<SarifLog>();
             List<SarifLog> secondLogSet = new List<SarifLog>();
             int count = random.Next(10) + 1;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Processors.Log
 
             SarifLog combinedLog = logs.Merge();
 
-            combinedLog.Runs.Count.ShouldBeEquivalentTo(secondLogSet.Select(l => l.Runs.Count).Sum());
+            combinedLog.Runs.Count.ShouldBeEquivalentTo(secondLogSet.Select(l => l.Runs == null ? 0 : l.Runs.Count).Sum());
         }
 
         [Fact]

--- a/src/Sarif.UnitTests/RandomSarifLogGenerator.cs
+++ b/src/Sarif.UnitTests/RandomSarifLogGenerator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return log;
         }
 
-        public static Run GenerateRandomRun(Random random)
+        public static Run GenerateRandomRun(Random random, int? resultCount = null)
         {
             Run run = new Run();
             List<string> ruleIds = new List<string>() { "TEST001", "TEST002", "TEST003", "TEST004", "TEST005" };
@@ -53,8 +53,26 @@ namespace Microsoft.CodeAnalysis.Sarif
             run.Tool = new Tool() { Name = "Test", Version = "1.0", };
             run.Rules = GenerateRules(ruleIds);
             run.Files = GenerateFiles(filePaths);
-            run.Results = GenerateFakeResults(random, ruleIds, filePaths, random.Next(100));
 
+            int results = resultCount == null ? random.Next(100) : (int)resultCount;
+            run.Results = GenerateFakeResults(random, ruleIds, filePaths, results);
+
+            return run;
+        }
+
+        public static Run GenerateRandomRunWithoutDuplicateIssues(Random random, IEqualityComparer<Result> comparer, int? resultCount = null)
+        {
+            Run run = GenerateRandomRun(random, resultCount);
+            IList<Result> resultList = run.Results;
+            List<Result> uniqueResults = new List<Result>();
+            foreach(var result in resultList)
+            {
+                if(!uniqueResults.Contains(result, comparer))
+                {
+                    uniqueResults.Add(result);
+                }
+            }
+            run.Results = uniqueResults;
             return run;
         }
 

--- a/src/Sarif.UnitTests/RandomSarifLogGenerator.cs
+++ b/src/Sarif.UnitTests/RandomSarifLogGenerator.cs
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             Run run = GenerateRandomRun(random, resultCount);
             IList<Result> resultList = run.Results;
             List<Result> uniqueResults = new List<Result>();
-            foreach(var result in resultList)
+            foreach (var result in resultList)
             {
-                if(!uniqueResults.Contains(result, comparer))
+                if (!uniqueResults.Contains(result, comparer))
                 {
                     uniqueResults.Add(result);
                 }

--- a/src/Sarif/Baseline/DefaultBaseline/AnnotatedCodeLocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/AnnotatedCodeLocationBaselineEquals.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -18,14 +17,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
                 {
                     return false;
                 }
+
                 if (x.Importance != y.Importance)
                 {
                     return false;
                 }
+
                 if (x.Module != y.Module)
                 {
                     return false;
                 }
+
                 if (x.Kind != y.Kind)
                 {
                     return false;
@@ -40,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
                 {
                     return false;
                 }
+
                 if (!ListComparisonHelpers.CompareListsAsSets(x.Annotations, y.Annotations, AnnotationBaselineEquals.Instance))
                 {
                     return false;
@@ -50,17 +53,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(AnnotatedCodeLocation obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode() ^ obj.Importance.GetNullCheckedHashCode() ^ obj.Kind.GetNullCheckedHashCode() ^ obj.Module.GetNullCheckedHashCode();
+                hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode() ^ obj.Importance.GetNullCheckedHashCode() ^ obj.Kind.GetNullCheckedHashCode() ^ obj.Module.GetNullCheckedHashCode();
 
-            hs = hs ^ obj.Target.GetNullCheckedHashCode() ^ obj.TargetKey.GetNullCheckedHashCode() ^ obj.LogicalLocationKey.GetNullCheckedHashCode();
+                hs = hs ^ obj.Target.GetNullCheckedHashCode() ^ obj.TargetKey.GetNullCheckedHashCode() ^ obj.LogicalLocationKey.GetNullCheckedHashCode();
 
-            hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.PhysicalLocation);
+                hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.PhysicalLocation);
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Annotations, AnnotationBaselineEquals.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Annotations, AnnotationBaselineEquals.Instance);
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/AnnotatedCodeLocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/AnnotatedCodeLocationBaselineEquals.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class AnnotatedCodeLocationBaselineEquals : IEqualityComparer<AnnotatedCodeLocation>
+    {
+        internal static readonly AnnotatedCodeLocationBaselineEquals DefaultInstance = new AnnotatedCodeLocationBaselineEquals();
+        
+        public bool Equals(AnnotatedCodeLocation x, AnnotatedCodeLocation y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                if (x.FullyQualifiedLogicalName != y.FullyQualifiedLogicalName || x.LogicalLocationKey != y.LogicalLocationKey)
+                {
+                    return false;
+                }
+                if (x.Importance != y.Importance)
+                {
+                    return false;
+                }
+                if (x.Module != y.Module)
+                {
+                    return false;
+                }
+                if (x.Kind != y.Kind)
+                {
+                    return false;
+                }
+
+                if (x.Target != y.Target || x.TargetKey != y.TargetKey)
+                {
+                    return false;
+                }
+
+                if (!PhysicalLocationBaselineEquals.Instance.Equals(x.PhysicalLocation, y.PhysicalLocation))
+                {
+                    return false;
+                }
+                if (!ListComparisonHelpers.CompareListsAsSets(x.Annotations, y.Annotations, AnnotationBaselineEquals.Instance))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(AnnotatedCodeLocation obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode() ^ obj.Importance.GetNullCheckedHashCode() ^ obj.Kind.GetNullCheckedHashCode() ^ obj.Module.GetNullCheckedHashCode();
+
+            hs = hs ^ obj.Target.GetNullCheckedHashCode() ^ obj.TargetKey.GetNullCheckedHashCode() ^ obj.LogicalLocationKey.GetNullCheckedHashCode();
+
+            hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.PhysicalLocation);
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Annotations, AnnotationBaselineEquals.Instance);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/AnnotationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/AnnotationBaselineEquals.cs
@@ -28,13 +28,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(Annotation obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ obj.Message.GetNullCheckedHashCode();
+                hs = hs ^ obj.Message.GetNullCheckedHashCode();
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, PhysicalLocationBaselineEquals.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, PhysicalLocationBaselineEquals.Instance);
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/AnnotationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/AnnotationBaselineEquals.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class AnnotationBaselineEquals : IEqualityComparer<Annotation>
+    {
+        internal static readonly AnnotationBaselineEquals Instance = new AnnotationBaselineEquals();
+
+        public bool Equals(Annotation x, Annotation y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                if (!ListComparisonHelpers.CompareListsAsSets(x.Locations, y.Locations, PhysicalLocationBaselineEquals.Instance))
+                {
+                    return false;
+                }
+
+                if (x.Message != y.Message)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(Annotation obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ obj.Message.GetNullCheckedHashCode();
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, PhysicalLocationBaselineEquals.Instance);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/CodeFlowBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/CodeFlowBaselineEquals.cs
@@ -23,11 +23,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(CodeFlow obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Locations);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Locations);
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/CodeFlowBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/CodeFlowBaselineEquals.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class CodeFlowBaselineEqualityComparator : IEqualityComparer<CodeFlow>
+    {
+        internal static readonly CodeFlowBaselineEqualityComparator Instance = new CodeFlowBaselineEqualityComparator();
+
+        public bool Equals(CodeFlow x, CodeFlow y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                if (!ListComparisonHelpers.CompareListsOrdered(x.Locations, y.Locations, AnnotatedCodeLocationBaselineEquals.DefaultInstance))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(CodeFlow obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Locations);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {

--- a/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
     {
         public static int GetNullCheckedHashCode(this object obj)
         {
-            if(obj == null)
+            if (obj == null)
             {
                 return 0;
             }

--- a/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/DefaultBaselineExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    public static class DefaultBaselineExtensions
+    {
+        public static int GetNullCheckedHashCode(this object obj)
+        {
+            if(obj == null)
+            {
+                return 0;
+            }
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/ListComparisonHelpers.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/ListComparisonHelpers.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal static class ListComparisonHelpers
+    {
+        // Use the default or a given equality comparator to determine if two lists of elements are equal (with order mattering)
+        internal static bool CompareListsOrdered<T>(IList<T> left, IList<T> right, IEqualityComparer<T> equalityComparer = null)
+        {
+            if (!object.ReferenceEquals(left, right))
+            {
+                if (left == null || right == null)
+                {
+                    return false;
+                }
+                if (left.Count != right.Count)
+                {
+                    return false;
+                }
+                for (int i = 0; i < left.Count; i++)
+                {
+                    if (equalityComparer != null && equalityComparer.Equals(left[i], right[i]))
+                    {
+                        return false;
+                    }
+                    else if (equalityComparer == null && left[i].Equals(right[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Use the default or a given equality comparator to determine if two lists of elements are equal, ignoring order.
+        internal static bool CompareListsAsSets<T>(IList<T> left, IList<T> right, IEqualityComparer<T> equalityComparer = null)
+        {
+            if (!object.ReferenceEquals(left, right))
+            {
+                if (left == null || right == null)
+                {
+                    return false;
+                }
+                if (left.Count != right.Count)
+                {
+                    return false;
+                }
+                foreach (T l in left)
+                {
+                    if (equalityComparer != null && !right.Any(r => equalityComparer.Equals(l, r)))
+                    {
+                        return false;
+                    }
+                    else if (equalityComparer == null && !right.Any(r => r.Equals(l)))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        internal static int GetHashOfListContentsAsSets<T>(IList<T> obj, IEqualityComparer<T> equalityComparer = null)
+        {
+            int hs = 0;
+            if (obj != null)
+            {
+                for (int i = 0; i < obj.Count; i++)
+                {
+                    if (equalityComparer == null)
+                    {
+                        hs = hs ^ obj[i].GetHashCode();
+                    }
+                    else
+                    {
+                        hs = hs ^ equalityComparer.GetHashCode(obj[i]);
+                    }
+                }
+            }
+            return hs;
+        }
+
+        internal static int GetHashOfListContentsOrdered<T>(IList<T> obj, IEqualityComparer<T> equalityComparer = null)
+        {
+            uint hs = 0;
+            if (obj != null)
+            {
+                for (int i = 0; i < obj.Count; i++)
+                {
+                    hs = (hs << 1) | (hs >> 31); // Rotate by 1 bit.
+                    if (equalityComparer == null)
+                    {
+                        hs = hs ^ (uint)obj[i].GetHashCode();
+                    }
+                    else
+                    {
+                        hs = hs ^ (uint)equalityComparer.GetHashCode(obj[i]);
+                    }
+                }
+            }
+            return (int) hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/ListComparisonHelpers.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/ListComparisonHelpers.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -19,10 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
                 {
                     return false;
                 }
+
                 if (left.Count != right.Count)
                 {
                     return false;
                 }
+
                 for (int i = 0; i < left.Count; i++)
                 {
                     if (equalityComparer != null && equalityComparer.Equals(left[i], right[i]))
@@ -47,10 +47,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
                 {
                     return false;
                 }
+
                 if (left.Count != right.Count)
                 {
                     return false;
                 }
+
                 foreach (T l in left)
                 {
                     if (equalityComparer != null && !right.Any(r => equalityComparer.Equals(l, r)))

--- a/src/Sarif/Baseline/DefaultBaseline/LocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/LocationBaselineEquals.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -37,13 +35,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(Location obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.AnalysisTarget) ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.ResultFile);
+                hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.AnalysisTarget) ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.ResultFile);
 
-            hs = hs ^ obj.DecoratedName.GetNullCheckedHashCode() ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
+                hs = hs ^ obj.DecoratedName.GetNullCheckedHashCode() ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/LocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/LocationBaselineEquals.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class LocationBaselineEquals : IEqualityComparer<Location>
+    {
+        public static readonly LocationBaselineEquals Instance = new LocationBaselineEquals();
+
+        public bool Equals(Location x, Location y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                // Target and Result file should match.
+                if (!PhysicalLocationBaselineEquals.Instance.Equals(x.AnalysisTarget, y.AnalysisTarget))
+                {
+                    return false;
+                }
+
+                if (!PhysicalLocationBaselineEquals.Instance.Equals(x.ResultFile, y.ResultFile))
+                {
+                    return false;
+                }
+
+                // Code locations (decorated name/fully qualified logical name) should match.
+                if (x.DecoratedName != y.DecoratedName || x.FullyQualifiedLogicalName != y.FullyQualifiedLogicalName)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(Location obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.AnalysisTarget) ^ PhysicalLocationBaselineEquals.Instance.GetHashCode(obj.ResultFile);
+
+            hs = hs ^ obj.DecoratedName.GetNullCheckedHashCode() ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class PhysicalLocationBaselineEquals : IEqualityComparer<PhysicalLocation>
+    {
+        public static readonly PhysicalLocationBaselineEquals Instance = new PhysicalLocationBaselineEquals();
+        public bool Equals(PhysicalLocation x, PhysicalLocation y)
+        {
+            if(!object.ReferenceEquals(x, y))
+            {
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                // Only compare URI (so file path/relative file path).  UriBaseId and Region may change run over run.
+                if (x.Uri != y.Uri)
+                {
+                    return false;
+                }
+            }
+            
+            return true;
+        }
+
+        public int GetHashCode(PhysicalLocation obj)
+        {
+            return obj.Uri.GetNullCheckedHashCode();
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -31,7 +29,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(PhysicalLocation obj)
         {
-            return obj.Uri.GetNullCheckedHashCode();
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                return obj.Uri.GetNullCheckedHashCode();
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/PhysicalLocationBaselineEquals.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
         public static readonly PhysicalLocationBaselineEquals Instance = new PhysicalLocationBaselineEquals();
         public bool Equals(PhysicalLocation x, PhysicalLocation y)
         {
-            if(!object.ReferenceEquals(x, y))
+            if (!object.ReferenceEquals(x, y))
             {
                 if (x == null || y == null)
                 {

--- a/src/Sarif/Baseline/DefaultBaseline/ResultBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/ResultBaselineEquals.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class ResultBaselineEquals : IEqualityComparer<Result>
+    {
+        internal static readonly ResultBaselineEquals DefaultInstance = new ResultBaselineEquals();
+        
+        public bool Equals(Result x, Result y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                // Rule ID/Key should match
+                if (x.RuleId != y.RuleId || x.RuleKey != y.RuleKey)
+                {
+                    return false;
+                }
+                // Locations should all be the same.
+                if (!ListComparisonHelpers.CompareListsAsSets(x.Locations, y.Locations, LocationBaselineEquals.Instance))
+                {
+                    return false;
+                }
+                // Related Locations should all be the same.
+                if (!ListComparisonHelpers.CompareListsAsSets(x.RelatedLocations, y.RelatedLocations, AnnotatedCodeLocationBaselineEquals.DefaultInstance))
+                {
+                    return false;
+                }
+
+                // Finger print contributions should be the same.
+                if (x.ToolFingerprintContribution != y.ToolFingerprintContribution)
+                {
+                    return false;
+                }
+
+                // If stacks are present, we'll make sure they're the same
+                if (!ListComparisonHelpers.CompareListsAsSets(x.Stacks, y.Stacks, StackBaselineEquals.Instance))
+                {
+                    return false;
+                }
+
+                // If codeflows are present, we'll make sure they're the same.
+                if (!ListComparisonHelpers.CompareListsAsSets(x.CodeFlows, y.CodeFlows, CodeFlowBaselineEqualityComparator.Instance))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(Result obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ obj.RuleId.GetNullCheckedHashCode() ^ obj.RuleKey.GetNullCheckedHashCode() ^ obj.ToolFingerprintContribution.GetNullCheckedHashCode();
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, LocationBaselineEquals.Instance);
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.RelatedLocations, AnnotatedCodeLocationBaselineEquals.DefaultInstance);
+            
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Stacks, StackBaselineEquals.Instance);
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.CodeFlows, CodeFlowBaselineEqualityComparator.Instance);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/ResultBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/ResultBaselineEquals.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -21,11 +18,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
                 {
                     return false;
                 }
+
                 // Locations should all be the same.
                 if (!ListComparisonHelpers.CompareListsAsSets(x.Locations, y.Locations, LocationBaselineEquals.Instance))
                 {
                     return false;
                 }
+
                 // Related Locations should all be the same.
                 if (!ListComparisonHelpers.CompareListsAsSets(x.RelatedLocations, y.RelatedLocations, AnnotatedCodeLocationBaselineEquals.DefaultInstance))
                 {
@@ -55,19 +54,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(Result obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ obj.RuleId.GetNullCheckedHashCode() ^ obj.RuleKey.GetNullCheckedHashCode() ^ obj.ToolFingerprintContribution.GetNullCheckedHashCode();
+                hs = hs ^ obj.RuleId.GetNullCheckedHashCode() ^ obj.RuleKey.GetNullCheckedHashCode() ^ obj.ToolFingerprintContribution.GetNullCheckedHashCode();
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, LocationBaselineEquals.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Locations, LocationBaselineEquals.Instance);
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.RelatedLocations, AnnotatedCodeLocationBaselineEquals.DefaultInstance);
-            
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Stacks, StackBaselineEquals.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.RelatedLocations, AnnotatedCodeLocationBaselineEquals.DefaultInstance);
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.CodeFlows, CodeFlowBaselineEqualityComparator.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.Stacks, StackBaselineEquals.Instance);
 
-            return hs;
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsAsSets(obj.CodeFlows, CodeFlowBaselineEqualityComparator.Instance);
+
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/StackBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/StackBaselineEquals.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class StackBaselineEquals : IEqualityComparer<Stack>
+    {
+        public static readonly StackBaselineEquals Instance = new StackBaselineEquals();
+
+        public bool Equals(Stack x, Stack y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                if (!ListComparisonHelpers.CompareListsOrdered(x.Frames, y.Frames))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(Stack obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Frames, StackFrameBaselineEquals.Instance);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/StackBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/StackBaselineEquals.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -25,11 +23,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(Stack obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Frames, StackFrameBaselineEquals.Instance);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Frames, StackFrameBaselineEquals.Instance);
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/DefaultBaseline/StackFrameBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/StackFrameBaselineEquals.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
+{
+    internal class StackFrameBaselineEquals : IEqualityComparer<StackFrame>
+    {
+        public static readonly StackFrameBaselineEquals Instance = new StackFrameBaselineEquals();
+
+        public bool Equals(StackFrame x, StackFrame y)
+        {
+            if (!object.ReferenceEquals(x, y))
+            {
+                if (x.Uri != y.Uri)
+                {
+                    return false;
+                }
+                if (x.FullyQualifiedLogicalName != y.FullyQualifiedLogicalName)
+                {
+                    return false;
+                }
+                if (x.Module != y.Module)
+                {
+                    return false;
+                }
+                if (!ListComparisonHelpers.CompareListsOrdered(x.Parameters, y.Parameters))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public int GetHashCode(StackFrame obj)
+        {
+            int hs = 0;
+
+            hs = hs ^ obj.Uri.GetNullCheckedHashCode();
+
+            hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
+
+            hs = hs ^ obj.Module.GetNullCheckedHashCode();
+
+            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Parameters);
+
+            return hs;
+        }
+    }
+}

--- a/src/Sarif/Baseline/DefaultBaseline/StackFrameBaselineEquals.cs
+++ b/src/Sarif/Baseline/DefaultBaseline/StackFrameBaselineEquals.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 {
@@ -37,17 +35,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.DefaultBaseline
 
         public int GetHashCode(StackFrame obj)
         {
-            int hs = 0;
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+            else
+            {
+                int hs = 0;
 
-            hs = hs ^ obj.Uri.GetNullCheckedHashCode();
+                hs = hs ^ obj.Uri.GetNullCheckedHashCode();
 
-            hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
+                hs = hs ^ obj.FullyQualifiedLogicalName.GetNullCheckedHashCode();
 
-            hs = hs ^ obj.Module.GetNullCheckedHashCode();
+                hs = hs ^ obj.Module.GetNullCheckedHashCode();
 
-            hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Parameters);
+                hs = hs ^ ListComparisonHelpers.GetHashOfListContentsOrdered(obj.Parameters);
 
-            return hs;
+                return hs;
+            }
         }
     }
 }

--- a/src/Sarif/Baseline/ISarifLogBaseliner.cs
+++ b/src/Sarif/Baseline/ISarifLogBaseliner.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    public interface ISarifLogBaseliner
+    {
+        Run CreateBaselinedRun(Run baseLine, Run nextLog);
+    }
+}

--- a/src/Sarif/Baseline/SarifBaselineType.cs
+++ b/src/Sarif/Baseline/SarifBaselineType.cs
@@ -6,6 +6,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
     public enum SarifBaselineType
     {
         Strict = 0,
-
+        Standard = 1,
     }
 }

--- a/src/Sarif/Baseline/SarifBaselineType.cs
+++ b/src/Sarif/Baseline/SarifBaselineType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    public enum SarifBaselineType
+    {
+        Strict = 0,
+
+    }
+}

--- a/src/Sarif/Baseline/SarifLogBaseliner.cs
+++ b/src/Sarif/Baseline/SarifLogBaseliner.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    internal class SarifLogBaseliner : ISarifLogBaseliner
+    {
+        IEqualityComparer<Result> ResultComparator;
+
+        public SarifLogBaseliner(IEqualityComparer<Result> comparator)
+        {
+            ResultComparator = comparator;
+        }
+
+        public Run CreateBaselinedRun(Run baseLine, Run nextLog)
+        {
+            Run differencedRun = nextLog.DeepClone();
+            differencedRun.Results = new List<Result>();
+            
+            foreach(var result in nextLog.Results)
+            {
+                Result newResult = result.DeepClone();
+
+                newResult.BaselineState = 
+                    baseLine.Results.Contains(result, ResultComparator) ? BaselineState.Existing : BaselineState.New;
+
+                differencedRun.Results.Add(newResult);
+            }
+
+            foreach(var result in baseLine.Results)
+            {
+                if(!nextLog.Results.Contains(result, ResultComparator))
+                {
+                    Result newResult = result.DeepClone();
+                    newResult.BaselineState = BaselineState.Absent;
+                    differencedRun.Results.Add(newResult);
+                }
+            }
+
+            return differencedRun;
+        }
+    }
+}

--- a/src/Sarif/Baseline/SarifLogBaseliner.cs
+++ b/src/Sarif/Baseline/SarifLogBaseliner.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             Run differencedRun = nextLog.DeepClone();
             differencedRun.Results = new List<Result>();
             
-            foreach(var result in nextLog.Results)
+            foreach (var result in nextLog.Results)
             {
                 Result newResult = result.DeepClone();
 
@@ -30,9 +30,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
                 differencedRun.Results.Add(newResult);
             }
 
-            foreach(var result in baseLine.Results)
+            foreach (var result in baseLine.Results)
             {
-                if(!nextLog.Results.Contains(result, ResultComparator))
+                if (!nextLog.Results.Contains(result, ResultComparator))
                 {
                     Result newResult = result.DeepClone();
                     newResult.BaselineState = BaselineState.Absent;

--- a/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
+++ b/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    public class SarifLogBaselinerFactory
+    {
+        public static ISarifLogBaseliner CreateSarifLogBaseliner(SarifBaselineType logBaselinerType)
+        {
+            switch (logBaselinerType)
+            {
+                case SarifBaselineType.Strict:
+                    return new SarifLogBaseliner(Result.ValueComparer);
+                default:
+                    return new SarifLogBaseliner(Result.ValueComparer);
+
+            }
+        }
+    }
+}

--- a/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
+++ b/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
@@ -15,7 +15,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
                     return new SarifLogBaseliner(DefaultBaseline.ResultBaselineEquals.DefaultInstance);
                 default:
                     return new SarifLogBaseliner(Result.ValueComparer);
-
             }
         }
     }

--- a/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
+++ b/src/Sarif/Baseline/SarifLogBaselinerFactory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             {
                 case SarifBaselineType.Strict:
                     return new SarifLogBaseliner(Result.ValueComparer);
+                case SarifBaselineType.Standard:
+                    return new SarifLogBaseliner(DefaultBaseline.ResultBaselineEquals.DefaultInstance);
                 default:
                     return new SarifLogBaseliner(Result.ValueComparer);
 


### PR DESCRIPTION
Adds a 'baseline' command to the multitool, which will compare two runs (one run per file) and create a new file with the appropriate states set.

There are two options for baselining at the moment--strict, which treats an issue as unique if *anything* changes, and standard, which treats an issue as unique if a variety of features that are more likely to be stable change.  Standard is kind of a test at the moment--we'll likely want to tune it as we get more experience with real results.