### PR TITLE
Fix #1110: "Express validator message logical locations in JavaScript rather than JSON Pointer"

### DIFF
--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
     {
         private class TestCase
         {
+            internal string Name;
             internal string JsonPointer;
             internal string ExpectedJavaScript;
         };
@@ -23,18 +24,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
             {
                 new TestCase
                 {
-                    JsonPointer = "/x",
-                    ExpectedJavaScript = "x"
+                    Name = "Single property",
+                    JsonPointer = "/version",
+                    ExpectedJavaScript = "version"
                 },
                 new TestCase
                 {
-                    JsonPointer = "/x/y",
-                    ExpectedJavaScript = "x.y"
+                    Name = "Nested properties",
+                    JsonPointer = "/properties/tags",
+                    ExpectedJavaScript = "properties.tags"
                 },
                 new TestCase
                 {
-                    JsonPointer = "/x/0/y/1",
-                    ExpectedJavaScript = "x[0].y[1]"
+                    Name = "Array indices",
+                    JsonPointer = "/runs/0/results/1",
+                    ExpectedJavaScript = "runs[0].results[1]"
+                },
+                new TestCase
+                {
+                    Name = "Non-identifier property name",
+                    JsonPointer = "/runs/0/files/example.c/mimeType",
+                    ExpectedJavaScript = "runs[0].files['example.c'].mimeType"
                 }
             };
 
@@ -44,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
                 string actualJavaScript = SarifValidationSkimmerBase.JsonPointerToJavaScript(testCase.JsonPointer);
                 if (string.CompareOrdinal(actualJavaScript, testCase.ExpectedJavaScript) != 0)
                 {
-                    sb.AppendLine($"Input: \"{testCase.JsonPointer}\", Expected: \"{testCase.ExpectedJavaScript}\", Actual: \"{actualJavaScript}\".");
+                    sb.AppendLine($"\nFAILED test case: {testCase.Name}:\n    Input: \"{testCase.JsonPointer}\"\n    Expected: \"{testCase.ExpectedJavaScript}\"\n    Actual: \"{actualJavaScript}\".");
                 }
             }
 

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -45,6 +45,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
                     Name = "Non-identifier property name",
                     JsonPointer = "/runs/0/files/example.c/mimeType",
                     ExpectedJavaScript = "runs[0].files['example.c'].mimeType"
+                },
+                new TestCase
+                {
+                    Name = "Non-identifier property name with escapes",
+                    JsonPointer = "/runs/0/files/file:~1~1~1c:~1src/mimeType",
+                    ExpectedJavaScript = "runs[0].files['file:///c:/src'].mimeType"
                 }
             };
 

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -55,8 +55,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
                 new TestCase
                 {
                     Name = "Property names with non-ASCII characters",
-                    JsonPointer = "/A/madárak/szépek",
-                    ExpectedJavaScript = "A.madárak.szépek"
+                    JsonPointer = "/A/madár/szép",       // Hungarian: "The bird is pretty."
+                    ExpectedJavaScript = "A.madár.szép"
                 }
             };
 

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif.Multitool.Rules;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
+{
+    public class SarifValidationSkimmerBaseTests
+    {
+        private class TestCase
+        {
+            internal string JsonPointer;
+            internal string ExpectedJavaScript;
+        };
+
+        [Fact]
+        public void SarifValidationSkimmerBase_JsonPointerToJavaScript_ProducesExpectedResults()
+        {
+            var testCases = new TestCase[]
+            {
+                new TestCase
+                {
+                    JsonPointer = "x",
+                    ExpectedJavaScript = "x"
+                }
+            };
+
+            var sb = new StringBuilder();
+            foreach (TestCase testCase in testCases)
+            {
+                string actualJavaScript = SarifValidationSkimmerBase.JsonPointerToJavaScript(testCase.JsonPointer);
+                if (string.CompareOrdinal(actualJavaScript, testCase.ExpectedJavaScript) != 0)
+                {
+                    sb.AppendLine($"Input: \"{testCase.JsonPointer}\", Expected: \"{testCase.ExpectedJavaScript}\", Actual: \"{actualJavaScript}\".");
+                }
+            }
+
+            string errorMessage = sb.ToString();
+            errorMessage.Should().BeEmpty();
+        }
+    }
+}

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -51,6 +51,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
                     Name = "Non-identifier property name with escapes",
                     JsonPointer = "/runs/0/files/file:~1~1~1c:~1src/mimeType",
                     ExpectedJavaScript = "runs[0].files['file:///c:/src'].mimeType"
+                },
+                new TestCase
+                {
+                    Name = "Property names with non-ASCII characters",
+                    JsonPointer = "/A/madárak/szépek",
+                    ExpectedJavaScript = "A.madárak.szépek"
                 }
             };
 

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -23,8 +23,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
             {
                 new TestCase
                 {
-                    JsonPointer = "x",
+                    JsonPointer = "/x",
                     ExpectedJavaScript = "x"
+                },
+                new TestCase
+                {
+                    JsonPointer = "/x/y",
+                    ExpectedJavaScript = "x.y"
                 }
             };
 

--- a/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
+++ b/src/Sarif.Multitool.UnitTests/Rules/SarifValidationSkimmerBaseTests.cs
@@ -30,6 +30,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.UnitTests.Rules
                 {
                     JsonPointer = "/x/y",
                     ExpectedJavaScript = "x.y"
+                },
+                new TestCase
+                {
+                    JsonPointer = "/x/0/y/1",
+                    ExpectedJavaScript = "x[0].y[1]"
                 }
             };
 

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Resources;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.Json.Pointer;
@@ -160,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         // For example, "/runs/0/id/instanceId" => "runs[0].id.instanceId".
         internal static string JsonPointerToJavaScript(string pointerString)
         {
-            var sb = new System.Text.StringBuilder();
+            var sb = new StringBuilder();
             var pointer = new JsonPointer(pointerString);
             foreach (string token in pointer.ReferenceTokens)
             {

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -163,8 +163,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             var pointer = new JsonPointer(pointerString);
             foreach (string token in pointer.ReferenceTokens)
             {
-                if (sb.Length > 0) { sb.Append('.'); }
-                sb.Append(token);
+                if (int.TryParse(token, out int index))
+                {
+                    sb.Append('[' + token + ']');
+                }
+                else
+                {
+                    if (sb.Length > 0) { sb.Append('.'); }
+                    sb.Append(token);
+                }
             }
 
             return sb.ToString();

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             return sb.ToString();
         }
 
-        private static readonly string s_javaScriptIdentifierPattern = "^[$_a-zA-Z][$_a-zA-Z0-9]*$";
+        private static readonly string s_javaScriptIdentifierPattern = @"^[$_\p{L}][$_\p{L}0-9]*$";
         private static readonly Regex s_javaScriptIdentifierRegex = new Regex(s_javaScriptIdentifierPattern, RegexOptions.Compiled);
 
         private static bool TokenIsJavascriptIdentifier(string token)

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -157,9 +157,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         // Convert a string in JSON Pointer format to JavaScript syntax.
         // For example, "/runs/0/id/instanceId" => runs[0].id.instanceId.
-        internal static string JsonPointerToJavaScript(string jPointer)
+        internal static string JsonPointerToJavaScript(string pointerString)
         {
-            return jPointer;
+            var sb = new System.Text.StringBuilder();
+            var pointer = new JsonPointer(pointerString);
+            foreach (string token in pointer.ReferenceTokens)
+            {
+                if (sb.Length > 0) { sb.Append('.'); }
+                sb.Append(token);
+            }
+
+            return sb.ToString();
         }
 
         private void Visit(SarifLog log, string logPointer)

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         }
 
         // Convert a string in JSON Pointer format to JavaScript syntax.
-        // For example, "/runs/0/id/instanceId" => runs[0].id.instanceId.
+        // For example, "/runs/0/id/instanceId" => "runs[0].id.instanceId".
         internal static string JsonPointerToJavaScript(string pointerString)
         {
             var sb = new System.Text.StringBuilder();

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             // All messages start with "In {file}, at {jPointer}, ...". Prepend the jPointer to the args.
             string[] argsWithPointer = new string[args.Length + 1];
             Array.Copy(args, 0, argsWithPointer, 1, args.Length);
-            argsWithPointer[0] = jPointer;
+            argsWithPointer[0] = JsonPointerToJavaScript(jPointer);
 
             Context.Logger.Log(this,
                 RuleUtilities.BuildResult(DefaultLevel, Context, region, formatId, argsWithPointer));
@@ -153,6 +153,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected virtual void Analyze(VersionControlDetails versionControlDetails, string versionControlDetailsPointer)
         {
+        }
+
+        // Convert a string in JSON Pointer format to JavaScript syntax.
+        // For example, "/runs/0/id/instanceId" => runs[0].id.instanceId.
+        internal static string JsonPointerToJavaScript(string jPointer)
+        {
+            return jPointer;
         }
 
         private void Visit(SarifLog log, string logPointer)

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                     }
                     else
                     {
-                        sb.Append("['" + token + "']");
+                        sb.Append("['" + token.UnescapeJsonPointer() + "']");
                     }
                 }
             }

--- a/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
+++ b/src/Sarif.Multitool/Rules/SarifValidationSkimmerBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Resources;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.Json.Pointer;
 using Newtonsoft.Json;
@@ -169,12 +170,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 }
                 else
                 {
-                    if (sb.Length > 0) { sb.Append('.'); }
-                    sb.Append(token);
+                    if (TokenIsJavascriptIdentifier(token))
+                    {
+                        if (sb.Length > 0) { sb.Append('.'); }
+                        sb.Append(token);
+                    }
+                    else
+                    {
+                        sb.Append("['" + token + "']");
+                    }
                 }
             }
 
             return sb.ToString();
+        }
+
+        private static readonly string s_javaScriptIdentifierPattern = "^[$_a-zA-Z][$_a-zA-Z0-9]*$";
+        private static readonly Regex s_javaScriptIdentifierRegex = new Regex(s_javaScriptIdentifierPattern, RegexOptions.Compiled);
+
+        private static bool TokenIsJavascriptIdentifier(string token)
+        {
+            return s_javaScriptIdentifierRegex.IsMatch(token);
         }
 
         private void Visit(SarifLog log, string logPointer)


### PR DESCRIPTION
The error messages now look like this:
```
C:\test\SarifSdk.sarif(82,49): warning SARIF1008: runs[11].results[110].relatedLocations[5].message.text:
The message "CounterSample.timeStamp" does not end with a period.
```
... instead of like this:
```
C:\test\SarifSdk.sarif(82,49): warning SARIF1008: /runs/11/results/110/relatedLocations/5/message/text:
The message "CounterSample.timeStamp" does not end with a period.
```