### PR TITLE
Dev/evmaus ms/sarif v2 rm propagate properties

### DIFF
--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 {
     /// <summary>
-    /// 
+    /// A set of two results that have been matched by a matching algorithm.
     /// </summary>
     public class MatchedResults
     {
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         public MatchingResult CurrentResult;
 
         public IResultMatcher MatchingAlgorithm;
-
-
+        
         public Result CalculateNewBaselineResult()
         {
             Result result = null;


### PR DESCRIPTION
Propagate existing properties in the specially named property when result matching, other than the ones that are set by the result matcher.