### PR TITLE
Build sample solution in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ branches:
 before_build:
   - '"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"'
   - ps: .\scripts\BeforeBuild.ps1
+  - nuget restore src/Samples/Sarif.Sdk.Sample.sln
 
 platform: Any CPU
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,13 @@ install:
 configuration:
   - Release
 
-build:
-  project: src/Sarif.Sdk.sln
+environment:
+  matrix:
+  - solution_name: src/Sarif.Sdk.sln
+  - solution_name: src/Samples/Sarif.Sdk.Sample.sln
+
+build_script:
+  - msbuild %solution_name%
 
 after_build:
   - ps: .\scripts\Run-Tests.ps1 -Configuration Release -AppVeyor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ branches:
 
 before_build:
   - '"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"'
-  - ps: .\scripts\BeforeBuild.ps1
+  - ps: .\scripts\BeforeBuild.ps1 -NuGetVerbosity detailed
 
 platform: Any CPU
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ configuration:
   - Release
 
 build_script:
-  - ps: .\scripts\BuildAndTest.ps1 -NoTest -NoPackage -NoPublish -NoSigningDirectory -Configuration Release -Verbosity detailed
+  - ps: .\scripts\BuildAndTest.ps1 -NoTest -NoPackage -NoPublish -NoSigningDirectory -Configuration Release -MSBuildVerbosity detailed
 
 after_build:
   - ps: .\scripts\Run-Tests.ps1 -Configuration Release -AppVeyor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ branches:
 before_build:
   - '"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"'
   - ps: .\scripts\BeforeBuild.ps1
-  - nuget restore src/Samples/Sarif.Sdk.Sample.sln
 
 platform: Any CPU
 
@@ -22,13 +21,8 @@ install:
 configuration:
   - Release
 
-environment:
-  matrix:
-  - solution_name: src/Sarif.Sdk.sln
-  - solution_name: src/Samples/Sarif.Sdk.Sample.sln
-
 build_script:
-  - msbuild %solution_name%
+  - ps: .\scripts\BuildAndTest.ps1 -NoTest -NoPackage -NoPublish -NoSigningDirectory -Configuration Release -Verbosity detailed
 
 after_build:
   - ps: .\scripts\Run-Tests.ps1 -Configuration Release -AppVeyor

--- a/scripts/BeforeBuild.ps1
+++ b/scripts/BeforeBuild.ps1
@@ -64,7 +64,7 @@ if (-not $NoClean) {
 if (-not $NoRestore) {
     Write-Information "Restoring NuGet packages for $SolutionFile..."
 
-    dotnet restore $SourceRoot\$SolutionFile --configfile $NuGetConfigFile --packages $NuGetPackageRoot --verbosity quiet
+    dotnet restore $SourceRoot\$SolutionFile --configfile $NuGetConfigFile --packages $NuGetPackageRoot --verbosity $NuGetVerbosity
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "NuGet restore failed for $SolutionFile."
     }

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -9,6 +9,9 @@
 .PARAMETER MSBuildVerbosity
     Specifies the amount of information for MSBuild to display: quiet, minimal,
     normal, detailed, or diagnostic. Default=minimal
+.PARAMETER NuGetVerbosity
+    Specifies the amount of information for NuGet to display: quiet, normal,
+    or detailed. Default=quiet
 .PARAMETER NoClean
     Do not remove the outputs from the previous build.
 .PARAMETER NoRestore
@@ -40,6 +43,10 @@ param(
     [string]
     [ValidateSet("quiet", "minimal", "normal", "detailed", "diagnostic")]
     $MSBuildVerbosity = "minimal",
+
+    [string]
+    [ValidateSet("quiet", "normal", "detailed")]
+    $NuGetVerbosity = "quiet",
 
     [switch]
     $NoClean,
@@ -81,8 +88,6 @@ $ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
 Import-Module -Force $PSScriptRoot\Projects.psm1
 
-$SolutionFile = "Sarif.Sdk.sln"
-$SampleSolutionFile = "Samples\Sarif.Sdk.Sample.sln"
 $BuildTarget = "Rebuild"
 
 function Invoke-MSBuild($solutionFileRelativePath, $logFile = $null) {
@@ -180,7 +185,7 @@ function Set-SarifFileAssociationRegistrySettings {
     }
 }
 
-& $PSScriptRoot\BeforeBuild.ps1 -NoClean:$NoClean -NoRestore:$NoRestore -NoObjectModel:$NoObjectModel
+& $PSScriptRoot\BeforeBuild.ps1 -NuGetVerbosity $NuGetVerbosity -NoClean:$NoClean -NoRestore:$NoRestore -NoObjectModel:$NoObjectModel -NoBuildSample:$NoBuildSample
 if (-not $?) {
     Exit-WithFailureMessage $ScriptName "BeforeBuild failed."
 }

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -6,6 +6,9 @@
     NuGet packages.
 .PARAMETER Configuration
     The build configuration: Release or Debug. Default=Release
+.PARAMETER MSBuildVerbosity
+    Specifies the amount of information for MSBuild to display: quiet, minimal,
+    normal, detailed, or diagnostic. Default=minimal
 .PARAMETER NoClean
     Do not remove the outputs from the previous build.
 .PARAMETER NoRestore
@@ -33,6 +36,10 @@ param(
     [string]
     [ValidateSet("Debug", "Release")]
     $Configuration="Release",
+
+    [string]
+    [ValidateSet("quiet", "minimal", "normal", "detailed", "diagnostic")]
+    $MSBuildVerbosity = "minimal",
 
     [switch]
     $NoClean,
@@ -89,7 +96,7 @@ function Invoke-MSBuild($solutionFileRelativePath, $logFile = $null) {
     $solutionFilePath = Join-Path $SourceRoot $solutionFileRelativePath
 
     $arguments =
-        "/verbosity:minimal",
+        "/verbosity:$MSBuildVerbosity",
         "/target:$BuildTarget",
         "/property:Configuration=$Configuration",
         "/fileloggerparameters:$fileLoggerParameters",

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -15,6 +15,8 @@ Import-Module $PSScriptRoot\Projects.psm1
 
 $NugetExePath = "$RepoRoot\.nuget\NuGet.exe"
 $NuGetPackageRoot = "$SourceRoot\packages"
+$NuGetConfigFile = "$SourceRoot\NuGet.Config"
+
 $PackageSource = "https://nuget.org"
 $PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
 
@@ -152,4 +154,6 @@ Export-ModuleMember -Function `
     New-NuGetPackages
 
 Export-ModuleMember -Variable `
+    NuGetConfigFile, `
+    NuGetExePath, `
     NuGetPackageRoot

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -16,6 +16,8 @@ $SourceRoot = "$RepoRoot\src"
 $JsonSchemaPath = "$SourceRoot\Sarif\Schemata\Sarif.schema.json"
 $BuildRoot = "$RepoRoot\bld"
 $BinRoot = "$BuildRoot\bin"
+$SolutionFile = "Sarif.Sdk.sln"
+$SampleSolutionFile = "Samples\Sarif.Sdk.Sample.sln"
 
 $SarifExtension = ".sarif"
 
@@ -57,10 +59,12 @@ Export-ModuleMember -Function `
     Write-CommandLine
 
 Export-ModuleMember -Variable `
-    RepoRoot, `
-    SourceRoot, `
-    JsonSchemaPath, `
-    BuildRoot, `
     BinRoot, `
+    BuildRoot, `
+    JsonSchemaPath, `
+    RepoRoot, `
+    Platform, `
+    SampleSolutionFile, `
     SarifExtension, `
-    Platform
+    SolutionFile, `
+    SourceRoot `


### PR DESCRIPTION
It's awkward to build multiple solutions in AppVeyor. For one technique, see https://help.appveyor.com/discussions/questions/833-target-multiple-solution-files. The drawback of this technique is that it repeats the clone and pre-build steps for each solution -- and since our pre-build step builds the object model, which is both slow and unnecessary for the samples solution, we decided not to do it this way.

Instead, we ask AppVeyor to actually run BuildAndTest.ps1 (which is what we probably should have done in the first place)  rather than invoking msbuild directly. This requires us to restore the NuGet packages for the samples solution during the pre-build step. This in turn induces some refactorings, where we move global (constant) variables around so they can be defined in one place and then referenced from multiple scripts