### PR TITLE
Restore the ability to create a proper Sarif.Multitool NuGet package.

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -14,18 +14,12 @@
     <tags>SARIF command line static analysis</tags>
   </metadata>
   <files>
-	  <!-- NOTE: the exclude attribute must be on a single line -->
-    <file src="bld\bin\AnyCPU_$configuration$\**\*"
-          target="tools"
-          exclude="**\ConverterTestData\**\*;**\DirectProducerTestData\**\*;**\SpecExamples\**\*;**\FluentAssertions.*;**\Castle.Core.dll;**\Moq.dll;**\UpdateBaselines.ps1;**\xunit.*;**\*Tests.*;**\*.TestUtilities.*;**\Sarif.schema.json"/>
-
-    <!-- Restore the netstandard assemblies from the package cache -->
-    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.*" target="tools\netcoreapp2.0" />
-    <file src="src\packages\CommandLineParser.*\lib\netstandard1.5\CommandLine.*" target="tools\netstandard2.0" />
-    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.*" target="tools\netcoreapp2.0" />
-    <file src="src\packages\CsvHelper.*\lib\netstandard1.3\CsvHelper.*" target="tools\netstandard2.0" />
-    <file src="src\packages\newtonsoft.json.10.*\lib\netstandard1.3\Newtonsoft.Json.*" target="tools\netcoreapp2.0" />
-    <file src="src\packages\newtonsoft.json.10.*\lib\netstandard1.3\Newtonsoft.Json.*" target="tools\netstandard2.0" />
+    <file src="bld\bin\Sarif.Multitool\AnyCPU_$configuration$\Publish\net461\**"
+          target="tools\net461"
+          />
+    <file src="bld\bin\Sarif.Multitool\AnyCPU_$configuration$\Publish\netcoreapp2.0\**"
+          target="tools\netcoreapp2.0"
+          />
 
     <file src="src\ReleaseHistory.md" />        
     <file src="src\Sarif.Multitool\**\*.cs" target="src" />


### PR DESCRIPTION
In my previous change, I removed an unnecessary subdirectory `AnyCPU_Release` from the root of the `bld\bin` directory. Unfortunately, I didn't let `BuildAndTest` run all the way through before I merged, so I didn't notice that this caused the creation of the `Sarif.Multitool` NuGet package to fail.

Actually, that package creation was already badly broken, in a couple of ways, and my mistake simply exposed the problem:

1. The `.nuspec` file asked for "all the files under `bld\bin\AnyCPU_Release`". But we were no longer placing _any_ binaries under `bld\bin\AnyCPU_Release`; they were all under individual project directories like `bld\bin\Sarif.Driver\AnyCPU_Release`. The only file directly under `bld\bin\AnyCPU_Release` was the schema file, which didn't belong there at all -- and also, which the `.nuspec` file was explicitly excluding! So when the package creation was "succeeding", it was creating a package with no files in it.

2. The _intent_ of the `.nuspec` file was to gather the entire contents of the `bld\bin` directory, and then _exclude_ the things we didn't want, like test binaries and test content. This was an error-prone process, and what's more, once you'd done it, the `.nuspec` file still had to reach into the `packages` directory to pull out the package binaries that the Multitool needs.

But good news! The `dotnet publish` command creates a layout directory that contains _precisely_ all the files that the Multitool needs, and no others. So all the `.nuspec` file has to do is reach into the `Publish` directory.

And that's what this change does.