### PR TITLE
Fix #1070: UrisMustBeValid fails on file dictionary key with uriBaseId

### DIFF
--- a/src/Sarif.Multitool.FunctionalTests/TestData/UrisMustBeValid/ValidUris.sarif
+++ b/src/Sarif.Multitool.FunctionalTests/TestData/UrisMustBeValid/ValidUris.sarif
@@ -22,6 +22,8 @@
       "files": {
         "file:///c:/src/file.c": {
           "mimeType": "text/x-c"
+        },
+        "#SRCROOT#src/file.c": {
         }
       },
       "originalUriBaseIds": {

--- a/src/Sarif.Multitool/Rules/UrisMustBeValid.cs
+++ b/src/Sarif.Multitool/Rules/UrisMustBeValid.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Json.Pointer;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
@@ -36,8 +37,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected override void Analyze(FileData fileData, string fileKey, string filePointer)
         {
-            string fileUriReference = fileKey.UnescapeJsonPointer();
+            string fileUriReference = RemoveUriBaseIdPrefix(fileKey);
             AnalyzeUri(fileUriReference, filePointer);
+        }
+
+        private const string UriWithPrefixPattern =
+@"^                     # Start of string, followed by
+(?<prefix>              # a prefix consisting of
+    \#                  #    a pound sign (escaped because otherwise it would signify a comment),
+    [^\#]+              #    one or more occurrences of anything that isn't a pound sign,
+    \#                  #    and another pound sign,
+)
+(?<uri>                 # followed by the URI, which is
+    .+                  #     everything
+)
+$                       # up to the end of the string (not strictly needed since the match is greedy).
+";
+
+        private static readonly Regex s_uriWithPrefixRegex =
+            new Regex(UriWithPrefixPattern, RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
+        private string RemoveUriBaseIdPrefix(string fileKey)
+        {
+            Match match = s_uriWithPrefixRegex.Match(fileKey);
+            return match.Success
+                ? match.Groups["uri"].Value
+                : fileKey;
         }
 
         protected override void Analyze(FileLocation fileLocation, string fileLocationPointer)


### PR DESCRIPTION
You have to remove the `"#<uriBaseId>#"` prefix, if present, before evaluating the remainder as a URI.