### PR TITLE
Fix #1090: SarifRewritingVisitor does not visit some dictionaries.

### DIFF
--- a/src/Sarif/Autogenerated/Resources.cs
+++ b/src/Sarif/Autogenerated/Resources.cs
@@ -5,7 +5,6 @@ using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Microsoft.CodeAnalysis.Sarif;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Autogenerated/ResourcesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ResourcesEqualityComparer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Sarif;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {

--- a/src/Sarif/Autogenerated/Result.cs
+++ b/src/Sarif/Autogenerated/Result.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string CorrelationGuid { get; set; }
 
         /// <summary>
-        /// A positive integer specifying the number of times a result with this result object's correlationGuid has been observed
+        /// A positive integer specifying the number of times this logically unique result was observed in this run.
         /// </summary>
         [DataMember(Name = "occurrenceCount", IsRequired = false, EmitDefaultValue = false)]
         public int OccurrenceCount { get; set; }

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -544,6 +544,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (node != null)
             {
+                if (node.Rules != null)
+                {
+                    var keys = node.Rules.Keys.ToArray();
+                    foreach (var key in keys)
+                    {
+                        var value = node.Rules[key];
+                        if (value != null)
+                        {
+                            node.Rules[key] = VisitNullChecked(value);
+                        }
+                    }
+                }
             }
 
             return node;
@@ -576,6 +588,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                     for (int index_0 = 0; index_0 < node.CodeFlows.Count; ++index_0)
                     {
                         node.CodeFlows[index_0] = VisitNullChecked(node.CodeFlows[index_0]);
+                    }
+                }
+
+                if (node.Graphs != null)
+                {
+                    var keys = node.Graphs.Keys.ToArray();
+                    foreach (var key in keys)
+                    {
+                        var value = node.Graphs[key];
+                        if (value != null)
+                        {
+                            node.Graphs[key] = VisitNullChecked(value);
+                        }
                     }
                 }
 
@@ -690,6 +715,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                         if (value != null)
                         {
                             node.LogicalLocations[key] = VisitNullChecked(value);
+                        }
+                    }
+                }
+
+                if (node.Graphs != null)
+                {
+                    var keys = node.Graphs.Keys.ToArray();
+                    foreach (var key in keys)
+                    {
+                        var value = node.Graphs[key];
+                        if (value != null)
+                        {
+                            node.Graphs[key] = VisitNullChecked(value);
                         }
                     }
                 }

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -207,14 +207,7 @@
   ],
   "Resources.Rules": [
     {
-      "kind": "DictionaryHint",
-      "arguments": {
-        "valueTypeName": "Rule",
-        "namespaceName": "Microsoft.CodeAnalysis.Sarif",
-        "comparisonKind": "EqualityComparerEquals",
-        "hashKind": "ObjectModelType",
-        "initializationKind": "Clone"
-      }
+      "kind": "DictionaryHint"
     }
   ],
   "result": [
@@ -244,13 +237,7 @@
   ],
   "Result.Graphs": [
     {
-      "kind": "DictionaryHint",
-      "arguments": {
-        "valueTypeName": "Graph",
-        "comparisonKind": "EqualityComparerEquals",
-        "hashKind": "ObjectModelType",
-        "initializationKind": "Clone"
-      }
+      "kind": "DictionaryHint"
     }
   ],
   "Result.Level": [
@@ -381,13 +368,7 @@
   ],
   "Run.Graphs": [
     {
-      "kind": "DictionaryHint",
-      "arguments": {
-        "valueTypeName": "Graph",
-        "comparisonKind": "EqualityComparerEquals",
-        "hashKind": "ObjectModelType",
-        "initializationKind": "Clone"
-      }
+      "kind": "DictionaryHint"
     }
   ],
   "Run.LogicalLocations": [


### PR DESCRIPTION
By default, when the `JsonSchemaToDotNet` code generator encounters a property whose JSON type is `object`, it generates a .NET property of type `System.Object`. However, if you specify a `DictionaryHint` for that property, the code generator instead generates a .NET property of type `IDictionary<TKey, TValue>`. If you don't supply any arguments to the `DictionaryHint`, the code generator sets `TKey` to `string`, and it infers `TValue` from the schema. However, you can supply arguments to the dictionary hint to specify the key type, the value type, and how the value type should be treated when its cloning and visiting code is generated.

In the file `CodeGenHints.json`, the `DictionaryHint`s for `run.files` and `run.logicalLocation` do not have any arguments, and their cloning code and visiting code is correctly generated. But -- for no particular reason; probably because I'd forgotten that the code generator can infer without any help -- the `DictionaryHint`s for `resources.rules`, `run.graphs`, and `result.graphs` _do_ have arguments.

The arguments I supplied should match the defaults inferred by the code generator. But _either_ because I got those arguments wrong, _or_ because there is a bug in the code generator (this possibility is tracked in Microsoft/jschema#37), the code generator did not generator any code in the `SarifRewritingVisitor` to visit those dictionaries.

Removing the arguments from those `DictionaryHint`s allowed the code generator to correctly infer how to generate the dictionary, its cloning code, and its visiting code.