### PR TITLE
Remove vsix install option from SDK build

### DIFF
--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -30,8 +30,8 @@
     Do not run dotnet publish, which creates a layout directory.
 .PARAMETER NoSigningDirectory
     Do not create a directory containing the binaries that need to be signed.
-.PARAMETER Install
-    Install the VSIX.
+.PARAMETER Associate
+    Associate SARIF files with Visual Studio.
 #>
 
 [CmdletBinding()]
@@ -76,7 +76,7 @@ param(
     $NoSigningDirectory,
 
     [switch]
-    $Install
+    $Associate
 )
 
 Set-StrictMode -Version Latest
@@ -160,16 +160,6 @@ function New-SigningDirectory {
     }
 }
 
-function  Install-SarifExtension {
-    $vsixInstallerPaths = Get-ChildItem $BinRoot "*.vsix" -Recurse
-    if (-not $vsixInstallerPaths) {
-        Exit-WithFailureMessage $ScriptName "Cannot install VSIX: .vsix file was not found."
-    }
-
-    Write-Information "Launching VSIX installer..."
-    & $vsixInstallerPaths[0].FullName
-}
-
 # Create registry settings to open SARIF files in Visual Studio by default.
 function Set-SarifFileAssociationRegistrySettings {
     # You need to be Admin to modify the registry, so create the settings by
@@ -221,8 +211,7 @@ if (-not $NoPackage) {
     New-NuGetPackages $Configuration $Projects
 }
 
-if ($Install) {
-    Install-SarifExtension
+if ($Associate) {
     Set-SarifFileAssociationRegistrySettings
 }
 

--- a/scripts/BuildAndTest.ps1
+++ b/scripts/BuildAndTest.ps1
@@ -161,6 +161,7 @@ function New-SigningDirectory {
 }
 
 # Create registry settings to open SARIF files in Visual Studio by default.
+# If the SARIF Viewer extension is not installed, the file will be opened by the JSON editor.
 function Set-SarifFileAssociationRegistrySettings {
     # You need to be Admin to modify the registry, so create the settings by
     # running a separate script, elevated ("-Verb RunAs").


### PR DESCRIPTION
Maintain the ability to associate .sarif files with VS by changing the Install switch to Associate.