### PR TITLE
Add missing Autogenerated files.

### DIFF
--- a/src/Sarif/Autogenerated/ExternalFiles.cs
+++ b/src/Sarif/Autogenerated/ExternalFiles.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// References to external files that should be inlined with the content of a root log file.
+    /// </summary>
+    [DataContract]
+    [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.58.0.0")]
+    public partial class ExternalFiles : ISarifNode
+    {
+        public static IEqualityComparer<ExternalFiles> ValueComparer => ExternalFilesEqualityComparer.Instance;
+
+        public bool ValueEquals(ExternalFiles other) => ValueComparer.Equals(this, other);
+        public int ValueGetHashCode() => ValueComparer.GetHashCode(this);
+
+        /// <summary>
+        /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
+        /// </summary>
+        public SarifNodeKind SarifNodeKind
+        {
+            get
+            {
+                return SarifNodeKind.ExternalFiles;
+            }
+        }
+
+        /// <summary>
+        /// An external reference to a run.conversion object to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "conversion", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation Conversion { get; set; }
+
+        /// <summary>
+        /// An external reference to a run.files object to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "files", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation Files { get; set; }
+
+        /// <summary>
+        /// An external reference to a run.graphs object to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "graphs", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation Graphs { get; set; }
+
+        /// <summary>
+        /// An external reference to an run.array of invocation objects to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "invocations", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation Invocations { get; set; }
+
+        /// <summary>
+        /// An external reference to a run.logicalLocations object to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "logicalLocations", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation LogicalLocations { get; set; }
+
+        /// <summary>
+        /// An external reference to a run.resources object to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "resources", IsRequired = false, EmitDefaultValue = false)]
+        public FileLocation Resources { get; set; }
+
+        /// <summary>
+        /// An array of external references to arrays of run.result objects to be merged with the root log file.
+        /// </summary>
+        [DataMember(Name = "results", IsRequired = false, EmitDefaultValue = false)]
+        public IList<FileLocation> Results { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalFiles" /> class.
+        /// </summary>
+        public ExternalFiles()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalFiles" /> class from the supplied values.
+        /// </summary>
+        /// <param name="conversion">
+        /// An initialization value for the <see cref="P: Conversion" /> property.
+        /// </param>
+        /// <param name="files">
+        /// An initialization value for the <see cref="P: Files" /> property.
+        /// </param>
+        /// <param name="graphs">
+        /// An initialization value for the <see cref="P: Graphs" /> property.
+        /// </param>
+        /// <param name="invocations">
+        /// An initialization value for the <see cref="P: Invocations" /> property.
+        /// </param>
+        /// <param name="logicalLocations">
+        /// An initialization value for the <see cref="P: LogicalLocations" /> property.
+        /// </param>
+        /// <param name="resources">
+        /// An initialization value for the <see cref="P: Resources" /> property.
+        /// </param>
+        /// <param name="results">
+        /// An initialization value for the <see cref="P: Results" /> property.
+        /// </param>
+        public ExternalFiles(FileLocation conversion, FileLocation files, FileLocation graphs, FileLocation invocations, FileLocation logicalLocations, FileLocation resources, IEnumerable<FileLocation> results)
+        {
+            Init(conversion, files, graphs, invocations, logicalLocations, resources, results);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalFiles" /> class from the specified instance.
+        /// </summary>
+        /// <param name="other">
+        /// The instance from which the new instance is to be initialized.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="other" /> is null.
+        /// </exception>
+        public ExternalFiles(ExternalFiles other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            Init(other.Conversion, other.Files, other.Graphs, other.Invocations, other.LogicalLocations, other.Resources, other.Results);
+        }
+
+        ISarifNode ISarifNode.DeepClone()
+        {
+            return DeepCloneCore();
+        }
+
+        /// <summary>
+        /// Creates a deep copy of this instance.
+        /// </summary>
+        public ExternalFiles DeepClone()
+        {
+            return (ExternalFiles)DeepCloneCore();
+        }
+
+        private ISarifNode DeepCloneCore()
+        {
+            return new ExternalFiles(this);
+        }
+
+        private void Init(FileLocation conversion, FileLocation files, FileLocation graphs, FileLocation invocations, FileLocation logicalLocations, FileLocation resources, IEnumerable<FileLocation> results)
+        {
+            if (conversion != null)
+            {
+                Conversion = new FileLocation(conversion);
+            }
+
+            if (files != null)
+            {
+                Files = new FileLocation(files);
+            }
+
+            if (graphs != null)
+            {
+                Graphs = new FileLocation(graphs);
+            }
+
+            if (invocations != null)
+            {
+                Invocations = new FileLocation(invocations);
+            }
+
+            if (logicalLocations != null)
+            {
+                LogicalLocations = new FileLocation(logicalLocations);
+            }
+
+            if (resources != null)
+            {
+                Resources = new FileLocation(resources);
+            }
+
+            if (results != null)
+            {
+                var destination_0 = new List<FileLocation>();
+                foreach (var value_0 in results)
+                {
+                    if (value_0 == null)
+                    {
+                        destination_0.Add(null);
+                    }
+                    else
+                    {
+                        destination_0.Add(new FileLocation(value_0));
+                    }
+                }
+
+                Results = destination_0;
+            }
+        }
+    }
+}

--- a/src/Sarif/Autogenerated/ExternalFilesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalFilesEqualityComparer.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// Defines methods to support the comparison of objects of type ExternalFiles for equality.
+    /// </summary>
+    [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.58.0.0")]
+    internal sealed class ExternalFilesEqualityComparer : IEqualityComparer<ExternalFiles>
+    {
+        internal static readonly ExternalFilesEqualityComparer Instance = new ExternalFilesEqualityComparer();
+
+        public bool Equals(ExternalFiles left, ExternalFiles right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.Conversion, right.Conversion))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.Files, right.Files))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.Graphs, right.Graphs))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.Invocations, right.Invocations))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.LogicalLocations, right.LogicalLocations))
+            {
+                return false;
+            }
+
+            if (!FileLocation.ValueComparer.Equals(left.Resources, right.Resources))
+            {
+                return false;
+            }
+
+            if (!object.ReferenceEquals(left.Results, right.Results))
+            {
+                if (left.Results == null || right.Results == null)
+                {
+                    return false;
+                }
+
+                if (left.Results.Count != right.Results.Count)
+                {
+                    return false;
+                }
+
+                for (int index_0 = 0; index_0 < left.Results.Count; ++index_0)
+                {
+                    if (!FileLocation.ValueComparer.Equals(left.Results[index_0], right.Results[index_0]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(ExternalFiles obj)
+        {
+            if (ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+
+            int result = 17;
+            unchecked
+            {
+                if (obj.Conversion != null)
+                {
+                    result = (result * 31) + obj.Conversion.ValueGetHashCode();
+                }
+
+                if (obj.Files != null)
+                {
+                    result = (result * 31) + obj.Files.ValueGetHashCode();
+                }
+
+                if (obj.Graphs != null)
+                {
+                    result = (result * 31) + obj.Graphs.ValueGetHashCode();
+                }
+
+                if (obj.Invocations != null)
+                {
+                    result = (result * 31) + obj.Invocations.ValueGetHashCode();
+                }
+
+                if (obj.LogicalLocations != null)
+                {
+                    result = (result * 31) + obj.LogicalLocations.ValueGetHashCode();
+                }
+
+                if (obj.Resources != null)
+                {
+                    result = (result * 31) + obj.Resources.ValueGetHashCode();
+                }
+
+                if (obj.Results != null)
+                {
+                    foreach (var value_0 in obj.Results)
+                    {
+                        result = result * 31;
+                        if (value_0 != null)
+                        {
+                            result = (result * 31) + value_0.ValueGetHashCode();
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
@michaelcfanning made a schema change that added an `externalFiles` object to the schema, but neither `ExternalFiles.cs` nor `ExternalFilesEqualityComparer.cs` was committed because `.gitignore` mentions `/src/Sarif/Autogenerated`.

I started a thread with Michael to settle whether that line should be in `.gitignore`. For now, I’m force-committing the missing files.
