### PR TITLE
Pass NoClean flag from BuildAndTest to BeforeBuild.

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -216,7 +216,7 @@ function Set-SarifFileAssociationRegistrySettings {
     }
 }
 
-& $PSScriptRoot\BeforeBuild.ps1 -NoRestore:$NoRestore -NoObjectModel:$NoObjectModel
+& $PSScriptRoot\BeforeBuild.ps1 -NoClean:$NoClean -NoRestore:$NoRestore -NoObjectModel:$NoObjectModel
 if (-not $?) {
     Exit-WithFailureMessage $ScriptName "BeforeBuild failed."
 }


### PR DESCRIPTION
I missed this in the previous PR when I moved the Clean operation into BeforeBuild.