### PR TITLE
Fix copying of validation test files

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -139,6 +139,8 @@ function New-NuGetPackageFromNuspecFile($project, $version, $suffix = "") {
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
     }
+
+    Write-Information "  Successfully created package '$BinRoot\NuGet\$Configuration\$Project.$version.nupkg'."
 }
 
 function New-NuGetPackages {

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -31,25 +31,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="$(SolutionDir)\Sarif\Schemata\Sarif.schema.json"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(SolutionDir)\Sarif.FunctionalTests\v1\**\*.sarif"
+          CopyToOutputDirectory="PreserveNewest"
+          LinkBase="v1" />
+    <None Include="$(SolutionDir)\Sarif.FunctionalTests\v2\**\*.sarif"
+          CopyToOutputDirectory="PreserveNewest"
+          LinkBase="v2" />
   </ItemGroup>
-
-  <Target Name="CopyTestData" AfterTargets="Build">
-    <ItemGroup>
-      <v1ConverterTestData Include="$(SolutionDir)\Sarif.FunctionalTests\v1\ConverterTestData\**\*.sarif" />
-      <v1DirectProducerTestData Include="$(SolutionDir)\Sarif.FunctionalTests\v1\DirectProducerTestData\**\*.sarif" />
-      <v1SpecExamples Include="$(SolutionDir)\Sarif.FunctionalTests\v1\SpecExamples\**\*.sarif" />
-      <v2ConverterTestData Include="$(SolutionDir)\Sarif.FunctionalTests\v2\ConverterTestData\**\*.sarif" />
-      <v2DirectProducerTestData Include="$(SolutionDir)\Sarif.FunctionalTests\v2\DirectProducerTestData\**\*.sarif" />
-      <v2SpecExamples Include="$(SolutionDir)\Sarif.FunctionalTests\v2\SpecExamples\**\*.sarif" />
-    </ItemGroup>
-    <Copy SourceFiles="@(v1ConverterTestData)" DestinationFolder="$(OutputPath)v1\ConverterTestData\%(RecursiveDir)" />
-    <Copy SourceFiles="@(v1DirectProducerTestData)" DestinationFolder="$(OutputPath)v1\DirectProducerTestData\%(RecursiveDir)" />
-    <Copy SourceFiles="@(v1SpecExamples)" DestinationFolder="$(OutputPath)v1\SpecExamples\%(RecursiveDir)" />
-    <Copy SourceFiles="@(v2ConverterTestData)" DestinationFolder="$(OutputPath)v2\ConverterTestData\%(RecursiveDir)" />
-    <Copy SourceFiles="@(v2DirectProducerTestData)" DestinationFolder="$(OutputPath)v2\DirectProducerTestData\%(RecursiveDir)" />
-    <Copy SourceFiles="@(v2SpecExamples)" DestinationFolder="$(OutputPath)v2\SpecExamples\%(RecursiveDir)" />
-  </Target>
 </Project>


### PR DESCRIPTION
The files were being copied in such a way that they ended up not only in the framework binaries directory (e.g., `bld\bin\Sarif.ValidationTests\AnyCPU_Release\net461`, but also in the parent directory (e.g., `bld\bin\Sarif.ValidationTests\AnyCPU_Release`). I don't know why.

This change not only avoids the extra copy, but is much simpler, and takes advantage of the project system rather than using custom code.