### PR TITLE
Resolve tail issues from PR #1114

### DIFF
--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             }
 
             // Potentially temporary -- we persist the "originally found date" forward, and this sets it.
-            if (CurrentResult.OriginalRun.Invocations != null && CurrentResult.OriginalRun.Invocations.Any() && CurrentResult.OriginalRun.Invocations[0].StartTimeUtc != null)
+            if (CurrentResult.OriginalRun?.Invocations?.Any() == true && CurrentResult.OriginalRun.Invocations[0].StartTimeUtc != null)
             {
                 ResultMatchingProperties.Add(MatchedResults.MatchResultMetadata_FoundDateName, CurrentResult.OriginalRun.Invocations[0].StartTimeUtc);
             }

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -1429,19 +1429,7 @@
 
         "parameters": {
           "description": "Contains configuration information specific to this rule.",
-          "type": "object",
-          "additionalProperties": true,
-          "properties": {
-            "tags": {
-              "description": "A set of distinct strings that provide additional configuration information.",
-              "type": "array",
-              "uniqueItems": true,
-              "default": [],
-              "items": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/propertyBag"
         },
 
         "properties": {

--- a/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
+++ b/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
@@ -865,7 +865,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     run.Files = v2Run.Files?.ToDictionary(v => v.Key, v => CreateFileData(v.Value));
 
                     run.Id = v2Run.Id?.InstanceGuid;
-                    run.AutomationId = v2Run.AggregateIds?.First()?.InstanceId;
+                    run.AutomationId = v2Run.AggregateIds?.FirstOrDefault()?.InstanceId;
 
                     run.StableId = v2Run.Id?.InstanceIdLogicalComponent();
 


### PR DESCRIPTION
- Avoid two potential null derefs.
- DRY out the schema declaration of `ruleConfiguration.parameters`