### PR TITLE
Clean up handling of schema file in tests

### DIFF
--- a/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
+++ b/src/Sarif.FunctionalTests/Sarif.FunctionalTests.csproj
@@ -3592,10 +3592,4 @@
       <LastGenOutput>startioroutine.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <Target Name="CopyFilesToOutput" AfterTargets="Build">
-    <ItemGroup>
-      <FilesToCopy Include="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json" />
-    </ItemGroup>
-    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(MsBuildThisFileDirectory)\..\..\bld\bin\$(Platform)_$(Configuration)\$(TargetFramework)\" />
-  </Target>
 </Project>

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -30,6 +30,12 @@
     <Reference Include="..\..\refs\$(TargetFramework)\*.dll" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Target Name="CopyTestData" AfterTargets="Build">
     <ItemGroup>
       <v1ConverterTestData Include="$(SolutionDir)\Sarif.FunctionalTests\v1\ConverterTestData\**\*.sarif" />
@@ -45,6 +51,5 @@
     <Copy SourceFiles="@(v2ConverterTestData)" DestinationFolder="$(OutputPath)v2\ConverterTestData\%(RecursiveDir)" />
     <Copy SourceFiles="@(v2DirectProducerTestData)" DestinationFolder="$(OutputPath)v2\DirectProducerTestData\%(RecursiveDir)" />
     <Copy SourceFiles="@(v2SpecExamples)" DestinationFolder="$(OutputPath)v2\SpecExamples\%(RecursiveDir)" />
-    <Copy SourceFiles="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json" DestinationFolder="$(OutputPath)" />
   </Target>
 </Project>


### PR DESCRIPTION
Sarif.FunctionalTests incorrectly copied the schema to the root of the bld\bin directory rather than to the Sarif.FunctionalTests subdirectory of the bld\bin directory. It turns out that the functional tests don't need the schema at all, so I removed the Copy task from the project file.

Sarif.ValidationTests copied the schema in such a way that not only was there a copy in each framework directory (for example. bld\bin\Sarif.ValidationTests\Any_CPU_Release\net461), but there was an extra copy in the "flavor" directory (bld\bin\Sarif.ValidationTests\Any_CPU_Release). I fixed that as well.

This was one of the tasks on my punch list as I converted the repo to the new project system. I noticed it because I wondered why there were copies of the schema directly under bld\bin\AnyCPU_Release.