### PR TITLE
Fix build break in VS due to collision on VersionConstants.cs

### DIFF
--- a/scripts/BeforeBuild.ps1
+++ b/scripts/BeforeBuild.ps1
@@ -55,11 +55,34 @@ function Remove-BuildOutput {
     }
 }
 
+# Install-VersionConstantsFile
+#
+# Create a source file containing a class that specifies the NuGet package
+# version number, and place it in the Sarif project directory.
+#
+function Install-VersionConstantsFile {
+    # The name of the project in which to install VersionConstants.cs.
+    $targetProjectName = "Sarif"
+
+    # The element in build.props from which to extract the root of the namespace
+    # used in VersionConstants.cs.
+    $xPath = "/msbuild:Project/msbuild:PropertyGroup[@Label='Build']/msbuild:RootNamespaceBase"
+    $xml = Select-Xml -Path $BuildPropsPath -Namespace $MSBuildXmlNamespaces -XPath $xPath
+    $rootNamespaceBase = $xml.Node.InnerText
+
+    $targetProjectDirectory = "$SourceRoot\$targetProjectName"
+    $rootNamespace = "$rootNamespaceBase.$targetProjectName"
+
+    & $PSScriptRoot\New-VersionConstantsFile.ps1 $targetProjectDirectory $rootNamespace
+}
+
 $ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 
 if (-not $NoClean) {
     Remove-BuildOutput
 }
+
+Install-VersionConstantsFile
 
 if (-not $NoRestore) {
     Write-Information "Restoring NuGet packages for $SolutionFile..."

--- a/scripts/Get-VersionConstants.ps1
+++ b/scripts/Get-VersionConstants.ps1
@@ -18,13 +18,11 @@ $InformationPreference = "Continue"
 
 Import-Module $PSScriptRoot\ScriptUtilities.psm1 -Force
 
-$buildPropsPath = "$SourceRoot\build.props"
-$namespace = @{ msbuild = "http://schemas.microsoft.com/developer/msbuild/2003" }
 $assemblyAttributesXPath = "/msbuild:Project/msbuild:PropertyGroup[@Label='AssemblyAttributes']"
 
 function Get-VersionComponent($componentName) {
     $xPath = "$assemblyAttributesXPath/msbuild:$componentName"
-    $xml = Select-Xml -Path $buildPropsPath -Namespace $namespace -XPath $xPath
+    $xml = Select-Xml -Path $BuildPropsPath -Namespace $MSBuildXmlNamespaces -XPath $xPath
     $xml.Node.InnerText
 }
 

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -14,10 +14,13 @@ $RepoRoot = $(Resolve-Path $PSScriptRoot\..).Path
 $Platform = "AnyCPU"
 $SourceRoot = "$RepoRoot\src"
 $JsonSchemaPath = "$SourceRoot\Sarif\Schemata\Sarif.schema.json"
+$BuildPropsPath = "$SourceRoot\build.props"
 $BuildRoot = "$RepoRoot\bld"
 $BinRoot = "$BuildRoot\bin"
 $SolutionFile = "Sarif.Sdk.sln"
 $SampleSolutionFile = "Samples\Sarif.Sdk.Sample.sln"
+
+$MSBuildXmlNamespaces = @{ msbuild = "http://schemas.microsoft.com/developer/msbuild/2003" }
 
 $SarifExtension = ".sarif"
 
@@ -60,11 +63,13 @@ Export-ModuleMember -Function `
 
 Export-ModuleMember -Variable `
     BinRoot, `
+    BuildPropsPath, `
     BuildRoot, `
     JsonSchemaPath, `
+    MSBuildXmlNamespaces, `
     RepoRoot, `
     Platform, `
     SampleSolutionFile, `
     SarifExtension, `
     SolutionFile, `
-    SourceRoot `
+    SourceRoot

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -73,9 +73,4 @@
   </ItemGroup>
 
   <Import Project="ToDotNet\ToDotNet.targets" />
-
-  <Target BeforeTargets="PrepareForBuild" Name="CreateVersionConstantsFile">
-    <Exec Command="powershell -ExecutionPolicy RemoteSigned $(MsBuildThisFileDirectory)..\..\scripts\New-VersionConstantsFile.ps1 $(MsBuildThisFileDirectory) $(RootNamespace)" />
-  </Target>
-
 </Project>

--- a/src/build.props
+++ b/src/build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworks);net461</TargetFrameworks>
-    <RootNamespace>Microsoft.CodeAnalysis.$(MSBuildProjectName)</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Label="AssemblyAttributes">
@@ -28,6 +27,12 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
+    <!--
+    Separate out the value of this property from the rest of RootNamespace so we can
+    use it in BeforeBuild.ps1.
+    -->
+    <RootNamespaceBase>Microsoft.CodeAnalysis</RootNamespaceBase>
+    <RootNamespace>$(RootNamespaceBase).$(MSBuildProjectName)</RootNamespace>
     <OutputSubDir>$(Platform)_$(Configuration)</OutputSubDir>
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(OutputSubDir)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>


### PR DESCRIPTION
In VS, it seems, the two platform versions of the Sarif project (net461 and netstandard20) are built simultaneously. Sometimes that results in a collision in the attempt to create `VersionConstants.cs`.

Instead, create it in `BeforeBuild.ps1`. This makes life a little more complicated, because now we have to read a property value from `build.props` instead of letting MSBuild do it for us. Note that `Get-VersionConstants` was already doing that, so we already had code that demonstrated the pattern.

We perform a little refactoring to DRY out a couple of Powershell variables that are now used in multiple places.

If we only built for one platform -- netstandard2.0, as @Evmaus-MS has suggested -- we wouldn't have hit this problem. Still, it's not a bad idea to move this into `BeforeBuild.ps1` in case we ever do in future build multiple platforms for flavors simultaneously (such as a Debug and a Release build).