### PR TITLE
Add new validation rule UriMustBeAbsolute

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ test: off
 notifications:
   - provider: Email
     to:
-     - vsarcplat@microsoft.com
+     - tse-securitytools@microsoft.com
     subject: '{{projectName}} Build {{status}}: Version: {{buildVersion}}'
     on_build_status_changed: true
 

--- a/src/Sarif.Multitool.FunctionalTests/Rules/UriMustBeAbsoluteTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/UriMustBeAbsoluteTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
+{
+    public class UriMustBeAbsoluteTests : SkimmerTestsBase
+    {
+        [Fact(DisplayName = nameof(UriMustBeAbsolute_ReportsInvalidSarif))]
+        public void UriMustBeAbsolute_ReportsInvalidSarif()
+        {
+            Verify(new UriMustBeAbsolute(), "Invalid.sarif");
+        }
+
+        [Fact(DisplayName = nameof(UriMustBeAbsolute_AcceptsValidSarif))]
+        public void UriMustBeAbsolute_AcceptsValidSarif()
+        {
+            Verify(new UriMustBeAbsolute(), "Valid.sarif");
+        }
+    }
+}

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.0.0",
+  "version": "2.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "downloadUri": "http://www.example.com/tools/codescanner/download.html"
+      },
+      "results": [],
+      "originalUriBaseIds": {
+        "SRCROOT": "Code/sarif-sdk/src"
+      }
+    }
+  ]
+}

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -26,6 +26,14 @@
       "originalUriBaseIds": {
         "SRCROOT": "Code/sarif-sdk/src"
       },
+      "resources": {
+        "rules": {
+          "TST0001": {
+            "id": "TST0001",
+            "helpUri": "www.example.com/rules/tst0001.html"
+          }
+        }
+      },
       "versionControlProvenance": [
         {
           "uri": "example.com/my-project"

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.0.0",
+  "$schema": "json.schemastore.org/sarif-2.0.0",
   "version": "2.0.0",
   "runs": [
     {

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -14,7 +14,15 @@
           }
         }
       ],
-      "results": [],
+      "results": [
+        {
+          "ruleId": "TST0001",
+          "level": "error",
+          "workItemUris": [
+            "example.com/my-project/issues/42"
+          ]
+        }
+      ],
       "originalUriBaseIds": {
         "SRCROOT": "Code/sarif-sdk/src"
       },

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "CodeScanner",
-        "downloadUri": "http://www.example.com/tools/codescanner/download.html"
+        "downloadUri": "tools/codescanner/download.html"
       },
       "results": [],
       "originalUriBaseIds": {

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -17,7 +17,12 @@
       "results": [],
       "originalUriBaseIds": {
         "SRCROOT": "Code/sarif-sdk/src"
-      }
+      },
+      "versionControlProvenance": [
+        {
+          "uri": "example.com/my-project"
+        }
+      ]
     }
   ]
 }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif
@@ -7,6 +7,13 @@
         "name": "CodeScanner",
         "downloadUri": "tools/codescanner/download.html"
       },
+      "invocations": [
+        {
+          "executableLocation": {
+            "uri": "tools/CodeScanner.exe"
+          }
+        }
+      ],
       "results": [],
       "originalUriBaseIds": {
         "SRCROOT": "Code/sarif-sdk/src"

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -58,8 +58,32 @@
                   "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
                 },
                 "region": {
-                  "startLine": 19,
+                  "startLine": 27,
                   "startColumn": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
+              "/runs/0/results/0/workItemUris/0",
+              "example.com/my-project/issues/42"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 22,
+                  "startColumn": 46
                 }
               }
             }
@@ -130,7 +154,7 @@
                   "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
                 },
                 "region": {
-                  "startLine": 23,
+                  "startLine": 31,
                   "startColumn": 41
                 }
               }
@@ -165,8 +189,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:34:20.986Z",
-          "endTime": "2018-08-21T01:34:21.775Z",
+          "startTime": "2018-08-21T01:37:46.784Z",
+          "endTime": "2018-08-21T01:37:47.596Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -179,7 +203,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:34:21.358Z"
+              "time": "2018-08-21T01:37:47.175Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -22,6 +22,30 @@
           "level": "error",
           "message": {
             "arguments": [
+              "/$schema",
+              "json.schemastore.org/sarif-2.0.0"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 47
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
               "/runs/0/originalUriBaseIds/SRCROOT",
               "Code/sarif-sdk/src"
             ]
@@ -69,8 +93,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:00:48.642Z",
-          "endTime": "2018-08-21T01:00:49.402Z",
+          "startTime": "2018-08-21T01:07:17.486Z",
+          "endTime": "2018-08-21T01:07:18.258Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -83,7 +107,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:00:48.996Z"
+              "time": "2018-08-21T01:07:17.856Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.0.0",
+  "version": "2.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "Sarif.Multitool",
+        "fullName": "Sarif.Multitool 2.0.0.0",
+        "version": "2.0.0.0",
+        "semanticVersion": "2.0.0",
+        "sarifLoggerVersion": "2.0.0.0",
+        "language": "en-US",
+        "properties": {
+          "Comments": "Command line tool to perform transformations of input files to SARIF.",
+          "CompanyName": "Microsoft",
+          "ProductName": "Microsoft SARIF SDK"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
+              "/runs/0/originalUriBaseIds/SRCROOT",
+              "Code/sarif-sdk/src"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 12,
+                  "startColumn": 39
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "resources": {
+        "rules": {
+          "SARIF1015": {
+            "id": "SARIF1015",
+            "name": {
+              "text": "UriMustBeAbsolute"
+            },
+            "shortDescription": {
+              "text": "Certain URIs in the SARIF specification are required to be absolute."
+            },
+            "fullDescription": {
+              "text": "Certain URIs in the SARIF specification are required to be absolute."
+            },
+            "messageStrings": {
+              "Default": "{0}: The SARIF specification requires the value of this property to be an absolute URI, but \"{1}\" is a relative URI reference."
+            },
+            "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.0/csprd01/sarif-v2.0-csprd01.html"
+          }
+        }
+      },
+      "files": {
+        "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif": {
+          "mimeType": "application/sarif-json"
+        }
+      },
+      "invocations": [
+        {
+          "startTime": "2018-08-21T01:00:48.642Z",
+          "endTime": "2018-08-21T01:00:49.402Z",
+          "toolNotifications": [
+            {
+              "id": "MSG001.AnalyzingTarget",
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                }
+              },
+              "message": {
+                "text": "Analyzing 'Invalid.sarif'..."
+              },
+              "level": "note",
+              "time": "2018-08-21T01:00:48.996Z"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -64,6 +64,30 @@
               }
             }
           ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
+              "/runs/0/tool/downloadUri",
+              "tools/codescanner/download.html"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 56
+                }
+              }
+            }
+          ]
         }
       ],
       "resources": {
@@ -93,8 +117,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:07:17.486Z",
-          "endTime": "2018-08-21T01:07:18.258Z",
+          "startTime": "2018-08-21T01:11:35.183Z",
+          "endTime": "2018-08-21T01:11:36.007Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -107,7 +131,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:07:17.856Z"
+              "time": "2018-08-21T01:11:35.584Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -112,6 +112,30 @@
               }
             }
           ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
+              "/runs/0/versionControlProvenance/0/uri",
+              "example.com/my-project"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 23,
+                  "startColumn": 41
+                }
+              }
+            }
+          ]
         }
       ],
       "resources": {
@@ -141,8 +165,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:24:34.442Z",
-          "endTime": "2018-08-21T01:24:35.194Z",
+          "startTime": "2018-08-21T01:34:20.986Z",
+          "endTime": "2018-08-21T01:34:21.775Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -155,7 +179,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:24:34.794Z"
+              "time": "2018-08-21T01:34:21.358Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -58,8 +58,32 @@
                   "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
                 },
                 "region": {
-                  "startLine": 12,
+                  "startLine": 19,
                   "startColumn": 39
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
+              "/runs/0/invocations/0/executableLocation/uri",
+              "tools/CodeScanner.exe"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 42
                 }
               }
             }
@@ -117,8 +141,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:11:35.183Z",
-          "endTime": "2018-08-21T01:11:36.007Z",
+          "startTime": "2018-08-21T01:24:34.442Z",
+          "endTime": "2018-08-21T01:24:35.194Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -131,7 +155,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:11:35.584Z"
+              "time": "2018-08-21T01:24:34.794Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid_Expected.sarif
@@ -94,6 +94,30 @@
           "level": "error",
           "message": {
             "arguments": [
+              "/runs/0/resources/rules/TST0001/helpUri",
+              "www.example.com/rules/tst0001.html"
+            ]
+          },
+          "ruleMessageId": "Default",
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
+                },
+                "region": {
+                  "startLine": 33,
+                  "startColumn": 59
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1015",
+          "level": "error",
+          "message": {
+            "arguments": [
               "/runs/0/invocations/0/executableLocation/uri",
               "tools/CodeScanner.exe"
             ]
@@ -154,7 +178,7 @@
                   "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Invalid.sarif"
                 },
                 "region": {
-                  "startLine": 31,
+                  "startLine": 39,
                   "startColumn": 41
                 }
               }
@@ -189,8 +213,8 @@
       },
       "invocations": [
         {
-          "startTime": "2018-08-21T01:37:46.784Z",
-          "endTime": "2018-08-21T01:37:47.596Z",
+          "startTime": "2018-08-21T01:40:41.577Z",
+          "endTime": "2018-08-21T01:40:42.450Z",
           "toolNotifications": [
             {
               "id": "MSG001.AnalyzingTarget",
@@ -203,7 +227,7 @@
                 "text": "Analyzing 'Invalid.sarif'..."
               },
               "level": "note",
-              "time": "2018-08-21T01:37:47.175Z"
+              "time": "2018-08-21T01:40:41.994Z"
             }
           ]
         }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
@@ -17,7 +17,12 @@
       "results": [],
       "originalUriBaseIds": {
         "SRCROOT": "file:///c:/Code/sarif-sdk/src"
-      }
+      },
+      "versionControlProvenance": [
+        {
+          "uri": "https://example.com/my-project"
+        }
+      ]
     }
   ]
 }

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
@@ -14,7 +14,15 @@
           }
         }
       ],
-      "results": [],
+      "results": [
+        {
+          "ruleId": "TST0001",
+          "level": "error",
+          "workItemUris": [
+            "https://example.com/my-project/issues/42"
+          ]
+        }
+      ],
       "originalUriBaseIds": {
         "SRCROOT": "file:///c:/Code/sarif-sdk/src"
       },

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
@@ -26,6 +26,14 @@
       "originalUriBaseIds": {
         "SRCROOT": "file:///c:/Code/sarif-sdk/src"
       },
+      "resources": {
+        "rules": {
+          "TST0001": {
+            "id": "TST0001",
+            "helpUri": "http://www.example.com/rules/tst0001.html"
+          }
+        }
+      },
       "versionControlProvenance": [
         {
           "uri": "https://example.com/my-project"

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.0.0",
+  "version": "2.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "downloadUri": "http://www.example.com/tools/codescanner/download.html"
+      },
+      "results": [],
+      "originalUriBaseIds": {
+        "SRCROOT": "file:///c:/Code/sarif-sdk/src"
+      }
+    }
+  ]
+}

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif
@@ -7,6 +7,13 @@
         "name": "CodeScanner",
         "downloadUri": "http://www.example.com/tools/codescanner/download.html"
       },
+      "invocations": [
+        {
+          "executableLocation": {
+            "uri": "file:///C:/tools/CodeScanner.exe"
+          }
+        }
+      ],
       "results": [],
       "originalUriBaseIds": {
         "SRCROOT": "file:///c:/Code/sarif-sdk/src"

--- a/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid_Expected.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid_Expected.sarif
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.0.0",
+  "version": "2.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "Sarif.Multitool",
+        "fullName": "Sarif.Multitool 2.0.0.0",
+        "version": "2.0.0.0",
+        "semanticVersion": "2.0.0",
+        "sarifLoggerVersion": "2.0.0.0",
+        "language": "en-US",
+        "properties": {
+          "Comments": "Command line tool to perform transformations of input files to SARIF.",
+          "CompanyName": "Microsoft",
+          "ProductName": "Microsoft SARIF SDK"
+        }
+      },
+      "results": [],
+      "invocations": [
+        {
+          "startTime": "2018-08-21T01:00:49.714Z",
+          "endTime": "2018-08-21T01:00:50.414Z",
+          "toolNotifications": [
+            {
+              "id": "MSG001.AnalyzingTarget",
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///C:/Code/sarif-sdk/src/Sarif.Multitool.FunctionalTests/TestData/UriMustBeAbsolute/Valid.sarif"
+                }
+              },
+              "message": {
+                "text": "Analyzing 'Valid.sarif'..."
+              },
+              "level": "note",
+              "time": "2018-08-21T01:00:50.065Z"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Sarif.Multitool/Rules/DoNotUseFriendlyNameAsRuleId.cs
+++ b/src/Sarif.Multitool/Rules/DoNotUseFriendlyNameAsRuleId.cs
@@ -22,16 +22,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.DoNotUseFriendlyNameAsRuleId;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1001_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1001_Default)
+        };
 
         protected override void Analyze(Rule rule, string rulePointer)
         {

--- a/src/Sarif.Multitool/Rules/EndColumnMustNotBeLessThanStartColumn.cs
+++ b/src/Sarif.Multitool/Rules/EndColumnMustNotBeLessThanStartColumn.cs
@@ -23,16 +23,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.EndColumnMustNotBeLessThanStartColumn;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1013_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1013_Default)
+        };
 
         protected override void Analyze(Region region, string regionPointer)
         {

--- a/src/Sarif.Multitool/Rules/EndLineMustNotBeLessThanStartLine.cs
+++ b/src/Sarif.Multitool/Rules/EndLineMustNotBeLessThanStartLine.cs
@@ -22,16 +22,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.EndLineMustNotBeLessThanStartLine;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1012_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1012_Default)
+        };
 
         protected override void Analyze(Region region, string regionPointer)
         {

--- a/src/Sarif.Multitool/Rules/EndTimeMustBeAfterStartTime.cs
+++ b/src/Sarif.Multitool/Rules/EndTimeMustBeAfterStartTime.cs
@@ -24,16 +24,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.EndTimeMustBeAfterStartTime;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1007_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1007_Default)
+        };
 
         protected override void Analyze(Invocation invocation, string invocationPointer)
         {

--- a/src/Sarif.Multitool/Rules/RuleId.cs
+++ b/src/Sarif.Multitool/Rules/RuleId.cs
@@ -15,5 +15,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public const string EndLineMustNotBeLessThanStartLine = "SARIF1012";
         public const string EndColumnMustNotBeLessThanStartColumn = "SARIF1013";
         public const string UriBaseIdRequiresRelativeUri = "SARIF1014";
+        public const string UriMustBeAbsolute = "SARIF1015";
     }
 }

--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -248,5 +248,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
                 return ResourceManager.GetString("SARIF1014_UriBaseIdRequiresRelativeUri", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: The SARIF specification requires the value of this property to be an absolute URI, but &quot;{1}&quot; is a relative URI reference..
+        /// </summary>
+        internal static string SARIF1015_Default {
+            get {
+                return ResourceManager.GetString("SARIF1015_Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certain URIs in the SARIF specification are required to be absolute..
+        /// </summary>
+        internal static string SARIF1015_UriMustBeAbsolute {
+            get {
+                return ResourceManager.GetString("SARIF1015_UriMustBeAbsolute", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: The SARIF specification requires the value of this property to be an absolute URI, but &quot;{1}&quot; is a relative URI reference..
+        ///   Looks up a localized string similar to {0}: The value of this property is required to be an absolute URI, but &quot;{1}&quot; is a relative URI reference..
         /// </summary>
         internal static string SARIF1015_Default {
             get {
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certain URIs in the SARIF specification are required to be absolute..
+        ///   Looks up a localized string similar to Certain URIs are required to be absolute..
         /// </summary>
         internal static string SARIF1015_UriMustBeAbsolute {
             get {

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -181,9 +181,9 @@
     <value>If a fileLocation object contains a "uriBaseId" property, the value of the "uri" property must be a relative URI reference.</value>
   </data>
   <data name="SARIF1015_Default" xml:space="preserve">
-    <value>{0}: The SARIF specification requires the value of this property to be an absolute URI, but "{1}" is a relative URI reference.</value>
+    <value>{0}: The value of this property is required to be an absolute URI, but "{1}" is a relative URI reference.</value>
   </data>
   <data name="SARIF1015_UriMustBeAbsolute" xml:space="preserve">
-    <value>Certain URIs in the SARIF specification are required to be absolute.</value>
+    <value>Certain URIs are required to be absolute.</value>
   </data>
 </root>

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -180,4 +180,10 @@
   <data name="SARIF1014_UriBaseIdRequiresRelativeUri" xml:space="preserve">
     <value>If a fileLocation object contains a "uriBaseId" property, the value of the "uri" property must be a relative URI reference.</value>
   </data>
+  <data name="SARIF1015_Default" xml:space="preserve">
+    <value>{0}: The SARIF specification requires the value of this property to be an absolute URI, but "{1}" is a relative URI reference.</value>
+  </data>
+  <data name="SARIF1015_UriMustBeAbsolute" xml:space="preserve">
+    <value>Certain URIs in the SARIF specification are required to be absolute.</value>
+  </data>
 </root>

--- a/src/Sarif.Multitool/Rules/StepValuesMustFormOneBasedSequence.cs
+++ b/src/Sarif.Multitool/Rules/StepValuesMustFormOneBasedSequence.cs
@@ -26,17 +26,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.StepValuesMustFormOneBasedSequence;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1009_StepNotPresentOnAllLocations),
-                    nameof(RuleResources.SARIF1009_InvalidStepValue)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1009_StepNotPresentOnAllLocations),
+            nameof(RuleResources.SARIF1009_InvalidStepValue)
+        };
 
         protected override void Analyze(ThreadFlow threadFlow, string threadFlowPointer)
         {

--- a/src/Sarif.Multitool/Rules/UriBaseIdRequiresRelativeUri.cs
+++ b/src/Sarif.Multitool/Rules/UriBaseIdRequiresRelativeUri.cs
@@ -22,16 +22,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.UriBaseIdRequiresRelativeUri;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1014_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1014_Default)
+        };
 
         protected override void Analyze(FileLocation fileLocation, string fileLocationPointer)
         {

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             AnalyzeUri(tool.DownloadUri, toolPointer.AtProperty(SarifPropertyName.DownloadUri));
         }
 
+        protected override void Analyze(VersionControlDetails versionControlDetails, string versionControlDetailsPointer)
+        {
+            AnalyzeUri(versionControlDetails.Uri, versionControlDetailsPointer.AtProperty(SarifPropertyName.Uri));
+        }
+
         private void AnalyzeUri(Uri uri, string pointer)
         {
             AnalyzeUri(uri?.OriginalString, pointer);

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Json.Pointer;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
+{
+    public class UriMustBeAbsolute : SarifValidationSkimmerBase
+    {
+        private Message _fullDescription = new Message
+        {
+            Text = RuleResources.SARIF1015_UriMustBeAbsolute
+        };
+
+        public override Message FullDescription => _fullDescription;
+
+        public override ResultLevel DefaultLevel => ResultLevel.Error;
+
+        /// <summary>
+        /// SARIF1015
+        /// </summary>
+        public override string Id => RuleId.UriMustBeAbsolute;
+
+        protected override IEnumerable<string> MessageResourceNames => new string[]
+        {
+            nameof(RuleResources.SARIF1015_Default)
+        };
+
+        protected override void Analyze(Run run, string runPointer)
+        {
+            if (run.OriginalUriBaseIds != null)
+            {
+                string originalUriBaseIdsPointer = runPointer.AtProperty(SarifPropertyName.OriginalUriBaseIds);
+
+                foreach (string key in run.OriginalUriBaseIds.Keys)
+                {
+                    AnalyzeUri(run.OriginalUriBaseIds[key], originalUriBaseIdsPointer.AtProperty(key));
+                }
+            }
+        }
+
+        private void AnalyzeUri(Uri uri, string pointer)
+        {
+            AnalyzeUri(uri?.OriginalString, pointer);
+        }
+
+        private void AnalyzeUri(string uriString, string pointer)
+        {
+            // If it's not a well-formed URI of _any_ kind, then don't bother triggering this rule.
+            // Rule SARIF1003, UrisMustBeValid, will catch it.
+            // Check for well-formedness first, before attempting to create a Uri object, to
+            // avoid having to do a try/catch. Unfortunately Uri.TryCreate will return true
+            // even for a malformed URI string.
+            if (uriString != null && Uri.IsWellFormedUriString(uriString, UriKind.RelativeOrAbsolute))
+            {
+                // Ok, it's a well-formed URI of some kind. But if it's not absolute, _now_ we
+                // can report it.
+                Uri uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
+                if (!uri.IsAbsoluteUri)
+                {
+                    LogResult(pointer, nameof(RuleResources.SARIF1015_Default), uriString);
+                }
+            }
+        }
+    }
+}

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -55,6 +55,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             }
         }
 
+        protected override void Analyze(Rule rule, string rulePointer)
+        {
+            AnalyzeUri(rule.HelpUri, rulePointer.AtProperty(SarifPropertyName.HelpUri));
+        }
+
         protected override void Analyze(Run run, string runPointer)
         {
             if (run.OriginalUriBaseIds != null)

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -33,6 +33,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             AnalyzeUri(log.SchemaUri, logPointer.AtProperty(SarifPropertyName.Schema));
         }
 
+        protected override void Analyze(Invocation invocation, string invocationPointer)
+        {
+            AnalyzeUri(
+                invocation.ExecutableLocation?.Uri,
+                invocationPointer.AtProperty(SarifPropertyName.ExecutableLocation).AtProperty(SarifPropertyName.Uri));
+        }
+
         protected override void Analyze(Run run, string runPointer)
         {
             if (run.OriginalUriBaseIds != null)

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             nameof(RuleResources.SARIF1015_Default)
         };
 
+        protected override void Analyze(SarifLog log, string logPointer)
+        {
+            AnalyzeUri(log.SchemaUri, logPointer.AtProperty(SarifPropertyName.Schema));
+        }
+
         protected override void Analyze(Run run, string runPointer)
         {
             if (run.OriginalUriBaseIds != null)

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -46,6 +46,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             }
         }
 
+        protected override void Analyze(Tool tool, string toolPointer)
+        {
+            AnalyzeUri(tool.DownloadUri, toolPointer.AtProperty(SarifPropertyName.DownloadUri));
+        }
+
         private void AnalyzeUri(Uri uri, string pointer)
         {
             AnalyzeUri(uri?.OriginalString, pointer);

--- a/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
+++ b/src/Sarif.Multitool/Rules/UriMustBeAbsolute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Json.Pointer;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
@@ -38,6 +39,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             AnalyzeUri(
                 invocation.ExecutableLocation?.Uri,
                 invocationPointer.AtProperty(SarifPropertyName.ExecutableLocation).AtProperty(SarifPropertyName.Uri));
+        }
+
+        protected override void Analyze(Result result, string resultPointer)
+        {
+            if (result.WorkItemUris != null)
+            {
+                Uri[] workItemUris = result.WorkItemUris.ToArray();
+                string workItemUrisPointer = resultPointer.AtProperty(SarifPropertyName.WorkItemUris);
+
+                for (int i = 0; i < workItemUris.Length; ++i)
+                {
+                    AnalyzeUri(workItemUris[i], workItemUrisPointer.AtIndex(i));
+                }
+            }
         }
 
         protected override void Analyze(Run run, string runPointer)

--- a/src/Sarif.Multitool/Rules/UrisMustBeValid.cs
+++ b/src/Sarif.Multitool/Rules/UrisMustBeValid.cs
@@ -24,16 +24,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.UrisMustBeValid;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1003_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1003_Default)
+        };
 
         protected override void Analyze(SarifLog log, string logPointer)
         {

--- a/src/Sarif.Multitool/Rules/UseAbsolutePathsForNestedFileUriFragments.cs
+++ b/src/Sarif.Multitool/Rules/UseAbsolutePathsForNestedFileUriFragments.cs
@@ -23,16 +23,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         /// </summary>
         public override string Id => RuleId.UseAbsolutePathsForNestedFileUriFragments;
 
-        protected override IEnumerable<string> MessageResourceNames
+        protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            get
-            {
-                return new string[]
-                {
-                    nameof(RuleResources.SARIF1002_Default)
-                };
-            }
-        }
+            nameof(RuleResources.SARIF1002_Default)
+        };
 
         protected override void Analyze(FileLocation fileLocation, string fileLocationPointer)
         {


### PR DESCRIPTION
Some URIs in SARIF are required to be absolute. Verify that the ones that must be, are:

- The values in the `run.originalUriBaseIds` dictionary.
- `sarifLog.$schema`
- `tool.downloadUri`
- `invocation.executableLocation.fileLocation.uri` (but see oasis-tcs/sarif-spec#221)
- `versionControlDetails.uri`
- The elements of the `result.workItemUris` array.
- `rule.HelpUri`

@michaelcfanning Note that I've taken your advice on structuring the tests. There is one test file where all the relevant properties are invalid, and one where they are all valid.

Also:
- Shorten some properties to expression bodies.