### PR TITLE
Make SkimmerTestBase generic on skimmer type

### DIFF
--- a/src/Sarif.Multitool.FunctionalTests/Rules/DoNotUseFriendlyNameAsRuleIdTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/DoNotUseFriendlyNameAsRuleIdTests.cs
@@ -5,18 +5,18 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class DoNotUseFriendlyNameAsRuleIdTests : SkimmerTestsBase
+    public class DoNotUseFriendlyNameAsRuleIdTests : SkimmerTestsBase<DoNotUseFriendlyNameAsRuleId>
     {
         [Fact(DisplayName = nameof(DoNotUseFriendlyNameAsRuleId_ReportsInvalidSarif))]
         public void DoNotUseFriendlyNameAsRuleId_ReportsInvalidSarif()
         {
-            Verify(new DoNotUseFriendlyNameAsRuleId(), "Invalid.sarif");
+            Verify("Invalid.sarif");
         }
 
         [Fact(DisplayName = nameof(DoNotUseFriendlyNameAsRuleId_AcceptsValidSarif))]
         public void DoNotUseFriendlyNameAsRuleId_AcceptsValidSarif()
         {
-            Verify(new DoNotUseFriendlyNameAsRuleId(), "Valid.sarif");
+            Verify("Valid.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/EndColumnMustNotBeLessThanStartColumnTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/EndColumnMustNotBeLessThanStartColumnTests.cs
@@ -5,48 +5,48 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class EndColumnMustNotBeLessThanStartColumnTests : SkimmerTestsBase
+    public class EndColumnMustNotBeLessThanStartColumnTests : SkimmerTestsBase<EndColumnMustNotBeLessThanStartColumn>
     {
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnEqualsStartColumn))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnEqualsStartColumn()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnEqualsStartColumn.sarif");
+            Verify("EndColumnEqualsStartColumn.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnEqualsStartColumnNoEndLine))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnEqualsStartColumnNoEndLine()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnEqualsStartColumnNoEndLine.sarif");
+            Verify("EndColumnEqualsStartColumnNoEndLine.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnGreaterThanStartColumn))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnGreaterThanStartColumn()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnGreaterThanStartColumn.sarif");
+            Verify("EndColumnGreaterThanStartColumn.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInCodeFlow))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInCodeFlow()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnLessThanStartColumnInCodeFlow.sarif");
+            Verify("EndColumnLessThanStartColumnInCodeFlow.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInRelatedLocation))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInRelatedLocation()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnLessThanStartColumnInRelatedLocation.sarif");
+            Verify("EndColumnLessThanStartColumnInRelatedLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInResultLocation))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnLessThanStartColumnInResultLocation()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnLessThanStartColumnInResultLocation.sarif");
+            Verify("EndColumnLessThanStartColumnInResultLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(EndColumnMustNotBeLessThanStartColumn_EndColumnNotSpecified))]
         public void EndColumnMustNotBeLessThanStartColumn_EndColumnNotSpecified()
         {
-            Verify(new EndColumnMustNotBeLessThanStartColumn(), "EndColumnNotSpecified.sarif");
+            Verify("EndColumnNotSpecified.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/EndLineMustNotBeLessThanStartLineTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/EndLineMustNotBeLessThanStartLineTests.cs
@@ -1,47 +1,46 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class EndLineMustNotBeLessThanStartLineTests : SkimmerTestsBase
+    public class EndLineMustNotBeLessThanStartLineTests : SkimmerTestsBase<EndLineMustNotBeLessThanStartLine>
     {
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineEqualsStartLine))]
         public void EndLineMustNotBeLessThanStartLine_EndLineEqualsStartLine()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineEqualsStartLine.sarif");
+            Verify("EndLineEqualsStartLine.sarif");
         }
 
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineGreaterThanStartLine))]
         public void EndLineMustNotBeLessThanStartLine_EndLineGreaterThanStartLine()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineGreaterThanStartLine.sarif");
+            Verify("EndLineGreaterThanStartLine.sarif");
         }
 
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInCodeFlow))]
         public void EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInCodeFlow()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineLessThanStartLineInCodeFlow.sarif");
+            Verify("EndLineLessThanStartLineInCodeFlow.sarif");
         }
 
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInRelatedLocation))]
         public void EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInRelatedLocation()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineLessThanStartLineInRelatedLocation.sarif");
+            Verify("EndLineLessThanStartLineInRelatedLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineNotSpecified))]
         public void EndLineMustNotBeLessThanStartLine_EndLineNotSpecified()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineNotSpecified.sarif");
+            Verify("EndLineNotSpecified.sarif");
         }
 
         [Fact(DisplayName = nameof(EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInResultLocation))]
         public void EndLineMustNotBeLessThanStartLine_EndLineLessThanStartLineInResultLocation()
         {
-            Verify(new EndLineMustNotBeLessThanStartLine(), "EndLineLessThanStartLineInResultLocation.sarif");
+            Verify("EndLineLessThanStartLineInResultLocation.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/EndTimeMustBeAfterStartTimeTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/EndTimeMustBeAfterStartTimeTests.cs
@@ -1,29 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class EndTimeMustBeAfterStartTimeTests : SkimmerTestsBase
+    public class EndTimeMustBeAfterStartTimeTests : SkimmerTestsBase<EndTimeMustBeAfterStartTime>
     {
         [Fact(DisplayName = nameof(EndTimeMustBeAfterStartTime_EndTimeIsAfterStartTime))]
         public void EndTimeMustBeAfterStartTime_EndTimeIsAfterStartTime()
         {
-            Verify(new EndTimeMustBeAfterStartTime(), "EndTimeIsAfterStartTime.sarif");
+            Verify("EndTimeIsAfterStartTime.sarif");
         }
 
         [Fact(DisplayName = nameof(EndTimeMustBeAfterStartTime_EndTimeEqualsStartTime))]
         public void EndTimeMustBeAfterStartTime_EndTimeEqualsStartTime()
         {
-            Verify(new EndTimeMustBeAfterStartTime(), "EndTimeEqualsStartTime.sarif");
+            Verify("EndTimeEqualsStartTime.sarif");
         }
 
         [Fact(DisplayName = nameof(EndTimeMustBeAfterStartTime_EndTimeIsBeforeStartTime))]
         public void EndTimeMustBeAfterStartTime_EndTimeIsBeforeStartTime()
         {
-            Verify(new EndTimeMustBeAfterStartTime(), "EndTimeIsBeforeStartTime.sarif");
+            Verify("EndTimeIsBeforeStartTime.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/HashAlgorithmsMustBeUniqueTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/HashAlgorithmsMustBeUniqueTests.cs
@@ -1,23 +1,22 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class HashAlgorithmsMustBeUniqueTests : SkimmerTestsBase
+    public class HashAlgorithmsMustBeUniqueTests : SkimmerTestsBase<HashAlgorithmsMustBeUnique>
     {
         [Fact(DisplayName = nameof(HashAlgorithmsMustBeUnique_UniqueHashAlgorithms))]
         public void HashAlgorithmsMustBeUnique_UniqueHashAlgorithms()
         {
-            Verify(new HashAlgorithmsMustBeUnique(), "UniqueHashAlgorithms.sarif");
+            Verify("UniqueHashAlgorithms.sarif");
         }
 
         [Fact(DisplayName = nameof(HashAlgorithmsMustBeUnique_NonUniqueHashAlgorithms))]
         public void HashAlgorithmsMustBeUnique_NonUniqueHashAlgorithms()
         {
-            Verify(new HashAlgorithmsMustBeUnique(), "NonUniqueHashAlgorithms.sarif");
+            Verify("NonUniqueHashAlgorithms.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/MessagesShouldEndWithPeriodTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/MessagesShouldEndWithPeriodTests.cs
@@ -1,59 +1,58 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class MessagesShouldEndWithPeriodTests : SkimmerTestsBase
+    public class MessagesShouldEndWithPeriodTests : SkimmerTestsBase<MessagesShouldEndWithPeriod>
     {
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_PeriodsAfterAllMessages))]
         public void MessagesShouldEndWithPeriod_PeriodsAfterAllMessages()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "PeriodsAfterAllMessages.sarif");
+            Verify("PeriodsAfterAllMessages.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_CodeFlowMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_CodeFlowMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "CodeFlowMessageWithoutPeriod.sarif");
+            Verify("CodeFlowMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_NotificationMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_NotificationMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "NotificationMessageWithoutPeriod.sarif");
+            Verify("NotificationMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_ResultMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_ResultMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "ResultMessageWithoutPeriod.sarif");
+            Verify("ResultMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_RuleMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_RuleMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "RuleMessageWithoutPeriod.sarif");
+            Verify("RuleMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_StackFrameMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_StackFrameMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "StackFrameMessageWithoutPeriod.sarif");
+            Verify("StackFrameMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_StackMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_StackMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "StackMessageWithoutPeriod.sarif");
+            Verify("StackMessageWithoutPeriod.sarif");
         }
 
         [Fact(DisplayName = nameof(MessagesShouldEndWithPeriod_ThreadFlowLocationMessageWithoutPeriod))]
         public void MessagesShouldEndWithPeriod_ThreadFlowLocationMessageWithoutPeriod()
         {
-            Verify(new MessagesShouldEndWithPeriod(), "ThreadFlowLocationMessageWithoutPeriod.sarif");
+            Verify("ThreadFlowLocationMessageWithoutPeriod.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/SkimmerTestsBase.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/SkimmerTestsBase.cs
@@ -10,11 +10,12 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public abstract class SkimmerTestsBase : SarifMultitoolTestBase
+    public abstract class SkimmerTestsBase<TSkimmer> : SarifMultitoolTestBase
+        where TSkimmer : SkimmerBase<SarifValidationContext>, new()
     {
-        protected void Verify(SkimmerBase<SarifValidationContext> skimmer, string testFileName)
+        protected void Verify(string testFileName)
         {
-            string ruleName = skimmer.GetType().Name;
+            string ruleName = typeof(TSkimmer).Name;
             string testDirectory = Path.Combine(Environment.CurrentDirectory, TestDataDirectory, ruleName);
 
             string targetPath = Path.Combine(testDirectory, testFileName);
@@ -29,6 +30,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             };
 
             SarifLog inputLog = JsonConvert.DeserializeObject<SarifLog>(inputLogContents, settings);
+
+            var skimmer = new TSkimmer();
 
             using (var logger = new SarifLogger(
                     actualFilePath,

--- a/src/Sarif.Multitool.FunctionalTests/Rules/StepValuesMustFormOneBasedSequenceTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/StepValuesMustFormOneBasedSequenceTests.cs
@@ -1,41 +1,40 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class StepValuesMustFormOneBasedSequenceTests : SkimmerTestsBase
+    public class StepValuesMustFormOneBasedSequenceTests : SkimmerTestsBase<StepValuesMustFormOneBasedSequence>
     {
         [Fact(DisplayName = nameof(StepValuesMustFormOneBasedSequence_ValidSteps))]
         public void StepValuesMustFormOneBasedSequence_ValidSteps()
         {
-            Verify(new StepValuesMustFormOneBasedSequence(), "ValidSteps.sarif");
+            Verify("ValidSteps.sarif");
         }
 
         [Fact(DisplayName = nameof(StepValuesMustFormOneBasedSequence_NoStepsPresent))]
         public void StepValuesMustFormOneBasedSequence_NoStepsPresent()
         {
-            Verify(new StepValuesMustFormOneBasedSequence(), "NoStepsPresent.sarif");
+            Verify("NoStepsPresent.sarif");
         }
 
         [Fact(DisplayName = nameof(StepValuesMustFormOneBasedSequence_StepNotPresentOnAllLocations))]
         public void StepValuesMustFormOneBasedSequence_StepNotPresentOnAllLocations()
         {
-            Verify(new StepValuesMustFormOneBasedSequence(), "StepNotPresentOnAllLocations.sarif");
+            Verify("StepNotPresentOnAllLocations.sarif");
         }
 
         [Fact(DisplayName = nameof(StepValuesMustFormOneBasedSequence_InvalidStepValues))]
         public void StepValuesMustFormOneBasedSequence_InvalidStepValues()
         {
-            Verify(new StepValuesMustFormOneBasedSequence(), "InvalidStepValues.sarif");
+            Verify("InvalidStepValues.sarif");
         }
 
         [Fact(DisplayName = nameof(StepValuesMustFormOneBasedSequence_MultipleThreadFlows))]
         public void StepValuesMustFormOneBasedSequence_MultipleThreadFlows()
         {
-            Verify(new StepValuesMustFormOneBasedSequence(), "MultipleThreadFlows.sarif");
+            Verify("MultipleThreadFlows.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/UriBaseIdRequiresRelativeUriTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/UriBaseIdRequiresRelativeUriTests.cs
@@ -5,120 +5,120 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class UriBaseIdRequiresRelativeUriTests : SkimmerTestsBase
+    public class UriBaseIdRequiresRelativeUriTests : SkimmerTestsBase<UriBaseIdRequiresRelativeUri>
     {
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_UrisAreRelative))]
         public void UriBaseIdRequiresRelativeUri_UrisAreRelative()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "UrisAreRelative.sarif");
+            Verify("UrisAreRelative.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInAnalysisTarget))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInAnalysisTarget()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInAnalysisTarget.sarif");
+            Verify("AbsoluteUriInAnalysisTarget.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInCodeFlow))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInCodeFlow()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInCodeFlow.sarif");
+            Verify("AbsoluteUriInCodeFlow.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInConfigurationNotification))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInConfigurationNotification()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInConfigurationNotification.sarif");
+            Verify("AbsoluteUriInConfigurationNotification.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInConversionAnalysisToolLogFiles))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInConversionAnalysisToolLogFiles()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInConversionAnalysisToolLogFiles.sarif");
+            Verify("AbsoluteUriInConversionAnalysisToolLogFiles.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInFileChange))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInFileChange()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInFileChange.sarif");
+            Verify("AbsoluteUriInFileChange.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInFilesDictionary))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInFilesDictionary()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInFilesDictionary.sarif");
+            Verify("AbsoluteUriInFilesDictionary.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationAttachment))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationAttachment()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInInvocationAttachment.sarif");
+            Verify("AbsoluteUriInInvocationAttachment.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationExecutableLocation))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationExecutableLocation()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInInvocationExecutableLocation.sarif");
+            Verify("AbsoluteUriInInvocationExecutableLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationResponseFile))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationResponseFile()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInInvocationResponseFile.sarif");
+            Verify("AbsoluteUriInInvocationResponseFile.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationStandardStreams))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInInvocationStandardStreams()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInInvocationStandardStreams.sarif");
+            Verify("AbsoluteUriInInvocationStandardStreams.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInRelatedLocation))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInRelatedLocation()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInRelatedLocation.sarif");
+            Verify("AbsoluteUriInRelatedLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInResultAttachment))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInResultAttachment()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInResultAttachment.sarif");
+            Verify("AbsoluteUriInResultAttachment.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInResultConversionProvenance))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInResultConversionProvenance()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInResultConversionProvenance.sarif");
+            Verify("AbsoluteUriInResultConversionProvenance.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInResultGraphNode))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInResultGraphNode()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInResultGraphNode.sarif");
+            Verify("AbsoluteUriInResultGraphNode.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInResultLocation))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInResultLocation()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInResultLocation.sarif");
+            Verify("AbsoluteUriInResultLocation.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInRunGraphNode))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInRunGraphNode()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInRunGraphNode.sarif");
+            Verify("AbsoluteUriInRunGraphNode.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInStackFrame))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInStackFrame()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInStackFrame.sarif");
+            Verify("AbsoluteUriInStackFrame.sarif");
         }
 
         [Fact(DisplayName = nameof(UriBaseIdRequiresRelativeUri_AbsoluteUriInToolNotification))]
         public void UriBaseIdRequiresRelativeUri_AbsoluteUriInToolNotification()
         {
-            Verify(new UriBaseIdRequiresRelativeUri(), "AbsoluteUriInToolNotification.sarif");
+            Verify("AbsoluteUriInToolNotification.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/UriMustBeAbsoluteTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/UriMustBeAbsoluteTests.cs
@@ -5,18 +5,18 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class UriMustBeAbsoluteTests : SkimmerTestsBase
+    public class UriMustBeAbsoluteTests : SkimmerTestsBase<UriMustBeAbsolute>
     {
         [Fact(DisplayName = nameof(UriMustBeAbsolute_ReportsInvalidSarif))]
         public void UriMustBeAbsolute_ReportsInvalidSarif()
         {
-            Verify(new UriMustBeAbsolute(), "Invalid.sarif");
+            Verify("Invalid.sarif");
         }
 
         [Fact(DisplayName = nameof(UriMustBeAbsolute_AcceptsValidSarif))]
         public void UriMustBeAbsolute_AcceptsValidSarif()
         {
-            Verify(new UriMustBeAbsolute(), "Valid.sarif");
+            Verify("Valid.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/UrisMustBeValidTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/UrisMustBeValidTests.cs
@@ -16,61 +16,61 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
     // choose the one in the result.analysisTarget property -- and for any "loose URIs"
     // that occur in the format, such as "rule.helpUri".
 
-    public class UrisMustBeValidTests : SkimmerTestsBase
+    public class UrisMustBeValidTests : SkimmerTestsBase<UrisMustBeValid>
     {
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidFileLocationUri))]
         public void UrisMustBeValid_InvalidFileLocationUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidFileLocationUri.sarif");
+            Verify("InvalidFileLocationUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidResultWorkItemUri))]
         public void UrisMustBeValid_InvalidResultWorkItemUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidResultWorkItemUri.sarif");
+            Verify("InvalidResultWorkItemUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidRuleHelpUri))]
         public void UrisMustBeValid_InvalidRuleHelpUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidRuleHelpUri.sarif");
+            Verify("InvalidRuleHelpUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidSarifLogSchemaUri))]
         public void UrisMustBeValid_InvalidSarifLogSchemaUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidSarifLogSchemaUri.sarif");
+            Verify("InvalidSarifLogSchemaUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidToolDownloadUri))]
         public void UrisMustBeValid_InvalidToolDownloadUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidToolDownloadUri.sarif");
+            Verify("InvalidToolDownloadUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidUriInFilePropertyName))]
         public void UrisMustBeValid_InvalidUriInFilePropertyName()
         {
-            Verify(new UrisMustBeValid(), "InvalidUriInFilePropertyName.sarif");
+            Verify("InvalidUriInFilePropertyName.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidUriInOriginalUriBaseIds))]
         public void UrisMustBeValid_InvalidUriInOriginalUriBaseIds()
         {
-            Verify(new UrisMustBeValid(), "InvalidUriInOriginalUriBaseIds.sarif");
+            Verify("InvalidUriInOriginalUriBaseIds.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_InvalidVersionControlDetailsUri))]
         public void UrisMustBeValid_InvalidVersionControlDetailsUri()
         {
-            Verify(new UrisMustBeValid(), "InvalidVersionControlDetailsUri.sarif");
+            Verify("InvalidVersionControlDetailsUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UrisMustBeValid_ValidUris))]
 
         public void UrisMustBeValid_ValidUris()
         {
-            Verify(new UrisMustBeValid(), "ValidUris.sarif");
+            Verify("ValidUris.sarif");
         }
     }
 }

--- a/src/Sarif.Multitool.FunctionalTests/Rules/UseAbsolutePathsForNestedFileUriFragmentsTests.cs
+++ b/src/Sarif.Multitool.FunctionalTests/Rules/UseAbsolutePathsForNestedFileUriFragmentsTests.cs
@@ -5,24 +5,24 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
-    public class UseAbsolutePathsForNestedFileUriFragmentsTests : SkimmerTestsBase
+    public class UseAbsolutePathsForNestedFileUriFragmentsTests : SkimmerTestsBase<UseAbsolutePathsForNestedFileUriFragments>
     {
         [Fact(DisplayName = nameof(UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentsAreAbsolute))]
         public void UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentsAreAbsolute()
         {
-            Verify(new UseAbsolutePathsForNestedFileUriFragments(), "NestedFileUriFragmentsAreAbsolute.sarif");
+            Verify("NestedFileUriFragmentsAreAbsolute.sarif");
         }
 
         [Fact(DisplayName = nameof(UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentIsRelativeInFileLocationUri))]
         public void UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentIsRelativeInFileLocationUri()
         {
-            Verify(new UseAbsolutePathsForNestedFileUriFragments(), "NestedFileUriFragmentIsRelativeInFileLocationUri.sarif");
+            Verify("NestedFileUriFragmentIsRelativeInFileLocationUri.sarif");
         }
 
         [Fact(DisplayName = nameof(UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentIsRelativeInFilePropertyName))]
         public void UseAbsolutePathsForNestedFileUriFragments_NestedFileUriFragmentIsRelativeInFilePropertyName()
         {
-            Verify(new UseAbsolutePathsForNestedFileUriFragments(), "NestedFileUriFragmentIsRelativeInFilePropertyName.sarif");
+            Verify("NestedFileUriFragmentIsRelativeInFilePropertyName.sarif");
         }
     }
 }


### PR DESCRIPTION
This allows `SkimmerTestBase` to instantiate the skimmer, rather than requiring each test method in each derived class to instantiate it.