### PR TITLE
Remove DirectProducer tests from ValidationTests

### DIFF
--- a/src/Sarif.ValidationTests/SarifValidatorTests.cs
+++ b/src/Sarif.ValidationTests/SarifValidatorTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly string[] s_testFileDirectories = new string[]
         {
-            "DirectProducerTestData",
+            //"DirectProducerTestData",
             "ConverterTestData",
             "SpecExamples"
         };


### PR DESCRIPTION
Wasting a lot of time fiddling with these test files. Will regenerate them and revert this change once we finish with schema changes.