### PR TITLE
SDK sample: Add result message strings and correct the regions.

### DIFF
--- a/src/Samples/Sarif.Sdk.Sample/Program.cs
+++ b/src/Samples/Sarif.Sdk.Sample/Program.cs
@@ -67,38 +67,42 @@ namespace Sarif.Sdk.Sample
                 {
                     Id ="CA1819",
                     Name = new Message { Text = "Properties should not return arrays" },
-                    FullDescription = new Message { Text = "Arrays returned by properties are not write-protected, even if the property is read-only. To keep the array tamper-proof, the property must return a copy of the array. Typically, users will not understand the adverse performance implications of calling such a property." }
+                    FullDescription = new Message { Text = "Arrays returned by properties are not write-protected, even if the property is read-only. To keep the array tamper-proof, the property must return a copy of the array. Typically, users will not understand the adverse performance implications of calling such a property." },
+                    MessageStrings = new Dictionary<string, string>
+                    {
+                        { "Default", "The property {0} returns an array." }
+                    }
                 },
                 new Rule
                 {
                     Id ="CA1820",
                     Name = new Message { Text = "Test for empty strings using string length" },
-                    FullDescription = new Message { Text = "Comparing strings by using the String.Length property or the String.IsNullOrEmpty method is significantly faster than using Equals." }
+                    FullDescription = new Message { Text = "Comparing strings by using the String.Length property or the String.IsNullOrEmpty method is significantly faster than using Equals." },
+                    MessageStrings = new Dictionary<string, string>
+                    {
+                        { "Default", "The test for an empty string is performed by a string comparison rather than by testing String.Length." }
+                    }
                 },
                 new Rule
                 {
                     Id ="CA2105",
                     Name = new Message { Text = "Array fields should not be read only" },
-                    FullDescription = new Message { Text = "When you apply the read-only (ReadOnly in Visual Basic) modifier to a field that contains an array, the field cannot be changed to reference a different array. However, the elements of the array stored in a read-only field can be changed." }
+                    FullDescription = new Message { Text = "When you apply the read-only (ReadOnly in Visual Basic) modifier to a field that contains an array, the field cannot be changed to reference a different array. However, the elements of the array stored in a read-only field can be changed." },
+                    MessageStrings = new Dictionary<string, string>
+                    {
+                        { "Default", "The array-valued field {0} is marked readonly." }
+                    }
                 },
                 new Rule
                 {
                     Id ="CA2215",
                     Name = new Message { Text = "Dispose methods should call base class dispose" },
-                    FullDescription = new Message { Text = "If a type inherits from a disposable type, it must call the Dispose method of the base type from its own Dispose method." }
-                },
-                //new Rule
-                //{
-                //    Id ="CA1816",
-                //    Name = new Message { Text = "Call GC.SuppressFinalize correctly" },
-                //    FullDescription = new Message { Text = "A method that is an implementation of Dispose does not call GC.SuppressFinalize, or a method that is not an implementation of Dispose calls GC.SuppressFinalize, or a method calls GC.SuppressFinalize and passes something other than this (Me in Visual Basic)." }
-                //},
-                //new Rule
-                //{
-                //    Id ="CA2006",
-                //    Name = new Message { Text = "Use SafeHandle to encapsulate native resources" },
-                //    FullDescription = new Message { Text = "Use of IntPtr in managed code might indicate a potential security and reliability problem. All uses of IntPtr must be reviewed to determine whether use of a SafeHandle, or similar technology, is required in its place." }
-                //}
+                    FullDescription = new Message { Text = "If a type inherits from a disposable type, it must call the Dispose method of the base type from its own Dispose method." },
+                    MessageStrings = new Dictionary<string, string>
+                    {
+                        { "Default", "The Dispose method does not call the base class Dispose method." }
+                    }
+                }
             };
             #endregion
 
@@ -108,32 +112,47 @@ namespace Sarif.Sdk.Sample
             {
                 new Region // CA1819
                 {
-                    StartLine = 16,
-                    StartColumn = 19,
-                    EndLine = 16,
-                    EndColumn = 38
+                    StartLine = 17,
+                    StartColumn = 16,
+                    EndColumn = 32
                 },
                 new Region // CA1820
                 {
-                    StartLine = 23,
+                    StartLine = 26,
                     StartColumn = 21,
-                    EndLine = 23,
                     EndColumn = 44
                 },
                 new Region // CA2105
                 {
-                    StartLine = 11,
-                    StartColumn = 9,
-                    EndLine = 11,
-                    EndColumn = 50
+                    StartLine = 14,
+                    StartColumn = 17,
+                    EndColumn = 25
                 },
                 new Region // CA2215
                 {
-                    StartLine = 32,
+                    StartLine = 37,
                     StartColumn = 9,
-                    EndLine = 32,
-                    EndColumn = 30
+                    EndColumn = 9
                 }
+            };
+            #endregion
+
+            #region Message arguments
+            string[][] messageArguments = new string[][]
+            {
+                new string[]
+                {
+                    "MyIntArray"
+                },
+
+                null,
+
+                new string[]
+                {
+                    "_myStringArray"
+                },
+
+                null
             };
             #endregion
 
@@ -240,6 +259,11 @@ namespace Sarif.Sdk.Sample
                         {
                             RuleId = rule.Id,
                             AnalysisTarget = new FileLocation { Uri = new Uri(@"file://d:/src/module/example.dll") }, // This is the file that was analyzed
+                            Message = new Message
+                            {
+                                Arguments = messageArguments[i]
+                            },
+                            RuleMessageId = "Default",
                             Locations = new[]
                             {
                                 new Location


### PR DESCRIPTION
Now that I can build and install the VSIX viewer, I used it to validate the SARIF file produced by the SDK sample app's `create` verb. As a result:

1. I added result message strings, two of which are parameterized with arguments.
2. I corrected the regions for each result.

Also, I noticed and filed two bugs on the viewer's handling of fixes:

Microsoft/sarif-visualstudio-extension#12: Fixes don't recognize text-based regions.
Microsoft/sarif-visualstudio-extension#13: Preview and Apply action links are disabled in Fixes.