### PR TITLE
[Design Only] Deferred Reader

### DIFF
--- a/src/Sarif.Sdk.sln
+++ b/src/Sarif.Sdk.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 15.0.26124.0
@@ -66,7 +67,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{90E0CA8D-0D6
 		ReleaseHistory.md = ReleaseHistory.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarif.Multitool.UnitTests", "Sarif.Multitool.UnitTests\Sarif.Multitool.UnitTests.csproj", "{706D3D4B-B669-496A-B4C2-7B9E91C4E684}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sarif.Multitool.UnitTests", "Sarif.Multitool.UnitTests\Sarif.Multitool.UnitTests.csproj", "{706D3D4B-B669-496A-B4C2-7B9E91C4E684}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SarifDeferredSample", "SarifDeferredSample\SarifDeferredSample.csproj", "{EBE491D1-790D-43CA-899B-FCD2FDD21823}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -222,6 +225,18 @@ Global
 		{706D3D4B-B669-496A-B4C2-7B9E91C4E684}.Release|x64.Build.0 = Release|Any CPU
 		{706D3D4B-B669-496A-B4C2-7B9E91C4E684}.Release|x86.ActiveCfg = Release|Any CPU
 		{706D3D4B-B669-496A-B4C2-7B9E91C4E684}.Release|x86.Build.0 = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|x64.Build.0 = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Debug|x86.Build.0 = Debug|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|x64.ActiveCfg = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|x64.Build.0 = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|x86.ActiveCfg = Release|Any CPU
+		{EBE491D1-790D-43CA-899B-FCD2FDD21823}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Sarif.Sdk.sln
+++ b/src/Sarif.Sdk.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 15.0.26124.0

--- a/src/Sarif.UnitTests/Readers/DeferredCollectionsTests.cs
+++ b/src/Sarif.UnitTests/Readers/DeferredCollectionsTests.cs
@@ -103,6 +103,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 contextsCopy[pair.Key] = pair.Value;
             }
             Assert.Equal(actual.CodeContexts.Count, contextsCopy.Count);
+
+            // Enumerate Keys
+            int keyCount = 0;
+            foreach(string key in actual.CodeContexts.Keys)
+            {
+                Assert.True(contextsCopy.ContainsKey(key));
+                keyCount++;
+            }
+            Assert.Equal(contextsCopy.Count, keyCount);
+
+            // Enumerate Values
+            int valueCount = 0;
+            foreach(CodeContext value in actual.CodeContexts.Values)
+            {
+                Assert.True(contextsCopy.ContainsValue(value));
+                valueCount++;
+            }
+            Assert.Equal(contextsCopy.Count, valueCount);
         }
 
         private static void AssertEqual(Log expected, Log actual)
@@ -113,15 +131,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             Assert.Equal(expected.ApplicationContext, actual.ApplicationContext);
 
             // Validate DeferredDictionary has the right keys and all equal values
-            Assert.Equal(expected.CodeContexts.Count, actual.CodeContexts.Count);
-            foreach(string key in expected.CodeContexts.Keys)
+            foreach(KeyValuePair<string, CodeContext> item in actual.CodeContexts)
             {
-                Assert.Equal(expected.CodeContexts[key], actual.CodeContexts[key]);
+                Assert.Equal(expected.CodeContexts[item.Key], item.Value);
             }
+            Assert.Equal(expected.CodeContexts.Count, actual.CodeContexts.Count);
 
             // Verify DeferredList has the right count and reconstructs identical messages
-            Assert.Equal(expected.Messages.Count, actual.Messages.Count);
-            for(int i = 0; i < expected.Messages.Count; ++i)
+            int count = 0;
+            foreach(LogMessage message in actual.Messages)
+            {
+                Assert.Equal(expected.Messages[count++], message);
+            }
+
+            // Enumerate list again via indexer
+            for (int i = 0; i < actual.Messages.Count; ++i)
             {
                 Assert.Equal(expected.Messages[i], actual.Messages[i]);
             }

--- a/src/Sarif.UnitTests/Readers/DeferredCollectionsTests.cs
+++ b/src/Sarif.UnitTests/Readers/DeferredCollectionsTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.Sarif.Readers.SampleModel;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    public class DeferredCollectionsTests
+    {
+        [Fact]
+        public void EndToEnd_NormalLog()
+        {
+            CompareReadNormalToReadDeferred(LogModelSampleBuilder.SampleLogPath);
+        }
+
+        [Fact]
+        public void EndToEnd_EmptyLog()
+        {
+            CompareReadNormalToReadDeferred(LogModelSampleBuilder.SampleEmptyPath);
+        }
+
+        [Fact]
+        public void EndToEnd_NoDictionary()
+        {
+            CompareReadNormalToReadDeferred(LogModelSampleBuilder.SampleNoCodeContextsPath);
+        }
+
+        [Fact]
+        public void EndToEnd_SingleLineJson()
+        {
+            CompareReadNormalToReadDeferred(LogModelSampleBuilder.SampleOneLinePath);
+        }
+
+        private static void CompareReadNormalToReadDeferred(string filePath)
+        {
+            LogModelSampleBuilder.EnsureSamplesBuilt();
+            JsonSerializer serializer = new JsonSerializer();
+
+            Log expected;
+            Log actual;
+
+            // Read normally (JsonSerializer -> JsonTextReader -> StreamReader)
+            using (JsonTextReader reader = new JsonTextReader(new StreamReader(filePath)))
+            {
+                expected = serializer.Deserialize<Log>(reader);
+                Assert.IsType<Dictionary<string, CodeContext>>(expected.CodeContexts);
+                Assert.IsType<List<LogMessage>>(expected.Messages);
+            }
+
+            // Read with Deferred collections
+            serializer.ContractResolver = new LogModelDeferredContractResolver();
+            using (JsonPositionedTextReader reader = new JsonPositionedTextReader(filePath))
+            {
+                actual = serializer.Deserialize<Log>(reader);
+                Assert.IsType<DeferredDictionary<CodeContext>>(actual.CodeContexts);
+                Assert.IsType<DeferredList<LogMessage>>(actual.Messages);
+            }
+
+            // Deep compare objects which were returned
+            AssertEqual(expected, actual);
+
+            // DeferredList Code Coverage - CopyTo()
+            LogMessage[] messages = new LogMessage[actual.Messages.Count + 1];
+            actual.Messages.CopyTo(messages, 1);
+            if(actual.Messages.Count > 0) Assert.Equal<LogMessage>(actual.Messages[0], messages[1]);
+
+            // DeferredDictionary Code Coverage
+            CodeContext context;
+
+            // TryGetValue
+            Assert.False(actual.CodeContexts.TryGetValue("missing", out context));
+            if (actual.CodeContexts.Count > 0) Assert.True(actual.CodeContexts.TryGetValue("load", out context));
+
+            // ContainsKey
+            Assert.False(actual.CodeContexts.ContainsKey("missing"));
+            if (actual.CodeContexts.Count > 0) Assert.True(actual.CodeContexts.ContainsKey("load"));
+
+            // Contains
+            context = new CodeContext() { Name = "LoadRules()", Type = CodeContextType.Method, ParentContextID = "run" };
+            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("missing", context)));        // Missing Key
+            Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("run", context)));            // Different Value
+
+            if (actual.CodeContexts.Count > 0)
+            {
+                Assert.True(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", context)));        // Match
+                Assert.False(actual.CodeContexts.Contains(new KeyValuePair<string, CodeContext>("load", null)));          // Match vs. Null
+            }
+
+            // CopyTo
+            KeyValuePair<string, CodeContext>[] contexts = new KeyValuePair<string, CodeContext>[actual.CodeContexts.Count + 1];
+            actual.CodeContexts.CopyTo(contexts, 1);
+            if (actual.CodeContexts.Count > 0) Assert.Equal(actual.CodeContexts.First(), contexts[1]);
+
+            // Enumeration
+            Dictionary<string, CodeContext> contextsCopy = new Dictionary<string, CodeContext>();
+            foreach(KeyValuePair<string, CodeContext> pair in actual.CodeContexts)
+            {
+                contextsCopy[pair.Key] = pair.Value;
+            }
+            Assert.Equal(actual.CodeContexts.Count, contextsCopy.Count);
+        }
+
+        private static void AssertEqual(Log expected, Log actual)
+        {
+            // Validate top level properties (which shouldn't have been read any differently)
+            Assert.Equal(expected.ID, actual.ID);
+            Assert.Equal(expected.StartTimeUtc, actual.StartTimeUtc);
+            Assert.Equal(expected.ApplicationContext, actual.ApplicationContext);
+
+            // Validate DeferredDictionary has the right keys and all equal values
+            Assert.Equal(expected.CodeContexts.Count, actual.CodeContexts.Count);
+            foreach(string key in expected.CodeContexts.Keys)
+            {
+                Assert.Equal(expected.CodeContexts[key], actual.CodeContexts[key]);
+            }
+
+            // Verify DeferredList has the right count and reconstructs identical messages
+            Assert.Equal(expected.Messages.Count, actual.Messages.Count);
+            for(int i = 0; i < expected.Messages.Count; ++i)
+            {
+                Assert.Equal(expected.Messages[i], actual.Messages[i]);
+            }
+        }
+    }
+}

--- a/src/Sarif.UnitTests/Readers/LineMappingStreamReaderTests.cs
+++ b/src/Sarif.UnitTests/Readers/LineMappingStreamReaderTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis.Sarif.Readers.SampleModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    public class LineMappingStreamReaderTests
+    {
+        [Fact]
+        public void LineMappingStreamReader_Basics()
+        {
+            LogModelSampleBuilder.EnsureSamplesBuilt();
+            string path = LogModelSampleBuilder.SampleLogPath;
+
+            // Read it all and find all newline indices
+            byte[] content = File.ReadAllBytes(path);
+            List<long> newlines = new List<long>();
+            newlines.Add(-1);
+            newlines.Add(-1);
+
+            for (long i = 0; i < content.Length; ++i)
+            {
+                if(content[i] == (byte)'\n')
+                {
+                    newlines.Add(i);
+                }
+            }
+
+            char[] buffer = new char[1024];
+            int nextLine = 1;
+            long bytesRead = 0;
+            using (LineMappingStreamReader reader = new LineMappingStreamReader(File.OpenRead(path)))
+            {
+                while (true)
+                {
+                    // Read a segment of the file
+                    int lengthRead = reader.Read(buffer, 0, buffer.Length);
+                    if (lengthRead == 0) break;
+
+                    // Count the file bytes now in range
+                    bytesRead += reader.CurrentEncoding.GetByteCount(buffer, 0, lengthRead);
+
+                    // Ask the LineMappingStreamReader for the position of (N, 1) for each line in range
+                    for(; nextLine < newlines.Count; nextLine++)
+                    {
+                        long nextNewlinePosition = newlines[nextLine];
+                        if (nextNewlinePosition > bytesRead) break;
+
+                        long reportedAtPosition = reader.LineAndCharToOffset(nextLine, 1) - 1;
+
+                        // Verify (N, 1) is one byte after the newline we found
+                        Assert.Equal(nextNewlinePosition, reportedAtPosition);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void LineMappingStreamReader_WithJsonReader()
+        {
+            string filePath = LogModelSampleBuilder.SampleLogPath;
+            JsonSerializer serializer = new JsonSerializer();
+
+            // Open a stream to read objects individually
+            using (Stream seekingStream = File.OpenRead(filePath))
+            {
+                // Read the Json with a LineMappingStreamReader
+                using (LineMappingStreamReader streamReader = new LineMappingStreamReader(File.OpenRead(filePath)))
+                using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+                {
+                    // Get into the top object
+                    jsonReader.Read();
+
+                    while (jsonReader.Read())
+                    {
+                        if (jsonReader.TokenType == JsonToken.StartObject)
+                        {
+                            // Map each object to a byte position
+                            long position = streamReader.LineAndCharToOffset(jsonReader.LineNumber, jsonReader.LinePosition);
+
+                            // Create an object from the original stream
+                            JObject expected = (JObject)serializer.Deserialize(jsonReader);
+
+                            // Compare to one we get by seeking to the calculated byte offset
+                            JObject actual = ReadAtPosition(serializer, seekingStream, position);
+
+                            // Confirm both objects are the same
+                            Assert.Equal(expected.ToString(), actual.ToString());
+                        }
+                    }
+                }
+            }
+        }
+
+        private static JObject ReadAtPosition(JsonSerializer serializer, Stream stream, long position)
+        {
+            stream.Seek(position, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(new StreamReader(stream)))
+            {
+                jsonReader.CloseInput = false;
+                return (JObject)serializer.Deserialize(jsonReader);
+            }
+        }
+    }
+}

--- a/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
+++ b/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
+{
+    // These classes are a sample object model with JSON representation for DeferredCollectionsTests.
+
+    public enum Level
+    {
+        Error = 0,
+        Warn = 1,
+        Info = 2,
+        Debug = 3,
+        Detail = 4
+    }
+
+    public class LogMessage
+    {
+        public Level Level { get; set; }
+        public DateTime WhenUtc { get; set; }
+        public string Text { get; set; }
+        public string CodeContextID { get; set; }
+
+        public override int GetHashCode()
+        {
+            return this.Level.GetHashCode() ^ this.WhenUtc.GetHashCode() ^ this.Text.GetHashCode() ^ this.CodeContextID.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            LogMessage other = obj as LogMessage;
+            if (other == null) return false;
+
+            return this.Level == other.Level
+                && this.WhenUtc == other.WhenUtc
+                && this.Text == other.Text
+                && this.CodeContextID == other.CodeContextID;
+        }
+    }
+
+    public enum CodeContextType
+    {
+        Application,
+        Binary,
+        Namespace,
+        Class,
+        Method,
+        Property,
+        Field,
+        Line
+    }
+
+    public class CodeContext
+    {
+        public string ParentContextID { get; set; }
+        public string Name { get; set; }
+        public CodeContextType Type { get; set; }
+
+        public override int GetHashCode()
+        {
+            return this.ParentContextID.GetHashCode() ^ this.Name.GetHashCode() ^ this.Type.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            CodeContext other = obj as CodeContext;
+            if (other == null) return false;
+
+            return this.ParentContextID == other.ParentContextID
+                && this.Name == other.Name
+                && this.Type == other.Type;
+        }
+    }
+
+    public class Log
+    {
+        public Guid ID { get; set; }
+        public DateTime StartTimeUtc { get; set; }
+        public string ApplicationContext { get; set; }
+
+        public IList<LogMessage> Messages { get; set; }
+
+        public IDictionary<string, CodeContext> CodeContexts { get; set; }
+    }
+
+    /// <summary>
+    ///  ContractResolver using DeferredList and DeferredDictionary for collections
+    /// </summary>
+    internal class LogModelDeferredContractResolver : DefaultContractResolver
+    {
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            JsonContract contract = base.CreateContract(objectType);
+
+            if(objectType == typeof(IList<LogMessage>))
+            {
+                contract.Converter = new DeferredListConverter<LogMessage>();
+            }
+            else if(objectType == typeof(IDictionary<string, CodeContext>))
+            {
+                contract.Converter = new DeferredDictionaryConverter<CodeContext>();
+            }
+
+            return contract;
+        }
+    }
+
+    internal class LogModelSampleBuilder
+    {
+        public const string SampleLogPath = "CodeCrawler.log.json";
+        public const string SampleOneLinePath = "CodeCrawler.OneLine.log.json";
+        public const string SampleNoCodeContextsPath = "CodeCrawler.NoCodeContexts.log.json";
+        public const string SampleEmptyPath = "CodeCrawler.Empty.log.json";
+
+        private static readonly string[] MessageTexts = { "File Scan starting", "File Scan complete", "Rules \u00A9 reloaded", "File Scan \u16A0 timed out \U00010908" };
+
+        public static Log Build()
+        {
+            return Build(new Random(5), DateTime.UtcNow.AddDays(-1), 500);
+        }
+
+        public static Log Build(Random r, DateTime whenUtc, int messageCount)
+        {
+            Log log = new Log();
+            log.ID = Guid.NewGuid();
+            log.StartTimeUtc = whenUtc;
+            log.ApplicationContext = "CodeCrawler.exe";
+
+            Dictionary<string, CodeContext> contexts = new Dictionary<string, CodeContext>();
+            contexts["app"] = new CodeContext() { Name = "CodeCrawler.exe", Type = CodeContextType.Binary };
+            contexts["scan"] = new CodeContext() { Name = "CodeCrawler.Scanners", Type = CodeContextType.Namespace, ParentContextID = "app" };
+            contexts["file"] = new CodeContext() { Name = "FileScanner", Type = CodeContextType.Class, ParentContextID = "scan" };
+            contexts["run"] = new CodeContext() { Name = "Run()", Type = CodeContextType.Method, ParentContextID = "file" };
+            contexts["load"] = new CodeContext() { Name = "LoadRules()", Type = CodeContextType.Method, ParentContextID = "run" };
+            log.CodeContexts = contexts;
+
+            List<string> codeContextKeys = new List<string>(contexts.Keys);
+
+            log.Messages = new List<LogMessage>();
+            for (int i = 0; i < messageCount; ++i)
+            {
+                whenUtc = whenUtc.AddMilliseconds(r.Next(10));
+
+                LogMessage m = new LogMessage()
+                {
+                    Level = (Level)r.Next(5),
+                    WhenUtc = whenUtc,
+                    Text = MessageTexts[r.Next(MessageTexts.Length)],
+                    CodeContextID = codeContextKeys[r.Next(codeContextKeys.Count)]
+                };
+
+                log.Messages.Add(m);
+            }
+
+            return log;
+        }
+
+        public static void EnsureSamplesBuilt()
+        {
+            Log log = null;
+            JsonSerializer serializer = new JsonSerializer();
+
+            if (!File.Exists(SampleLogPath))
+            {
+                if(log == null) log = Build();
+
+                using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleLogPath))))
+                {
+                    serializer.Formatting = Formatting.Indented;
+                    serializer.Serialize(writer, log);
+                }
+            }
+
+            if(!File.Exists(SampleOneLinePath))
+            {
+                if (log == null) log = Build();
+
+                using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleOneLinePath))))
+                {
+                    serializer.Formatting = Formatting.None;
+                    serializer.Serialize(writer, log);
+                }
+            }
+
+            if (!File.Exists(SampleNoCodeContextsPath))
+            {
+                if (log == null) log = Build();
+
+                log.CodeContexts.Clear();
+                foreach (LogMessage m in log.Messages)
+                {
+                    m.CodeContextID = null;
+                }
+
+                using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleNoCodeContextsPath))))
+                {
+                    serializer.Formatting = Formatting.None;
+                    serializer.Serialize(writer, log);
+                }
+            }
+
+            if (!File.Exists(SampleEmptyPath))
+            {
+                if (log == null) log = Build();
+
+                log.CodeContexts.Clear();
+                log.Messages.Clear();
+
+                using (JsonTextWriter writer = new JsonTextWriter(new StreamWriter(File.OpenWrite(SampleEmptyPath))))
+                {
+                    serializer.Formatting = Formatting.Indented;
+                    serializer.Serialize(writer, log);
+                }
+            }
+        }
+    }
+}

--- a/src/Sarif/Readers/DeferredDictionary.cs
+++ b/src/Sarif/Readers/DeferredDictionary.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  DeferredDictionary is an IDictionary&lt;string, T&gt; which uses JSON.NET
+    ///  to read the dictionary items as they are accessed. It pre-builds the mapping
+    ///  from string to JSON file position for fast retrieval.
+    /// </summary>
+    /// <typeparam name="T">Type of items in Dictionary</typeparam>
+    public class DeferredDictionary<T> : IDictionary<string, T>
+    {
+        private JsonSerializer _jsonSerializer;
+        private Func<Stream> _streamProvider;
+
+        private Stream _stream;
+        private Dictionary<string, long> _itemPositions;
+
+        public DeferredDictionary(JsonSerializer jsonSerializer, JsonPositionedTextReader reader)
+        {
+            _jsonSerializer = jsonSerializer;
+            _streamProvider = reader.StreamProvider;
+            _itemPositions = Build(jsonSerializer, reader);
+        }
+
+        private static Dictionary<string, long> Build(JsonSerializer serializer, JsonPositionedTextReader reader)
+        {
+            Dictionary<string, long> result = new Dictionary<string, long>();
+
+            while(true)
+            {
+                reader.Read();
+                if (reader.TokenType == JsonToken.EndObject) break;
+
+                if (reader.TokenType != JsonToken.PropertyName) throw new InvalidDataException($"@({reader.LineNumber}, {reader.LinePosition}): Expected property name, found {reader.TokenType} \"{reader.Value}\".");
+                string key = (string)reader.Value;
+
+                reader.Read();
+                long position = reader.TokenPosition;
+
+                reader.Skip();
+                result[key] = position;
+            }
+
+            return result;
+        }
+
+        public T this[string key]
+        {
+            get
+            {
+                T value;
+                if (!this.TryGetValue(key, out value)) throw new KeyNotFoundException(key);
+
+                return value;
+            }
+
+            set => throw new NotSupportedException();
+        }
+
+        public ICollection<string> Keys => _itemPositions.Keys;
+
+        public ICollection<T> Values => throw new NotSupportedException("DeferredDictionary is designed not to load all values at once.");
+
+        public int Count => _itemPositions.Count;
+
+        public bool IsReadOnly => true;
+
+        #region Dictionary Mutators [not supported]
+        public void Add(string key, T value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Add(KeyValuePair<string, T> item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(string key)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(KeyValuePair<string, T> item)
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+
+        public bool TryGetValue(string key, out T value)
+        {
+            value = default(T);
+
+            long position;
+            if (!_itemPositions.TryGetValue(key, out position)) return false;
+
+            if (_stream == null) _stream = _streamProvider();
+            _stream.Seek(position, SeekOrigin.Begin);
+
+            using (JsonTextReader reader = new JsonTextReader(new StreamReader(_stream)))
+            {
+                reader.CloseInput = false;
+                value = _jsonSerializer.Deserialize<T>(reader);
+            }
+
+            return true;
+        }
+
+        public bool Contains(KeyValuePair<string, T> item)
+        {
+            T value;
+            if (!this.TryGetValue(item.Key, out value)) return false;
+            return EqualityComparer<T>.Default.Equals(value, item.Value);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _itemPositions.ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<string, T>[] array, int arrayIndex)
+        {
+            if (arrayIndex < 0 || arrayIndex + this.Count > array.Length) throw new ArgumentOutOfRangeException("arrayIndex");
+
+            int index = arrayIndex;
+            foreach(KeyValuePair<string, T> item in this)
+            {
+                array[index++] = item;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
+        {
+            return new JsonDeferredDictionaryEnumerator<T>(this);
+        }
+        
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new JsonDeferredDictionaryEnumerator<T>(this);
+        }
+
+        private class JsonDeferredDictionaryEnumerator<U> : IEnumerator<KeyValuePair<string, U>>
+        {
+            private IEnumerator<string> _keyEnumerator;
+            private IDictionary<string, U> _dictionary;
+
+            public JsonDeferredDictionaryEnumerator(IDictionary<string, U> dictionary)
+            {
+                _keyEnumerator = dictionary.Keys.GetEnumerator();
+                _dictionary = dictionary;
+            }
+
+            object IEnumerator.Current => Current;
+
+            public KeyValuePair<string, U> Current
+            {
+                get
+                {
+                    string key = _keyEnumerator.Current;
+                    return new KeyValuePair<string, U>(key, _dictionary[key]);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_keyEnumerator != null)
+                {
+                    _keyEnumerator.Dispose();
+                    _keyEnumerator = null;
+                }
+            }
+
+            public bool MoveNext()
+            {
+                return _keyEnumerator.MoveNext();
+            }
+
+            public void Reset()
+            {
+                _keyEnumerator.Reset();
+            }
+        }
+    }
+}

--- a/src/Sarif/Readers/DeferredDictionary.cs
+++ b/src/Sarif/Readers/DeferredDictionary.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         {
             _jsonSerializer = jsonSerializer;
             _streamProvider = reader.StreamProvider;
-
             _start = reader.TokenPosition;
 
             // We have the JsonTextReader, which must scan to after the collection to resume building the outer object

--- a/src/Sarif/Readers/DeferredDictionaryConverter.cs
+++ b/src/Sarif/Readers/DeferredDictionaryConverter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  DeferredDictionaryConverter is a JsonConverter which allows reading IDictionary&lt;string, T&gt;
+    ///  items only at enumeration time, saving the memory cost of keeping every object around.
+    ///  
+    ///  The set of keys and the file position in the JSON stream of the values is pre-loaded and kept around
+    ///  for fast retrieval.
+    /// </summary>
+    /// <typeparam name="T">Type of items in the Dictionary</typeparam>
+    public class DeferredDictionaryConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IDictionary<string, T>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JsonPositionedTextReader r = reader as JsonPositionedTextReader;
+            if (r == null) throw new InvalidOperationException($"DeferredDictionaryConverter requires a JsonPositionedTextReader be used for deserialization.");
+
+            return new DeferredDictionary<T>(serializer, r);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // Default Serialization is fine
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/Sarif/Readers/DeferredList.cs
+++ b/src/Sarif/Readers/DeferredList.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  DeferredList is an IList&lt;T&gt; which wraps a specific position in a JSON stream.
+    ///  It uses JSON.NET to read the items from the stream when they are enumerated in the list,
+    ///  saving the memory cost of keeping them around.
+    ///  
+    ///  DeferredList supports enumerable and in-order access only.
+    /// </summary>
+    /// <typeparam name="T">Type of items in list</typeparam>
+    public class DeferredList<T> : IList<T>
+    {
+        private JsonSerializer _jsonSerializer;
+        private Func<Stream> _streamProvider;
+        private long _start;
+
+        private IEnumerator<T> _currentEnumerator;
+        private int _currentIndex;
+
+        public int Count { get; private set; }
+        public bool IsReadOnly => true;
+
+        public DeferredList(JsonSerializer jsonSerializer, JsonPositionedTextReader reader)
+        {
+            _jsonSerializer = jsonSerializer;
+            _streamProvider = reader.StreamProvider;
+
+            _start = reader.TokenPosition;
+            int count = 0;
+
+            while (true)
+            {
+                reader.Read();
+                if (reader.TokenType == JsonToken.EndArray) break;
+
+                reader.Skip();
+                count++;
+            }
+
+            Count = count;
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if(index == 0)
+                {
+                    if (_currentEnumerator != null) _currentEnumerator.Dispose();
+
+                    _currentIndex = 0;
+                    _currentEnumerator = this.GetEnumerator();
+                }
+
+                if(index != _currentIndex)
+                {
+                    throw new NotSupportedException("DeferredList only allows enumerating items in order.");
+                }
+
+                if (!_currentEnumerator.MoveNext()) throw new IndexOutOfRangeException("index");
+                _currentIndex++;
+                return _currentEnumerator.Current;
+            }
+
+            set => throw new NotSupportedException();
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            if (arrayIndex < 0 || arrayIndex + this.Count > array.Length) throw new ArgumentOutOfRangeException("arrayIndex");
+
+            int index = arrayIndex;
+            foreach(T item in this)
+            {
+                array[index++] = item;
+            }
+        }
+
+        #region List Search [not supported]
+        public bool Contains(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public int IndexOf(T item)
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+
+        #region List Mutators [not supported]
+        public void Add(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Insert(int index, T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+        #endregion
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new JsonDeferredListEnumerator<T>(_jsonSerializer, _streamProvider, _start);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new JsonDeferredListEnumerator<T>(_jsonSerializer, _streamProvider, _start);
+        }
+
+        private class JsonDeferredListEnumerator<U> : IEnumerator<U>
+        {
+            private JsonSerializer _jsonSerializer;
+            private Func<Stream> _streamProvider;
+            private long _start;
+
+            private JsonTextReader _jsonTextReader;
+            private Stream _stream;
+
+            public JsonDeferredListEnumerator(JsonSerializer jsonSerializer, Func<Stream> streamProvider, long start)
+            {
+                _jsonSerializer = jsonSerializer;
+                _streamProvider = streamProvider;
+                _start = start;
+
+                Reset();
+            }
+
+            public U Current { get; private set; }
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                if (_stream != null)
+                {
+                    _stream.Dispose();
+                    _stream = null;
+                    _jsonTextReader = null;
+                }
+            }
+
+            public bool MoveNext()
+            {
+                if (_jsonTextReader.TokenType == JsonToken.EndArray) return false;
+
+                // Read the next item
+                Current = _jsonSerializer.Deserialize<U>(_jsonTextReader);
+
+                // Read EndObject, next is StartObject of next member
+                _jsonTextReader.Read();
+
+                return true;
+            }
+
+            public void Reset()
+            {
+                Dispose();
+
+                // Open a new Stream
+                _stream = _streamProvider();
+
+                // Seek to the array start
+                _stream.Seek(_start, SeekOrigin.Begin);
+
+                // Build a JsonTextReader
+                _jsonTextReader = new JsonTextReader(new StreamReader(_stream));
+
+                // StartArray
+                _jsonTextReader.Read();
+
+                // StartObject of first member
+                _jsonTextReader.Read();
+            }
+        }
+    }
+}

--- a/src/Sarif/Readers/DeferredListConverter.cs
+++ b/src/Sarif/Readers/DeferredListConverter.cs
@@ -9,6 +9,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
     /// <summary>
     ///  DeferredListConverter is a JsonConverter which allows reading a List&lt;T&gt;
     ///  only at enumeration time, saving the memory cost of keeping every object around.
+    ///  
+    ///  The position of each item is saved on the first random access, so that later use
+    ///  of List[index] is fast.
     /// </summary>
     /// <typeparam name="T">Type of items in the List</typeparam>
     public class DeferredListConverter<T> : JsonConverter

--- a/src/Sarif/Readers/DeferredListConverter.cs
+++ b/src/Sarif/Readers/DeferredListConverter.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  DeferredListConverter is a JsonConverter which allows reading a List&lt;T&gt;
+    ///  only at enumeration time, saving the memory cost of keeping every object around.
+    /// </summary>
+    /// <typeparam name="T">Type of items in the List</typeparam>
+    public class DeferredListConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IList<T>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JsonPositionedTextReader r = reader as JsonPositionedTextReader;
+            if (r == null) throw new InvalidOperationException($"DeferredListConverter requires a JsonPositionedTextReader be used for deserialization.");
+
+            return new DeferredList<T>(serializer, r);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // Default Serialization is fine
+            serializer.Serialize(writer, value);
+        }
+    }
+}

--- a/src/Sarif/Readers/JsonPositionedTextReader.cs
+++ b/src/Sarif/Readers/JsonPositionedTextReader.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  JsonPositionedTextReader is a JsonTextReader which exposes TokenPosition(),
+    ///  the byte offset in the stream where the current token begins. It is used to
+    ///  enable deferred collections, which look like other collections but are deserialized
+    ///  only when enumerated, saving memory.
+    /// </summary>
+    public class JsonPositionedTextReader : JsonTextReader
+    {
+        private LineMappingStreamReader StreamReader { get; set; }
+        private int LastReadLineNumber { get; set; }
+        private int LastReadLinePosition { get; set; }
+
+        public Func<Stream> StreamProvider { get; private set; }
+
+        public JsonPositionedTextReader(string filePath) : this(() => File.OpenRead(filePath))
+        { }
+
+        public JsonPositionedTextReader(Func<Stream> streamProvider) : this(streamProvider, new LineMappingStreamReader(streamProvider()))
+        { }
+
+        internal JsonPositionedTextReader(Func<Stream> streamProvider, LineMappingStreamReader reader) : base(reader)
+        {
+            this.StreamProvider = streamProvider;
+            this.StreamReader = reader;
+        }
+
+        /// <summary>
+        ///  Return the byte offset of the current token in the file.
+        /// </summary>
+        /// <remarks>
+        ///  This must be derived by mapping the (Line, Position) the JsonTextReader returns to an absolute offset.
+        ///  The offset isn't exposed, and StreamReader and JsonTextReader both buffer, so StreamReader.BaseStream.Position is not correct.
+        ///  </remarks>
+        public long TokenPosition => this.StreamReader.LineAndCharToOffset(this.LineNumber, this.LinePosition);
+    }
+}

--- a/src/Sarif/Readers/LineMappingStreamReader.cs
+++ b/src/Sarif/Readers/LineMappingStreamReader.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  LineMappingStreamReader is a StreamReader which additionally tracks the byte offsets of each line start
+    ///  in the part of the file currently read. This allows it to map a line and char back to a byte offset
+    ///  to allow consumers to seek back to the position later.
+    /// </summary>
+    internal class LineMappingStreamReader : StreamReader
+    {
+        // Track bytes read before the current read (to return absolute line offsets) and in the current read
+        private long _bytesReadPreviously;
+        private int _bytesRead;
+
+        // Keep the char index and byte offset of the start of each line in the currently read buffer (byteOffset + _bytesReadPreviously => LineOffset)
+        private int[] _lineStartIndices;
+        private int[] _lineStartByteOffsets;
+        private long _lineCount;
+
+        // Track the first line number and byte offset because it can start before the buffer range
+        private long _firstLineNumber;
+        private int _firstLineCharsBeforeBuffer;
+        private int _lastLineChars;
+
+        // Keep a copy of the last read buffer and the valid range of it so we can count bytes within the requested line.
+        private char[] _buffer;
+        private int _bufferIndex;
+        private int _bufferLength;
+
+
+        public LineMappingStreamReader(Stream stream) : base(stream)
+        {
+            // (1, 1) is the 0th byte, so the line number before the read is 1 and there is one character (the newline before the first line) before the first read.
+            _firstLineNumber = 1;
+            _firstLineCharsBeforeBuffer = 1;
+        }
+
+        public long LineAndCharToOffset(int line, int charInLine)
+        {
+            if (line < _firstLineNumber || line > _firstLineNumber + _lineCount) throw new ArgumentOutOfRangeException($"Line must be in the range of lines last read, ({_firstLineNumber} - {_firstLineNumber + _lineCount}). It was {line}.");
+
+            int bytesInLine;
+
+            if (line == _firstLineNumber)
+            {
+                if (charInLine < _firstLineCharsBeforeBuffer || charInLine - _firstLineCharsBeforeBuffer > _bufferLength) throw new ArgumentOutOfRangeException($"Line {line} chars ({_firstLineCharsBeforeBuffer} to {_firstLineCharsBeforeBuffer + _bufferLength} in range. {charInLine} requested was out of range.");
+
+                // For the first line, the offset is total bytes read plus byte count for the characters in the line which are in the current buffer.
+                int charsInBufferForLine = charInLine - _firstLineCharsBeforeBuffer;
+                bytesInLine = this.CurrentEncoding.GetByteCount(_buffer, _bufferIndex, charsInBufferForLine);
+                return _bytesReadPreviously + bytesInLine;
+            }
+
+            // Find the newline starting the line
+            long newlineByteOffset = _bytesReadPreviously + _lineStartByteOffsets[line - (_firstLineNumber + 1)];
+            int newlineCharIndex = _lineStartIndices[line - (_firstLineNumber + 1)];
+
+            // Get the byte count for the characters in the line
+            if (newlineCharIndex + charInLine > _bufferLength)
+            {
+                throw new ArgumentOutOfRangeException($"Line {line} up to char {charInLine} isn't available in buffer. Only {_bufferLength - newlineCharIndex} characters available.");
+            }
+            bytesInLine = this.CurrentEncoding.GetByteCount(_buffer, _bufferIndex + newlineCharIndex, charInLine);
+
+            // Return the byte offset to this specific character
+            long position = newlineByteOffset + bytesInLine;
+            return position;
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            // Track the first line number and char total before the current buffer
+            if (_lineCount > 0)
+            {
+                _firstLineNumber += _lineCount;
+                _firstLineCharsBeforeBuffer = 0;
+            }
+
+            _firstLineCharsBeforeBuffer += _lastLineChars;
+
+            // Maintain total byte count read
+            _bytesReadPreviously += _bytesRead;
+
+            // Read the new buffer
+            int charsRead = base.Read(buffer, index, count);
+
+            // Copy buffer so we can map char in line to byte count (real buffer can be shifted by reader, invalidating indices)
+            if (_buffer == null || _buffer.Length < buffer.Length) _buffer = new char[buffer.Length];
+            Buffer.BlockCopy(buffer, 2 * index, _buffer, 0, 2 * charsRead);
+            _bufferIndex = 0;
+            _bufferLength = charsRead;
+
+            // Ensure space to hold start of each line
+            if (_lineStartByteOffsets == null || _lineStartByteOffsets.Length < charsRead) _lineStartByteOffsets = new int[charsRead];
+            if (_lineStartIndices == null || _lineStartIndices.Length < charsRead) _lineStartIndices = new int[charsRead];
+            _lineCount = 0;
+
+            // Find each newline byte offset relative to current read
+            int bytesRead = 0;
+            int lastEnd = index;
+
+            for (int i = index; i < index + charsRead; ++i)
+            {
+                if (buffer[i] == '\n')
+                {
+                    // Count bytes up to this line
+                    bytesRead += this.CurrentEncoding.GetByteCount(buffer, lastEnd, i - lastEnd);
+                    lastEnd = i;
+
+                    // Store the char index and byte offset of the newline for this line
+                    _lineStartIndices[_lineCount] = i - index;
+                    _lineStartByteOffsets[_lineCount] = bytesRead;
+                    _lineCount++;
+                }
+            }
+
+            // Count bytes in last line until end of buffer
+            if (lastEnd < index + charsRead)
+            {
+                bytesRead += this.CurrentEncoding.GetByteCount(buffer, lastEnd, (index + charsRead) - lastEnd);
+            }
+
+            // Count chars in the last line in this buffer
+            _lastLineChars = (index + charsRead) - lastEnd;
+
+            _bytesRead = bytesRead;
+            return charsRead;
+        }
+    }
+}

--- a/src/Sarif/Readers/LineMappingStreamReader.cs
+++ b/src/Sarif/Readers/LineMappingStreamReader.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
         public long LineAndCharToOffset(int line, int charInLine)
         {
+            if (line == 0 && charInLine == 0) return 0;
             if (line < _firstLineNumber || line > _firstLineNumber + _lineCount) throw new ArgumentOutOfRangeException($"Line must be in the range of lines last read, ({_firstLineNumber} - {_firstLineNumber + _lineCount}). It was {line}.");
 
             int bytesInLine;

--- a/src/Sarif/Readers/SarifDeferredContractResolver.cs
+++ b/src/Sarif/Readers/SarifDeferredContractResolver.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.CodeAnalysis.Sarif.Readers;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.CodeAnalysis.Sarif.Readers

--- a/src/Sarif/Readers/SarifDeferredContractResolver.cs
+++ b/src/Sarif/Readers/SarifDeferredContractResolver.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.CodeAnalysis.Sarif.Readers
+{
+    /// <summary>
+    ///  SarifDeferredContractResolver is a JSON.NET contract resolver for the SARIF file format
+    ///  which uses deferred collection classes for the large collections in the file so that the
+    ///  full object graph doesn't have to be kept in memory.
+    ///  
+    ///  JSON.NET still must parse the whole file, and must parse the deferred collections again
+    ///  when they are enumerated, so load times are slower.
+    /// </summary>
+    public class SarifDeferredContractResolver : SarifContractResolver
+    {
+        public static new readonly SarifDeferredContractResolver Instance = new SarifDeferredContractResolver();
+
+        private static readonly DeferredListConverter<Result> ResultConverterInstance = new DeferredListConverter<Result>();
+        private static readonly DeferredDictionaryConverter<FileData> FilesConverterInstance = new DeferredDictionaryConverter<FileData>();
+
+        protected override JsonContract CreateContract(Type type)
+        {
+            JsonContract contract = base.CreateContract(type);
+
+            if (type == typeof(IList<Result>))
+            {
+                contract.Converter = ResultConverterInstance;
+                return contract;
+            }
+            else if (type == typeof(IDictionary<string, FileData>))
+            {
+                contract.Converter = FilesConverterInstance;
+                return contract;
+            }
+
+            return contract;
+        }
+    }
+}

--- a/src/SarifDeferredSample/App.config
+++ b/src/SarifDeferredSample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -15,9 +15,9 @@ namespace SarifDeferredSample
 
         private static void Main(string[] args)
         {
-            bool deferred = true;
-
             string filePath = args[0];
+            bool deferred = bool.Parse(args[1]);
+            
             SarifLog log = null;
 
             Console.WriteLine($"Loading {filePath}{(deferred ? " (deferred)" : "")}...");
@@ -32,7 +32,7 @@ namespace SarifDeferredSample
                     log = serializer.Deserialize<SarifLog>(reader);
                 }
 
-                return $"Loaded {filePath} ({new FileInfo(filePath).Length / BytesPerMB} MB)";
+                return $"Loaded {filePath} ({(new FileInfo(filePath).Length / BytesPerMB):n1} MB)";
             });
 
             Run run = log.Runs[0];
@@ -47,14 +47,14 @@ namespace SarifDeferredSample
                 }
 
                 // Slower: Count and indexer
-                //messageCount = run.Results.Count;
+                //int messageCount = run.Results.Count;
                 //for (int i = 0; i < messageCount; ++i)
                 //{
                 //    Result result = run.Results[i];
                 //    messageLengthTotal += result?.Message?.Text?.Length ?? 0;
                 //}
 
-                return $"Enumerated {run.Results.Count:n0} Results message total {messageLengthTotal:n0}b";
+                return $"Enumerated {run.Results.Count:n0} Results message total {messageLengthTotal / BytesPerMB:n0}MB";
             });
 
             Measure(() =>
@@ -81,7 +81,7 @@ namespace SarifDeferredSample
                     //}
                 } 
 
-                return $"Enumerated {fileCount:n0} Files, URI total {uriLengthTotal:n0}b.";
+                return $"Enumerated {fileCount:n0} Files, URI total {uriLengthTotal / BytesPerMB:n0}MB.";
             });
 
             GC.KeepAlive(log);
@@ -97,7 +97,7 @@ namespace SarifDeferredSample
             w.Stop();
             long ramAfter = GC.GetTotalMemory(true);
 
-            Console.WriteLine($"{message} in {w.ElapsedMilliseconds:n0}ms using {(ramAfter - ramBefore) / (BytesPerMB):n3}MB RAM.");
+            Console.WriteLine($"{message} in {w.ElapsedMilliseconds:n0}ms and {(ramAfter - ramBefore) / (BytesPerMB):n1}MB RAM.");
         }
 
         private static string SeekAndRead(string filePath, long position)

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -55,19 +55,19 @@ namespace SarifDeferredSample
 
                 if (run.Files != null)
                 {
-                    fileCount = run.Files.Count;
-
-                    //foreach (var item in run.Files)
-                    //{
-                    //    FileData file = item.Value;
-                    //    uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
-                    //}
-
-                    foreach (var key in run.Files.Keys)
+                    foreach (var item in run.Files)
                     {
-                        FileData file = run.Files[key];
+                        FileData file = item.Value;
                         uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
+                        fileCount++;
                     }
+
+                    //foreach (var key in run.Files.Keys)
+                    //{
+                    //    FileData file = run.Files[key];
+                    //    uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
+                    //    fileCount++;
+                    //}
                 } 
 
                 return $"Enumerated {fileCount:n0} Files, URI total {uriLengthTotal:n0}b.";

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -40,10 +40,19 @@ namespace SarifDeferredSample
             {
                 int messageLengthTotal = 0;
 
+                // Fastest: Enumerate
                 foreach (Result result in run.Results)
                 {
                     messageLengthTotal += result?.Message?.Text?.Length ?? 0;
                 }
+
+                // Slower: Count and indexer
+                //messageCount = run.Results.Count;
+                //for (int i = 0; i < messageCount; ++i)
+                //{
+                //    Result result = run.Results[i];
+                //    messageLengthTotal += result?.Message?.Text?.Length ?? 0;
+                //}
 
                 return $"Enumerated {run.Results.Count:n0} Results message total {messageLengthTotal:n0}b";
             });
@@ -55,6 +64,7 @@ namespace SarifDeferredSample
 
                 if (run.Files != null)
                 {
+                    // Fastest: Enumerate
                     foreach (var item in run.Files)
                     {
                         FileData file = item.Value;
@@ -62,6 +72,7 @@ namespace SarifDeferredSample
                         fileCount++;
                     }
 
+                    // Slower: Keys and indexer
                     //foreach (var key in run.Files.Keys)
                     //{
                     //    FileData file = run.Files[key];

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -57,9 +57,15 @@ namespace SarifDeferredSample
                 {
                     fileCount = run.Files.Count;
 
-                    foreach (string fileKey in run.Files.Keys)
+                    //foreach (var item in run.Files)
+                    //{
+                    //    FileData file = item.Value;
+                    //    uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
+                    //}
+
+                    foreach (var key in run.Files.Keys)
                     {
-                        FileData file = run.Files[fileKey];
+                        FileData file = run.Files[key];
                         uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
                     }
                 } 

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -15,8 +15,8 @@ namespace SarifDeferredSample
 
         private static void Main(string[] args)
         {
-            string filePath = args[0];
-            bool deferred = bool.Parse(args[1]);
+            bool deferred = bool.Parse(args[0]);
+            string filePath = args[1];
             
             SarifLog log = null;
 

--- a/src/SarifDeferredSample/Program.cs
+++ b/src/SarifDeferredSample/Program.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+using Newtonsoft.Json;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace SarifDeferredSample
+{
+    // NOTE: Not being submitted. This is a sample of usage of the Deferred Collections.
+
+    internal class Program
+    {
+        private const float BytesPerMB = (float)(1024 * 1024);
+
+        private static void Main(string[] args)
+        {
+            bool deferred = true;
+
+            string filePath = args[0];
+            SarifLog log = null;
+
+            Console.WriteLine($"Loading {filePath}{(deferred ? " (deferred)" : "")}...");
+
+            Measure(() =>
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.ContractResolver = (deferred ? SarifDeferredContractResolver.Instance : SarifContractResolver.Instance);
+
+                using (JsonTextReader reader = (deferred ? new JsonPositionedTextReader(filePath) : new JsonTextReader(new StreamReader(filePath))))
+                {
+                    log = serializer.Deserialize<SarifLog>(reader);
+                }
+
+                return $"Loaded {filePath} ({new FileInfo(filePath).Length / BytesPerMB} MB)";
+            });
+
+            Run run = log.Runs[0];
+            Measure(() =>
+            {
+                int messageLengthTotal = 0;
+
+                foreach (Result result in run.Results)
+                {
+                    messageLengthTotal += result?.Message?.Text?.Length ?? 0;
+                }
+
+                return $"Enumerated {run.Results.Count:n0} Results message total {messageLengthTotal:n0}b";
+            });
+
+            Measure(() =>
+            {
+                int fileCount = 0;
+                int uriLengthTotal = 0;
+
+                if (run.Files != null)
+                {
+                    fileCount = run.Files.Count;
+
+                    foreach (string fileKey in run.Files.Keys)
+                    {
+                        FileData file = run.Files[fileKey];
+                        uriLengthTotal += file?.FileLocation?.Uri?.OriginalString?.Length ?? 0;
+                    }
+                } 
+
+                return $"Enumerated {fileCount:n0} Files, URI total {uriLengthTotal:n0}b.";
+            });
+
+            GC.KeepAlive(log);
+        }
+
+        private static void Measure(Func<string> action)
+        {
+            long ramBefore = GC.GetTotalMemory(true);
+            Stopwatch w = Stopwatch.StartNew();
+
+            string message = action();
+
+            w.Stop();
+            long ramAfter = GC.GetTotalMemory(true);
+
+            Console.WriteLine($"{message} in {w.ElapsedMilliseconds:n0}ms using {(ramAfter - ramBefore) / (BytesPerMB):n3}MB RAM.");
+        }
+
+        private static string SeekAndRead(string filePath, long position)
+        {
+            char[] buffer = new char[500];
+            using (StreamReader reader = new StreamReader(filePath))
+            {
+                reader.BaseStream.Seek(position, SeekOrigin.Begin);
+                int length = reader.Read(buffer, 0, buffer.Length);
+                return new string(buffer, 0, length);
+            }
+        }
+    }
+}

--- a/src/SarifDeferredSample/Properties/AssemblyInfo.cs
+++ b/src/SarifDeferredSample/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SarifDeferredSample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SarifDeferredSample")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ebe491d1-790d-43ca-899b-fcd2fdd21823")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/SarifDeferredSample/SarifDeferredSample.csproj
+++ b/src/SarifDeferredSample/SarifDeferredSample.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EBE491D1-790D-43CA-899B-FCD2FDD21823}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SarifDeferredSample</RootNamespace>
+    <AssemblyName>SarifDeferredSample</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Sarif\Sarif.csproj">
+      <Project>{47010491-7fc3-4063-94aa-833a99cc9352}</Project>
+      <Name>Sarif</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/SarifDeferredSample/packages.config
+++ b/src/SarifDeferredSample/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I'd like feedback on the design, usage, and design compromises of the reader.

See the executable (won't be submitted) for sample usage. Essentially deferred reading is transparent to the consumer other than changing the ContractResolver and JsonTextReader types.

It uses much less RAM for Results, and somewhat less for files depending on how big the FileData objects are relative to the URIs. 

You can only enumerate the results in order, and you can currently randomly access any items in the Files Dictionary.

The design is generic; any JSON array can be deferred via DeferredList<T> and any JSON object (string to object map) can be deferred via DeferredDictionary<T>.

Key questions:
  - Does this user experience look reasonable?
  - Should this be submitted to Sarif.SDK? If not, where?
  - Do the usage compromises seem ok? (enumerate lists in order only)
  - How much do we want to constrain RAM vs. maintain performance? (will bring up in standup)

Thanks!