### PR TITLE
Restore the functionality of DelistCurrentPackages.cmd

### DIFF
--- a/DelistCurrentPackages.cmd
+++ b/DelistCurrentPackages.cmd
@@ -1,27 +1,2 @@
 @echo off
-call SetCurrentVersion.cmd
-
-set VERSION=%MAJOR_PREVIOUS%.%MINOR_PREVIOUS%.%PATCH_PREVIOUS%%PRERELEASE_PREVIOUS%
-set NUGET=.nuget\nuget.exe
-set SOURCE=https://nuget.org
-
-if exist ..\SetNugetSarifApiKey.cmd (
-call ..\SetNugetSarifApiKey.cmd
-call %NUGET% SetApiKey %API_KEY% -Source %SOURCE%
-)
-if "%ERRORLEVEL%" NEQ "0" (echo set api key of %API_KEY% to %SOURCE% FAILED && goto Exit)
-
-call :DelistPackage Sarif.Sdk        || goto :EOF
-call :DelistPackage Sarif.Driver     || goto :EOF
-call :DelistPackage Sarif.Converters || goto :EOF
-call :DelistPackage Sarif.Multitool  || goto :EOF
-
-goto :EOF
-
-:DelistPackage
-set ID=%1
-call %NUGET% delete %ID% %VERSION% -Source %SOURCE%
-if "%ERRORLEVEL%" NEQ "0" (echo Delisting of %ID% failed.)
-Exit /B %ERRORLEVEL%
-
-:EOF
+powershell -ExecutionPolicy RemoteSigned -File %~dp0\scripts\DelistCurrentPackages.ps1 %*

--- a/scripts/BeforeBuild.ps1
+++ b/scripts/BeforeBuild.ps1
@@ -31,8 +31,9 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
-Import-Module $PSScriptRoot\ScriptUtilities.psm1 -Force
-Import-Module $PSScriptRoot\Projects.psm1 -Force
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1
+Import-Module -Force $PSScriptRoot\Projects.psm1
 
 function Remove-BuildOutput {
     Remove-DirectorySafely $BuildRoot

--- a/scripts/DelistCurrentPackages.ps1
+++ b/scripts/DelistCurrentPackages.ps1
@@ -1,0 +1,17 @@
+<#
+.SYNOPSIS
+    Delists currently visible NuGet packages.
+.DESCRIPTION
+    Whenever we bump the SDK version number, we publish new packages. Then we
+    need to "delist" the packages from the previous version. ("hide" is really
+    what it amounts to, and "delete" is what the NuGet command line calls it.)
+#>
+
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+Import-Module $PSScriptRoot\NuGetUtilities.psm1
+
+Hide-NuGetPackages

--- a/scripts/Get-VersionConstants.ps1
+++ b/scripts/Get-VersionConstants.ps1
@@ -1,7 +1,16 @@
 <#
 .SYNOPSIS
 Extract the version number from build.props.
+
+.PARAMETER Previous
+Extract the previous version number rather than the current version number.
 #>
+
+[CmdletBinding()]
+param(
+    [switch]
+    $Previous
+)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
@@ -19,7 +28,12 @@ function Get-VersionComponent($componentName) {
     $xml.Node.InnerText
 }
 
-$versionPrefix = Get-VersionComponent VersionPrefix
-$versionSuffix = Get-VersionComponent VersionSuffix
+$PreviousNamePrefix = ""
+if ($Previous) {
+    $PreviousNamePrefix = "Previous"
+}
+
+$versionPrefix = Get-VersionComponent "${PreviousNamePrefix}VersionPrefix"
+$versionSuffix = Get-VersionComponent "${PreviousNamePrefix}VersionSuffix"
 
 $versionPrefix, $versionSuffix

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    NuGet utility functions.
+
+.DESCRIPTION
+    The NuGetUtilities module exports functions for performing NuGet actions.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+Import-Module $PSScriptRoot\ScriptUtilities.psm1
+
+$NuGetPackageRoot = "$SourceRoot\packages"
+$PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
+
+function Get-PackageDirectoryName($configuration) {
+    Join-Path $PackageOutputDirectoryRoot $configuration
+}
+
+function New-NuGetPackageFromProjectFile($configuration, $project, $version) {
+    $projectFile = "$SourceRoot\$project\$project.csproj"
+
+    $arguments =
+        "pack", $projectFile,
+        "--configuration", $configuration,
+        "--no-build", "--no-restore",
+        "--include-source", "--include-symbols",
+        "-p:Platform=$Platform",
+        "--output", (Get-PackageDirectoryName $configuration)
+
+    Write-Debug "dotnet $($arguments -join ' ')"
+
+    dotnet $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
+    }
+}
+
+function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suffix = "") {
+    $nuspecFile = "$SourceRoot\NuGet\$project.nuspec"
+
+    $arguments=
+        "pack", $nuspecFile,
+        "-Symbols",
+        "-Properties", "platform=$Platform;configuration=$configuration;version=$version",
+        "-Verbosity", "Quiet",
+        "-BasePath", ".\",
+        "-OutputDirectory", (Get-PackageDirectoryName $configuration)
+
+    if ($suffix -ne "") {
+        $arguments += "-Suffix", $Suffix
+    }
+
+    $nugetExePath = "$RepoRoot\.nuget\NuGet.exe"
+
+    Write-Debug "$nuGetExePath $($arguments -join ' ')"
+
+    &$nuGetExePath $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
+    }
+
+    Write-Information "  Successfully created package '$BinRoot\NuGet\$Configuration\$Project.$version.nupkg'."
+}
+
+function New-NuGetPackages($configuration, $projects) {
+    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
+    if ($versionSuffix)
+    {
+        $version = "$versionPrefix-$versionSuffix"
+    }
+
+    # We can build the NuGet packages for library projects directly from their
+    # project file.
+    foreach ($project in $projects.NewLibrary) {
+        New-NuGetPackageFromProjectFile $configuration $project $version
+    }
+
+    # Unfortunately, application projects like MultiTool need to include things
+    # that are not specified in the project file, so their packages still require
+    # a .nuspec file.
+    foreach ($project in $Projects.NewApplication) {
+        New-NuGetPackageFromNuSpecFile $configuration $project $version
+    }
+}
+
+Export-ModuleMember -Function `
+    New-NuGetPackages
+
+Export-ModuleMember -Variable `
+    NuGetPackageRoot

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -11,9 +11,23 @@ $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
 Import-Module $PSScriptRoot\ScriptUtilities.psm1
+Import-Module $PSScriptRoot\Projects.psm1
 
+$NugetExePath = "$RepoRoot\.nuget\NuGet.exe"
 $NuGetPackageRoot = "$SourceRoot\packages"
+$PackageSource = "https://nuget.org"
 $PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
+
+function Get-CurrentVersion {
+    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
+    $version = $versionPrefix
+    if ($versionSuffix)
+    {
+        $version += "-$versionSuffix"
+    }
+
+    $version
+}
 
 function Get-PackageDirectoryName($configuration) {
     Join-Path $PackageOutputDirectoryRoot $configuration
@@ -30,7 +44,7 @@ function New-NuGetPackageFromProjectFile($configuration, $project, $version) {
         "-p:Platform=$Platform",
         "--output", (Get-PackageDirectoryName $configuration)
 
-    Write-Debug "dotnet $($arguments -join ' ')"
+    Write-CommandLine dotnet $arguments
 
     dotnet $arguments
     if ($LASTEXITCODE -ne 0) {
@@ -53,11 +67,9 @@ function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suf
         $arguments += "-Suffix", $Suffix
     }
 
-    $nugetExePath = "$RepoRoot\.nuget\NuGet.exe"
+    Write-CommandLine $NuGetExePath $arguments
 
-    Write-Debug "$nuGetExePath $($arguments -join ' ')"
-
-    &$nuGetExePath $arguments
+    & $NuGetExePath $arguments
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
     }
@@ -66,11 +78,7 @@ function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suf
 }
 
 function New-NuGetPackages($configuration, $projects) {
-    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
-    if ($versionSuffix)
-    {
-        $version = "$versionPrefix-$versionSuffix"
-    }
+    $version = Get-CurrentVersion
 
     # We can build the NuGet packages for library projects directly from their
     # project file.
@@ -86,7 +94,61 @@ function New-NuGetPackages($configuration, $projects) {
     }
 }
 
+function Get-NuGetApiKey {
+    # We temporarily implement this function by parsing the key from the file
+    # SetNuGetJSarifApiKey.cmd, which is expected to exist in the parent
+    # directory of the developer's sarif-sdk enlistment.
+    # In future, we should get this key from the Azure Key Vault.
+    $apiKeyPath = Join-Path $PSScriptRoot ..\..\SetNuGetSarifApiKey.cmd
+    if (-not (Test-Path $apiKeyPath)) {
+        Exit-WithFailureMessage NuGetUtilties "API key file $apiKeyPath does not exist."
+    }
+
+    # Everything that isn't a double quote, followed by a double quote, followed
+    # by the key (everything up to the next double quote).
+    $pattern = '^[^"]*"(?<key>[^"]*)'
+
+    $firstLine = [IO.File]::ReadAllLines($apiKeyPath)[0]
+    if ($firstLine -match $pattern) {
+        $matches["key"]
+    } else {
+        Exit-WithFailureMessage NuGetUtilties "API key file $apiKeyPath does not contain a key."
+    }
+}
+
+function Set-NuGetApiKey {
+    $apiKey = Get-NuGetApiKey
+
+    $arguments = "SetApiKey", $apiKey, "-Source", $PackageSource
+    Write-CommandLine $NuGetExePath $arguments
+
+    & $NugetExePath $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Could not set NuGet API key."
+    }
+}
+
+function Hide-NuGetPackage($project, $version) {
+    $arguments = "delete", $project, $version, "-Source", $PackageSource
+    Write-CommandLine $NuGetExePath $arguments
+
+    & $NugetExePath $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Exit-WithFailureMessage $ScriptName "Could not delist NuGet package $project $version."
+    }
+}
+
+function Hide-NuGetPackages {
+    Set-NuGetApiKey
+
+    $version = Get-CurrentVersion
+    foreach ($project in $Projects.New) {
+        Hide-NuGetPackage $project $version
+    }
+}
+
 Export-ModuleMember -Function `
+    Hide-NuGetPackages, `
     New-NuGetPackages
 
 Export-ModuleMember -Variable `

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -96,7 +96,7 @@ function New-NuGetPackages($configuration, $projects) {
 
 function Get-NuGetApiKey {
     # We temporarily implement this function by parsing the key from the file
-    # SetNuGetJSarifApiKey.cmd, which is expected to exist in the parent
+    # SetNuGetSarifApiKey.cmd, which is expected to exist in the parent
     # directory of the developer's sarif-sdk enlistment.
     # In future, we should get this key from the Azure Key Vault.
     $apiKeyPath = Join-Path $PSScriptRoot ..\..\SetNuGetSarifApiKey.cmd

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -18,8 +18,8 @@ $NuGetPackageRoot = "$SourceRoot\packages"
 $PackageSource = "https://nuget.org"
 $PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
 
-function Get-CurrentVersion {
-    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
+function Get-PackageVersion([switch]$previous) {
+    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1 -Previous:$previous
     $version = $versionPrefix
     if ($versionSuffix)
     {
@@ -78,7 +78,7 @@ function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suf
 }
 
 function New-NuGetPackages($configuration, $projects) {
-    $version = Get-CurrentVersion
+    $version = Get-PackageVersion
 
     # We can build the NuGet packages for library projects directly from their
     # project file.
@@ -141,7 +141,7 @@ function Hide-NuGetPackage($project, $version) {
 function Hide-NuGetPackages {
     Set-NuGetApiKey
 
-    $version = Get-CurrentVersion
+    $version = Get-PackageVersion -Previous
     foreach ($project in $Projects.New) {
         Hide-NuGetPackage $project $version
     }

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -119,7 +119,7 @@ function Get-NuGetApiKey {
 function Set-NuGetApiKey {
     $apiKey = Get-NuGetApiKey
 
-    $arguments = "SetApiKey", $apiKey, "-Source", $PackageSource
+    $arguments = "SetApiKey", $apiKey, "-Source", $PackageSource, "-Verbosity", "quiet"
     Write-CommandLine $NuGetExePath $arguments
 
     & $NugetExePath $arguments
@@ -142,7 +142,7 @@ function Hide-NuGetPackages {
     Set-NuGetApiKey
 
     $version = Get-PackageVersion -Previous
-    foreach ($project in $Projects.New) {
+    foreach ($project in $Projects.NewProduct) {
         Hide-NuGetPackage $project $version
     }
 }

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -28,8 +28,9 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
-Import-Module $PSScriptRoot\ScriptUtilities.psm1 -Force
-Import-Module $PSScriptRoot\Projects.psm1 -Force
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1
+Import-Module -Force $PSScriptRoot\Projects.psm1
 
 $ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -41,16 +41,20 @@ function Exit-WithFailureMessage($scriptName, $message) {
     exit 1
 }
 
-function Get-ProjectBinDirectory($project, $configuration)
-{
+function Get-ProjectBinDirectory($project, $configuration) {
     "$BinRoot\${Platform}_$configuration\$project\"
+}
+
+function Write-CommandLine($exeName, $arguments) {
+    Write-Verbose "$exeName $($arguments -join ' ')"
 }
 
 Export-ModuleMember -Function `
     Exit-WithFailureMessage, `
     New-DirectorySafely, `
     Remove-DirectorySafely, `
-    Get-ProjectBinDirectory
+    Get-ProjectBinDirectory, `
+    Write-CommandLine
 
 Export-ModuleMember -Variable `
     RepoRoot, `

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -3,13 +3,21 @@
     Utility functions.
 
 .DESCRIPTION
-    The ScriptUtilties module exports generally useful functions to PowerShell
-    scripts in the SARIF SDK.
+    The ScriptUtilties module exports generally useful functions.
 #>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
+
+$RepoRoot = $(Resolve-Path $PSScriptRoot\..).Path
+$Platform = "AnyCPU"
+$SourceRoot = "$RepoRoot\src"
+$JsonSchemaPath = "$SourceRoot\Sarif\Schemata\Sarif.schema.json"
+$BuildRoot = "$RepoRoot\bld"
+$BinRoot = "$BuildRoot\bin"
+
+$SarifExtension = ".sarif"
 
 function Remove-DirectorySafely($dir) {
     if (Test-Path $dir) {
@@ -33,109 +41,20 @@ function Exit-WithFailureMessage($scriptName, $message) {
     exit 1
 }
 
-# NuGet Package Creation section
-function New-NuGetPackageFromProjectFile($configuration, $project, $version) {
-    $projectFile = "$SourceRoot\$project\$project.csproj"
-
-    $arguments =
-        "pack", $projectFile,
-        "--configuration", $configuration,
-        "--no-build", "--no-restore",
-        "--include-source", "--include-symbols",
-        "-p:Platform=$Platform",
-        "--output", (Get-PackageDirectoryName $configuration)
-
-    Write-Debug "dotnet $($arguments -join ' ')"
-
-    dotnet $arguments
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
-    }
-}
-
-function New-NuGetPackageFromNuspecFile($configuration, $project, $version, $suffix = "") {
-    $nuspecFile = "$SourceRoot\NuGet\$project.nuspec"
-
-    $arguments=
-        "pack", $nuspecFile,
-        "-Symbols",
-        "-Properties", "platform=$Platform;configuration=$configuration;version=$version",
-        "-Verbosity", "Quiet",
-        "-BasePath", ".\",
-        "-OutputDirectory", (Get-PackageDirectoryName $configuration)
-
-    if ($suffix -ne "") {
-        $arguments += "-Suffix", $Suffix
-    }
-
-    $nugetExePath = "$RepoRoot\.nuget\NuGet.exe"
-
-    Write-Debug "$nuGetExePath $($arguments -join ' ')"
-
-    &$nuGetExePath $arguments
-    if ($LASTEXITCODE -ne 0) {
-        Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
-    }
-
-    Write-Information "  Successfully created package '$BinRoot\NuGet\$Configuration\$Project.$version.nupkg'."
-}
-
-function New-NuGetPackages($configuration, $projects) {
-    $versionPrefix, $versionSuffix = & $PSScriptRoot\Get-VersionConstants.ps1
-    if ($versionSuffix)
-    {
-        $version = "$versionPrefix-$versionSuffix"
-    }
-
-    # We can build the NuGet packages for library projects directly from their
-    # project file.
-    foreach ($project in $projects.NewLibrary) {
-        New-NuGetPackageFromProjectFile $configuration $project $version
-    }
-
-    # Unfortunately, application projects like MultiTool need to include things
-    # that are not specified in the project file, so their packages still require
-    # a .nuspec file.
-    foreach ($project in $Projects.NewApplication) {
-        New-NuGetPackageFromNuSpecFile $configuration $project $version
-    }
-}
-
-# Get the packaging directory name.
-function Get-PackageDirectoryName($configuration) {
-    Join-Path $PackageOutputDirectoryRoot $configuration
-}
-
 function Get-ProjectBinDirectory($project, $configuration)
 {
     "$BinRoot\${Platform}_$configuration\$project\"
 }
 
-$RepoRoot = $(Resolve-Path $PSScriptRoot\..).Path
-$Platform = "AnyCPU"
-$SourceRoot = "$RepoRoot\src"
-$NuGetPackageRoot = "$SourceRoot\packages"
-$JsonSchemaPath = "$SourceRoot\Sarif\Schemata\Sarif.schema.json"
-$BuildRoot = "$RepoRoot\bld"
-$BinRoot = "$BuildRoot\bin"
-$PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
-
-$SarifExtension = ".sarif"
-
 Export-ModuleMember -Function `
     Exit-WithFailureMessage, `
     New-DirectorySafely, `
     Remove-DirectorySafely, `
-    New-NuGetPackages, `
-    New-NuGetPackageFromProjectFile, `
-    New-NuGetPackageFromNuSpecFile, `
-    Get-PackageDirectoryName, `
     Get-ProjectBinDirectory
 
 Export-ModuleMember -Variable `
     RepoRoot, `
     SourceRoot, `
-    NuGetPackageRoot, `
     JsonSchemaPath, `
     BuildRoot, `
     BinRoot, `

--- a/src/build.props
+++ b/src/build.props
@@ -21,6 +21,19 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix Condition=" '$(VersionPrefix)' == ''">2.0.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == ''">csd.1</VersionSuffix>
+
+    <!--
+    Whenever you increment VersionPrefix or VersionSuffix, copy the old value(s)
+    into the following properties.
+
+    These properties are defined here, not because our MSBuild .props or .targets
+    files use them (they don't), but rather to make it convenient for you to
+    increment the version number by having all the relevant values in one
+    place. These properties are actually used by the PowerShell script that
+    hides the previous package versions on nuget.org.
+    -->
+    <PreviousVersionPrefix>1.7.5</PreviousVersionPrefix>
+    <PreviousVersionSuffix></PreviousVersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
This change implements a PowerShell script `DelistCurrentPackages.ps1` that does just what `DelistCurrentPackages.cmd` used to do. `DelistCurrentPackages.cmd` still exists, but it just invokes `DelistCurrentPackages.ps1`.

Implementing the script in PowerShell allows us to take advantage of the PowerShell-based machinery I implemented for BuildAndTest, including:

- Extracting version information from the same location (`build.props`) that the build uses.
- Taking advantage of utilities such as `Exit-WithFailureMessage` and `Write-CommandLine` to ensure a uniform user experience with the scripts.

**NOTE** I have not actually delisted the v1.7.5 packages. I tested this change by temporarily commenting out the line that issues the "`nuget delete`" command, and observing (by way of `Write-CommandLine`) that the correct commands would be executed.