### PR TITLE
Fix autogenerated comment

### DIFF
--- a/src/Sarif/Autogenerated/Region.cs
+++ b/src/Sarif/Autogenerated/Region.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public int EndLine { get; set; }
 
         /// <summary>
-        /// The column number of the last character in the region.
+        /// The column number of the character following the end of the region.
         /// </summary>
         [DataMember(Name = "endColumn", IsRequired = false, EmitDefaultValue = false)]
         public int EndColumn { get; set; }


### PR DESCRIPTION
When I checked in a change to the schema, I neglected to push the resulting change to the comment in the autogenerated source file.