### PR TITLE
Protect against null v1 results collection

### DIFF
--- a/src/Sarif.UnitTests/Transformers/SarifVersionOneToCurrentTests.cs
+++ b/src/Sarif.UnitTests/Transformers/SarifVersionOneToCurrentTests.cs
@@ -143,8 +143,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Transformers
       ""tool"": {
         ""name"": ""CodeScanner"",
         ""semanticVersion"": ""2.1.0""
-      },
-      ""results"": []
+      }
     }
   ]
 }";
@@ -159,9 +158,8 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Transformers
         ""name"": ""CodeScanner"",
         ""semanticVersion"": ""2.1.0""
       },
-      ""results"": [],
       ""properties"": {
-        ""sarifv1/run"": {""tool"":{""name"":""CodeScanner"",""semanticVersion"":""2.1.0""},""results"":[]}
+        ""sarifv1/run"": {""tool"":{""name"":""CodeScanner"",""semanticVersion"":""2.1.0""}}
       }
     }
   ]

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -893,7 +893,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                         BaselineInstanceGuid = v1Run.BaselineId,
                         InstanceGuid = v1Run.Id,
                         Properties = v1Run.Properties,
-                        Results = new List<Result>(),
                         LogicalId = v1Run.StableId,
                         Tool = CreateTool(v1Run.Tool)
                     };
@@ -951,6 +950,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                     if (v1Run.Results != null)
                     {
+                        run.Results = new List<Result>();
+
                         foreach (ResultVersionOne v1Result in v1Run.Results)
                         {
                             run.Results.Add(CreateResult(v1Result));

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -949,9 +949,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                         };
                     }
 
-                    foreach (ResultVersionOne v1Result in v1Run.Results)
+                    if (v1Run.Results != null)
                     {
-                        run.Results.Add(CreateResult(v1Result));
+                        foreach (ResultVersionOne v1Result in v1Run.Results)
+                        {
+                            run.Results.Add(CreateResult(v1Result));
+                        }
                     }
 
                     // Stash the entire v1 run in this v2 run's property bag


### PR DESCRIPTION
Also don't return an empty results collection in the v2 output, since that property is not required.