### PR TITLE
AppVeyor should now build sarif-v1, not -v2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 branches:
   only:
     - master
-    - sarif-v2
+    - sarif-v1
 
 before_build:
   - '"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"'


### PR DESCRIPTION
I missed this when I did the master/sarif-v2/sarif-v1 branch shuffle yesterday. I noticed it when I used this file to seed the one in jschema.