### PR TITLE
Powershell Build Updates

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -6,6 +6,8 @@
     NuGet packages.
 .PARAMETER Configuration
     The build configuration: Release or Debug. Default=Release
+.PARAMETER SDKOnly
+    Build only the SARIF SDK, rather than the SDK and the VSIX.
 .PARAMETER NoClean
     Do not remove the outputs from the previous build.
 .PARAMETER NoRestore
@@ -31,6 +33,9 @@ param(
     [string]
     [ValidateSet("Debug", "Release")]
     $Configuration="Release",
+
+    [switch]
+    $SDKOnly,
 
     [switch]
     $NoClean,
@@ -69,7 +74,15 @@ $ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
 Import-Module -Force $PSScriptRoot\Projects.psm1
 
-$SolutionFile = "$SourceRoot\Everything.sln"
+if (-not $SDKOnly)
+{
+    $SolutionFile = "$SourceRoot\Everything.sln"
+} 
+else 
+{
+    $SolutionFile = "$SourceRoot\Everything.sln"
+}
+
 $Platform = "AnyCPU"
 $BuildTarget = "Rebuild"
 $PackageOutputDirectory = "$BinRoot\NuGet\$Configuration"

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -80,7 +80,7 @@ if (-not $SDKOnly)
 } 
 else 
 {
-    $SolutionFile = "$SourceRoot\Everything.sln"
+    $SolutionFile = "$SourceRoot\Sarif.SDK.sln"
 }
 
 $Platform = "AnyCPU"

--- a/scripts/BuildPackagesFromSigningDirectory.ps1
+++ b/scripts/BuildPackagesFromSigningDirectory.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    Package the SARIF SDK from a custom signing directory.
+.DESCRIPTION
+    Builds the SARIF SDK NuGet Packages from a custom signing directory after
+    they have been signed.
+.PARAMETER Configuration
+    The build configuration: Release or Debug. Default=Release
+#>
+
+[CmdletBinding()]
+param(
+    [string]
+    [ValidateSet("Debug", "Release")]
+    $Configuration="Release"
+)
+
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\Projects.psm1
+
+# Copy signed binaries back into the normal directory structure.
+function CopyFromSigningDirectory {
+    Write-Information "Copying files to signing directory..."
+    $SigningDirectory = "$BinRoot\Signing"
+
+    foreach ($project in $Projects.NewProduct) {
+        $projectBinDirectory = "$BinRoot\${Platform}_$Configuration\$project\"
+
+        foreach ($framework in $Frameworks.All) {
+            $sourceDirectory = "$SigningDirectory\$framework"
+            $destinationDirectory = "$projectBinDirectory\$framework"
+
+            # Everything we copy is a DLL, _except_ that application projects built for
+            # NetFX have a .exe extension.
+            $fileExtension = ".dll"
+            if ($Projects.NewApplication -contains $project -and $Frameworks.NetFx -contains $framework) {
+                $fileExtension = ".exe"
+            }
+
+            $fileToCopy = "$sourceDirectory\$project$fileExtension"
+            if (Test-Path $fileToCopy) {
+                Write-Information "$fileToCopy $destinationDirectory"
+                Copy-Item -Force -Path $fileToCopy -Destination $destinationDirectory
+            }
+        }
+    }
+
+    # Copy the viewer. Its name doesn't fit the pattern binary name == project name,
+    # so we copy it by hand.
+    foreach ($framework in $Frameworks.NetFX) {
+        Copy-Item -Force -Path $SigningDirectory\$framework\Microsoft.Sarif.Viewer.dll -Destination $BinRoot\${Platform}_$Configuration\Sarif.Viewer.VisualStudio\Microsoft.Sarif.Viewer.dll
+    }
+}
+
+CopyFromSigningDirectory
+
+New-NuGetPackages $Configuration $Projects

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -18,8 +18,7 @@ $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 # Frameworks for which we build applications.
 $Frameworks.Application = @("netcoreapp2.0") + $Frameworks.NetFx
 
-$Frameworks.All = ($Frameworks.LIbrary + $Frameworks.Application | Select -Unique)
-
+$Frameworks.All = ($Frameworks.Library + $Frameworks.Application | Select -Unique)
 
 $Projects = @{}
 

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -43,7 +43,7 @@ $TestRunnerRootPath = "$NuGetPackageRoot\xunit.runner.console\2.3.1\tools\"
 foreach ($project in $Projects.NewTest) {
     foreach ($framework in $Frameworks.Application) {
         Write-Information "Running tests in ${project}: $framework..."
-        Push-Location $BinRoot\AnyCPU_$Configuration\$project\$framework
+        Push-Location $BinRoot\${Platform}_$Configuration\$project\$framework
         $dll = "$project" + ".dll"
         if ($framework -eq "netcoreapp2.0") {
             & dotnet ${TestRunnerRootPath}netcoreapp2.0\xunit.console.dll $dll $ReporterOption
@@ -60,7 +60,7 @@ foreach ($project in $Projects.NewTest) {
 
 foreach ($project in $Projects.OldTest) {
     Write-Information "Running tests in ${project}..."
-    Push-Location $BinRoot\AnyCPU_$Configuration\$project
+    Push-Location $BinRoot\${Platform}_$Configuration\$project
     $dll = "$project" + ".dll"
     & ${TestRunnerRootPath}net452\xunit.console.exe $dll $ReporterOption -parallel none
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -43,7 +43,7 @@ $TestRunnerRootPath = "$NuGetPackageRoot\xunit.runner.console\2.3.1\tools\"
 foreach ($project in $Projects.NewTest) {
     foreach ($framework in $Frameworks.Application) {
         Write-Information "Running tests in ${project}: $framework..."
-        Push-Location $BinRoot\$project\AnyCPU_$Configuration\$framework
+        Push-Location $BinRoot\AnyCPU_$Configuration\$project\$framework
         $dll = "$project" + ".dll"
         if ($framework -eq "netcoreapp2.0") {
             & dotnet ${TestRunnerRootPath}netcoreapp2.0\xunit.console.dll $dll $ReporterOption
@@ -60,7 +60,7 @@ foreach ($project in $Projects.NewTest) {
 
 foreach ($project in $Projects.OldTest) {
     Write-Information "Running tests in ${project}..."
-    Push-Location $BinRoot\$project\AnyCPU_$Configuration
+    Push-Location $BinRoot\AnyCPU_$Configuration\$project
     $dll = "$project" + ".dll"
     & ${TestRunnerRootPath}net452\xunit.console.exe $dll $ReporterOption -parallel none
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -33,19 +33,89 @@ function Exit-WithFailureMessage($scriptName, $message) {
     exit 1
 }
 
+# NuGet Package Creation section
+function New-NuGetPackageFromProjectFile($Configuration, $project, $version) {
+    $PackageOutputDirectory = "$BinRoot\NuGet\$Configuration"
+    $projectFile = "$SourceRoot\$project\$project.csproj"
+
+    $arguments =
+        "pack", $projectFile,
+        "--configuration", $Configuration,
+        "--no-build", "--no-restore",
+        "--include-source", "--include-symbols",
+        "-p:Platform=$Platform",
+        "--output", $PackageOutputDirectory
+
+    Write-Debug "dotnet $($arguments -join ' ')"
+
+    dotnet $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
+    }
+}
+
+function New-NuGetPackageFromNuspecFile($Configuration, $project, $version, $suffix = "") {
+    $PackageOutputDirectory = "$BinRoot\NuGet\$Configuration"
+    $nuspecFile = "$SourceRoot\NuGet\$project.nuspec"
+
+    $arguments=
+        "pack", $nuspecFile,
+        "-Symbols",
+        "-Properties", "configuration=$Configuration;version=$version",
+        "-Verbosity", "Quiet",
+        "-BasePath", ".\",
+        "-OutputDirectory", $PackageOutputDirectory
+
+    if ($suffix -ne "") {
+        $arguments += "-Suffix", $Suffix
+    }
+
+    $nugetExePath = "$RepoRoot\.nuget\NuGet.exe"
+
+    Write-Debug "$nuGetExePath $($arguments -join ' ')"
+
+    &$nuGetExePath $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
+    }
+
+    Write-Information "  Successfully created package '$BinRoot\NuGet\$Configuration\$Project.$version.nupkg'."
+}
+
+function New-NuGetPackages($Configuration, $Projects) {
+    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
+    $version = "$versionPrefix-$versionSuffix"
+
+    # We can build the NuGet packages for library projects directly from their
+    # project file.
+    foreach ($project in $Projects.NewLibrary) {
+        New-NuGetPackageFromProjectFile $Configuration $project $version
+    }
+
+    # Unfortunately, application projects like MultiTool need to include things
+    # that are not specified in the project file, so their packages still require
+    # a .nuspec file.
+    foreach ($project in $Projects.NewApplication) {
+        New-NuGetPackageFromNuSpecFile $Configuration $project $version
+    }
+}
+
 $RepoRoot = $(Resolve-Path $PSScriptRoot\..).Path
+$Platform = "AnyCPU"
 $SourceRoot = "$RepoRoot\src"
 $NuGetPackageRoot = "$SourceRoot\packages"
 $JsonSchemaPath = "$SourceRoot\Sarif\Schemata\Sarif.schema.json"
 $BuildRoot = "$RepoRoot\bld"
 $BinRoot = "$BuildRoot\bin"
-
 $SarifExtension = ".sarif"
 
 Export-ModuleMember -Function `
     Exit-WithFailureMessage, `
     New-DirectorySafely, `
-    Remove-DirectorySafely
+    Remove-DirectorySafely, `
+    New-NuGetPackages, `
+    New-NuGetPackageFromProjectFile, `
+    New-NuGetPackageFromNuSpecFile
 
 Export-ModuleMember -Variable `
     RepoRoot, `
@@ -54,4 +124,6 @@ Export-ModuleMember -Variable `
     JsonSchemaPath, `
     BuildRoot, `
     BinRoot, `
-    SarifExtension
+    SarifExtension, `
+    Platform, `
+    PackageOutputDirectory

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -14,10 +14,10 @@
     <tags>SARIF command line static analysis</tags>
   </metadata>
   <files>
-    <file src="bld\bin\Sarif.Multitool\AnyCPU_$configuration$\Publish\net461\**"
+    <file src="bld\bin\AnyCPU_$configuration$\Sarif.Multitool\Publish\net461\**"
           target="tools\net461"
           />
-    <file src="bld\bin\Sarif.Multitool\AnyCPU_$configuration$\Publish\netcoreapp2.0\**"
+    <file src="bld\bin\AnyCPU_$configuration$\Sarif.Multitool\Publish\netcoreapp2.0\**"
           target="tools\netcoreapp2.0"
           />
 

--- a/src/build.common.props
+++ b/src/build.common.props
@@ -9,8 +9,8 @@ whether they use the VS 2017 project system or the old project system.
 
   <PropertyGroup Label="Build">
     <OutputSubDir>$(Platform)_$(Configuration)</OutputSubDir>
-    <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(MSBuildProjectName)\$(OutputSubDir)\</IntermediateOutputPath>
-    <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(MSBuildProjectName)\$(OutputSubDir)\</OutputPath>
+    <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(OutputSubDir)\$(MSBuildProjectName)\</IntermediateOutputPath>
+    <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>
     <PublishDir>$(OutputPath)\Publish\$(TargetFramework)\</PublishDir>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MsBuildThisFileDirectory)</SolutionDir>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
The main changes here are:
1. Switching output back to \bld\bin\AnyCPU_$Configuration\$(Project) rather than \bld\bin\$Project\AnyCPU_Configuration--the second allows you to clean up a particular flavor of build much more easily.
2. Adding a script to pull the libraries back from the Signing directory to create the NuGet packages.  This is necessary for automating the entire process of (build) -> (sign) -> (package).

This does some restructuring of the Powershell build scripts--in particular, I opted to move the NuGet package creation into the shared scripts.