### PR TITLE
Float file regions cache notion + basic unit test harness

### DIFF
--- a/src/Sarif.UnitTests/FileRegionsCacheTests.cs
+++ b/src/Sarif.UnitTests/FileRegionsCacheTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.ObjectModel;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.UnitTests
+{
+    public class FileRegionsCacheTests
+    {
+        //                                 0          10          20         30
+        //                                 01234 5 6789012 3 45678901 2 345679012
+        private const string s_testText = "line1\r\n line2\r\n  line3\r\n   line4";
+
+        private static ReadOnlyCollection<Tuple<string, Region, Region>> s_testCases =
+            new ReadOnlyCollection<Tuple<string, Region, Region>>(new Tuple<string, Region, Region>[]
+            {
+                // Regions specified only by start line
+                new Tuple<string, Region, Region>(
+                    "line1",
+                    new Region() { StartLine = 1 }, 
+                    new Region() { StartLine = 1, EndLine = 1, StartColumn = 1, EndColumn = 5, CharOffset = 0, CharLength = 5 })
+            });
+
+
+        [Fact]
+        public void FileRegionsCache_PopulatesRegionsFromAbsoluteFileUri()
+        {            
+            var run = new Run();
+            var fileRegionsCache = new FileRegionsCache(run);
+
+            Uri uri = new Uri(@"c:\temp\myFile.cpp");
+            var mockFileSystem = MockFactory.MakeMockFileSystem(uri.LocalPath, s_testText);
+
+            fileRegionsCache._fileSystem = mockFileSystem;
+
+            var physicalLocation = new PhysicalLocation()
+            {
+                FileLocation = new FileLocation()
+                {
+                    Uri = uri
+                }
+            };
+
+            ExecuteTests(fileRegionsCache, physicalLocation);
+        }
+
+        private static void ExecuteTests(FileRegionsCache fileRegionsCache, PhysicalLocation physicalLocation)
+        {
+            foreach (Tuple<string, Region, Region> testCase in s_testCases)
+            {
+                string snippet = testCase.Item1;
+                Region inputRegion = testCase.Item2;
+                Region expectedRegion = testCase.Item3;
+
+                physicalLocation.Region = inputRegion;
+
+                Region actualRegion = fileRegionsCache.PopulatePrimaryRegionProperties(physicalLocation, populateSnippet: false);
+
+                actualRegion.ValueEquals(expectedRegion).Should().BeTrue();
+                actualRegion.Snippet.Should().BeNull();
+
+                actualRegion = fileRegionsCache.PopulatePrimaryRegionProperties(physicalLocation, populateSnippet: true);
+
+                expectedRegion.Snippet = new FileContent() { Text = snippet };
+                actualRegion.ValueEquals(expectedRegion).Should().BeTrue();
+                actualRegion.Snippet.Text.Should().Be(snippet);
+            }
+        }
+    }
+}

--- a/src/Sarif.UnitTests/MockFactory.cs
+++ b/src/Sarif.UnitTests/MockFactory.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Moq;
+
+using Match = System.Text.RegularExpressions.Match; // Avoid ambiguity with Moq.Match;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    internal static class MockFactory
+    {
+        public static IFileSystem MakeMockFileSystem(string fileName, string fileText = null, string[] fileLines = null)
+        {
+            var mock = new Mock<IFileSystem>(MockBehavior.Strict);
+            mock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns((string s) => s.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+            mock.Setup(fs => fs.GetFullPath(It.IsAny<string>())).Returns((string path) => path);
+            mock.Setup(fs => fs.ReadAllText(fileName)).Returns(fileText);
+            mock.Setup(fs => fs.ReadAllLines(fileName)).Returns(fileLines);
+            return mock.Object;
+        }
+    }
+}

--- a/src/Sarif/FileRegionsCache.cs
+++ b/src/Sarif/FileRegionsCache.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// This class is a file cache that can be used to populate
+    /// regions with comprehensive data, to retrieve file text
+    /// associated with a SARIF log, and to construct text
+    /// snippets associated with region instances.
+    /// </summary>
+    public class FileRegionsCache
+    {
+        internal IFileSystem _fileSystem;
+
+        private Run _run;
+
+        public FileRegionsCache(Run run)
+        {
+            // Each file regions cache is associated with a single SARIF run.
+            // The reason is that a run provides an isolated scope for 
+            // things like URLs, point-in-time file contents, etc.
+            _run = run;
+
+            _fileSystem = new FileSystem();
+        }
+
+        /// <summary>
+        /// Accepts a physical location and returns a Region object, based on the input
+        /// physicalLocation.region property, that has all its properties populated. If an 
+        /// input text region, for example, only specifies the startLine property, the returned
+        /// Region instance will have computed and populated other properties, such as charOffset,
+        /// charLength, etc. 
+        /// </summary>
+        /// <param name="physicalLocation">The physical location containing the region which should be populated.</param>
+        /// <param name="populateSnippet">Specifies whether the physicalLocation.region.snippet property should be populated.</param>
+        /// <returns></returns>
+        public Region PopulatePrimaryRegionProperties(PhysicalLocation physicalLocation, bool populateSnippet)
+        {
+            Region inputRegion = physicalLocation.Region;
+
+            if (inputRegion == null || inputRegion.IsBinaryRegion)
+            {
+                // For binary regions, only the byteOffset and byteLength properties
+                // are relevant, and their values are always specified.
+                return inputRegion;
+            }
+
+            string fileText = GetFileText(physicalLocation.FileLocation);
+            return PopulatePrimaryRegionProperties(fileText, inputRegion, populateSnippet);
+        }
+
+        private Region PopulatePrimaryRegionProperties(string fileText, Region inputRegion, bool populateSnippet)
+        {
+            if (fileText == null) { return inputRegion; }
+
+            Region result = new Region() { StartLine = 1, EndLine = 1, StartColumn = 1, EndColumn = 5, CharOffset = 0, CharLength = 5 };
+
+            if (populateSnippet) { result.Snippet = new FileContent() { Text = "line1" }; }
+
+            return result;
+        }
+
+        private string GetFileText(FileLocation fileLocation)
+        {
+            return _fileSystem.ReadAllText(fileLocation.Uri.LocalPath);
+        }
+    }
+}


### PR DESCRIPTION
@lgolding @EasyRhin0 

This is setup work for hydrating region text snippets. In order to do so, we need to compute the actual length of a region (which isn't always explicit). I propose to do this with a 'file regions cache' object that has the capability of completing expanding a region's properties and to then compute the textual snippet associated with that precise region.

This PR just shows the basic mechanics of unit-testing with no real functionality.

Michael