### PR TITLE
Update v2

### DIFF
--- a/src/Sarif.Driver/FileHelpers.cs
+++ b/src/Sarif.Driver/FileHelpers.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using Microsoft.CodeAnalysis.Sarif.Readers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -15,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
     /// </summary>
     static class FileHelpers
     {
-        public static T ReadSarifFile<T>(string filePath, IContractResolver contractResolver = null)
+        public static T ReadSarifFile<T>(IFileSystem fileSystem, string filePath, IContractResolver contractResolver = null)
         {
-            string logText = File.ReadAllText(filePath);
+            string logText = fileSystem.ReadAllText(filePath);
 
             var settings = new JsonSerializerSettings
             {
@@ -28,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             return JsonConvert.DeserializeObject<T>(logText);
         }
 
-        public static void WriteSarifFile<T>(T sarifFile, string outputName, Formatting formatting = Formatting.None, IContractResolver contractResolver = null)
+        public static void WriteSarifFile<T>(IFileSystem fileSystem, T sarifFile, string outputName, Formatting formatting = Formatting.None, IContractResolver contractResolver = null)
         {
             var settings = new JsonSerializerSettings
             {
@@ -36,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 Formatting = formatting
             };
 
-            File.WriteAllText(outputName, JsonConvert.SerializeObject(sarifFile, settings));
+            fileSystem.WriteAllText(outputName, JsonConvert.SerializeObject(sarifFile, settings));
         }
 
         public static HashSet<string> CreateTargetsSet(IEnumerable<string> targetSpecifiers, bool recurse)

--- a/src/Sarif.Driver/FileHelpers.cs
+++ b/src/Sarif.Driver/FileHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             };
 
 
-            return JsonConvert.DeserializeObject<T>(logText);
+            return JsonConvert.DeserializeObject<T>(logText, settings);
         }
 
         public static void WriteSarifFile<T>(IFileSystem fileSystem, T sarifFile, string outputName, Formatting formatting = Formatting.None, IContractResolver contractResolver = null)

--- a/src/Sarif.Driver/Sdk/SingleFileOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/SingleFileOptionsBase.cs
@@ -12,19 +12,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             MetaName = "<inputFile>",
             HelpText = "A path to a file to process.",
             Required = true)]
-        public string InputFilePath { get; internal set; }
+        public string InputFilePath { get; set; }
 
         [Option(
             'i',
             "inline",
             Default = false,
             HelpText = "Write all newly generated content to the input file.")]
-        public bool Inline { get; internal set; }
+        public bool Inline { get; set; }
 
         [Option(
             'o',
             "output",
             HelpText = "A file path to the generated SARIF log.")]
-        public string OutputFilePath { get; internal set; }
+        public string OutputFilePath { get; set; }
     }
 }

--- a/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
+++ b/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Multitool;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Sarif.Multitool.UnitTests
+{
+    public class TransformCommandTests
+    {
+        // Regression test for Issue #1064, "ValidatorCommand fails when target file name contains a space"
+        [Fact]
+        public void TransformCommand_TransformsMinimalFile()
+        {
+            // A minimal valid log file.
+            string logFileContents =
+@"{
+  ""$schema"": ""http://json.schemastore.org/sarif-2.0.0"",
+  ""version"": ""2.0.0-beta.2018-09-26"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""TestTool""
+      },
+      ""results"": []
+    }
+  ]
+}";
+            // First, ensure that our test sample\ schema uri and SARIF version differs 
+            // from current. Otherwise we won't realize any value from this test
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logFileContents);
+            sarifLog.SchemaUri.Should().NotBe(SarifUtilities.SarifSchemaUri);
+            sarifLog.Version.Should().NotBe(SarifUtilities.SemanticVersion);
+
+
+            string logFilePath = @"c:\logs\mylog.sarif";
+            string transformedContents = null;
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.ReadAllText(logFilePath)).Returns(logFileContents);
+            mockFileSystem.Setup(x => x.WriteAllText(logFilePath, It.IsAny<string>())).Callback<string, string>((path, contents) => { transformedContents = contents; });
+
+            var transformCommand = new TransformCommand(mockFileSystem.Object, testing: true);
+
+            var options = new TransformOptions
+            {
+                Inline = true,
+                Version = SarifVersion.Current,
+                InputFilePath = logFilePath
+            };
+
+            int returnCode = transformCommand.Run(options);            
+            returnCode.Should().Be(0);
+
+            // Finally, ensure that transformation corrected schema uri and SARIF version.
+            sarifLog = JsonConvert.DeserializeObject<SarifLog>(transformedContents);
+            sarifLog.SchemaUri.Should().Be(SarifUtilities.SarifSchemaUri);
+            sarifLog.Version.Should().Be(SarifVersion.Current);
+        }
+    }
+}

--- a/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
+++ b/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
@@ -19,7 +19,7 @@ namespace Sarif.Multitool.UnitTests
         public const string MinimalPrereleaseV2 =
     @"{
   ""$schema"": ""http://json.schemastore.org/sarif-2.0.0"",
-  ""version"": ""2.0.0-beta.2018-09-26"",
+  ""version"": ""2.0.0-csd.2.beta.2018-09-26"",
   ""runs"": [
     {
       ""tool"": {

--- a/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
+++ b/src/Sarif.Multitool.UnitTests/TransformCommandTests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Multitool;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+using Microsoft.CodeAnalysis.Sarif.VersionOne;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -13,13 +16,8 @@ namespace Sarif.Multitool.UnitTests
 {
     public class TransformCommandTests
     {
-        // Regression test for Issue #1064, "ValidatorCommand fails when target file name contains a space"
-        [Fact]
-        public void TransformCommand_TransformsMinimalFile()
-        {
-            // A minimal valid log file.
-            string logFileContents =
-@"{
+        public const string MinimalPrereleaseV2 =
+    @"{
   ""$schema"": ""http://json.schemastore.org/sarif-2.0.0"",
   ""version"": ""2.0.0-beta.2018-09-26"",
   ""runs"": [
@@ -31,13 +29,120 @@ namespace Sarif.Multitool.UnitTests
     }
   ]
 }";
+        public static readonly string MinimalCurrentV2 =
+@"{
+  ""$schema"": """ + SarifUtilities.SarifSchemaUri + @""",
+  ""version"": """ + SarifUtilities.SemanticVersion + @""",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""TestTool""
+      },
+      ""results"": []
+    }
+  ]
+}";
+
+        // A minimal valid log file. We add a single result to ensure
+        // there's enough v1 contents so that we trigger any bad code
+        // paths that assume the file contents is v2.
+        public const string MinimalV1 =
+@"{
+  ""version"": ""1.0.0"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""TestTool""
+      },
+      ""results"": [{ ""ruleId"" : ""JS1001"", ""message"" : ""My rule message."" } ]
+    }
+  ]
+}";
+
+        [Fact]
+        public void TransformCommand_TransformsMinimalCurrentV2FileToCurrentV2()
+        {
+            // A minimal valid pre-release v2 log file.
+            string logFileContents = MinimalCurrentV2;
+
+            RunTransformationToV2Test(logFileContents);
+        }
+
+        [Fact]
+        public void TransformCommand_TransformsMinimalPrereleaseV2FileToCurrentV2()
+        {
+            // A minimal valid pre-release v2 log file.
+            string logFileContents = MinimalPrereleaseV2;
+
             // First, ensure that our test sample\ schema uri and SARIF version differs 
             // from current. Otherwise we won't realize any value from this test
             var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logFileContents);
             sarifLog.SchemaUri.Should().NotBe(SarifUtilities.SarifSchemaUri);
             sarifLog.Version.Should().NotBe(SarifUtilities.SemanticVersion);
 
+            RunTransformationToV2Test(logFileContents);
+        }
 
+        [Fact]
+        public void TransformCommand_TransformsMinimalV1FileToCurrentV2()
+        {
+            RunTransformationToV2Test(MinimalV1);
+        }
+
+        [Fact]
+        public void TransformCommand_TransformsMinimalCurrentV2FileToV1()
+        {
+            // A minimal valid pre-release v2 log file.
+            string logFileContents = MinimalCurrentV2;
+
+            RunTransformationToV1Test(logFileContents);
+        }
+
+        [Fact]
+        public void TransformCommand_TransformsMinimalPrereleaseV2FileToV1()
+        {
+            // A minimal valid pre-release v2 log file.
+            string logFileContents = MinimalPrereleaseV2;
+
+            // First, ensure that our test sample\ schema uri and SARIF version differs 
+            // from current. Otherwise we won't realize any value from this test
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logFileContents);
+            sarifLog.SchemaUri.Should().NotBe(SarifUtilities.SarifSchemaUri);
+            sarifLog.Version.Should().NotBe(SarifUtilities.SemanticVersion);
+
+            RunTransformationToV1Test(logFileContents);
+        }
+
+        [Fact]
+        public void TransformCommand_TransformsMinimalV1FileToV1()
+        {
+            RunTransformationToV1Test(MinimalV1);
+        }
+
+        private static void RunTransformationToV2Test(string logFileContents)
+        {
+            string transformedContents = RunTransformationCore(logFileContents, SarifVersion.Current);
+
+            // Finally, ensure that transformation corrected schema uri and SARIF version.
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(transformedContents);
+            sarifLog.SchemaUri.Should().Be(SarifUtilities.SarifSchemaUri);
+            sarifLog.Version.Should().Be(SarifVersion.Current);
+        }
+
+        private void RunTransformationToV1Test(string logFileContents)
+        {
+            string transformedContents = RunTransformationCore(logFileContents, SarifVersion.OneZeroZero);
+
+            // Finally, ensure that transformation corrected schema uri and SARIF version.
+            var settings = new JsonSerializerSettings { ContractResolver = SarifContractResolverVersionOne.Instance };
+            SarifLogVersionOne v1SarifLog = JsonConvert.DeserializeObject<SarifLogVersionOne>(transformedContents, settings);
+            v1SarifLog.SchemaUri.Should().Be(@"http://json.schemastore.org/sarif-1.0.0");
+            v1SarifLog.Version.Should().Be(SarifVersionVersionOne.OneZeroZero);
+        }
+
+        private static string RunTransformationCore(string logFileContents, SarifVersion targetVersion)
+        {
             string logFilePath = @"c:\logs\mylog.sarif";
             string transformedContents = null;
 
@@ -50,17 +155,14 @@ namespace Sarif.Multitool.UnitTests
             var options = new TransformOptions
             {
                 Inline = true,
-                Version = SarifVersion.Current,
+                TargetVersion = targetVersion,
                 InputFilePath = logFilePath
             };
 
-            int returnCode = transformCommand.Run(options);            
+            int returnCode = transformCommand.Run(options);
             returnCode.Should().Be(0);
 
-            // Finally, ensure that transformation corrected schema uri and SARIF version.
-            sarifLog = JsonConvert.DeserializeObject<SarifLog>(transformedContents);
-            sarifLog.SchemaUri.Should().Be(SarifUtilities.SarifSchemaUri);
-            sarifLog.Version.Should().Be(SarifVersion.Current);
+            return transformedContents;
         }
     }
 }

--- a/src/Sarif.Multitool.UnitTests/ValidateCommandTests.cs
+++ b/src/Sarif.Multitool.UnitTests/ValidateCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.IO;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;

--- a/src/Sarif.Multitool.UnitTests/ValidateCommandTests.cs
+++ b/src/Sarif.Multitool.UnitTests/ValidateCommandTests.cs
@@ -17,19 +17,8 @@ namespace Sarif.Multitool.UnitTests
         public void ValidateCommand_AcceptsTargetFileWithSpaceInName()
         {
             // A minimal valid log file.
-            string logFileContents =
-@"{
-  ""$schema"": """ + SarifUtilities.SarifSchemaUri + @""",
-  ""version"": """ + SarifUtilities.SemanticVersion + @""",
-  ""runs"": [
-    {
-      ""tool"": {
-        ""name"": ""TestTool""
-      },
-      ""results"": []
-    }
-  ]
-}";
+            string logFileContents = TransformCommandTests.MinimalCurrentV2;
+
             // A simple schema against which the log file successfully validates.
             // This way, we don't have to read the SARIF schema from disk to run this test.
             const string SchemaFileContents =

--- a/src/Sarif.Multitool/AbsoluteUriCommand.cs
+++ b/src/Sarif.Multitool/AbsoluteUriCommand.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class AbsoluteUriCommand
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
 
         public AbsoluteUriCommand(IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool/AbsoluteUriCommand.cs
+++ b/src/Sarif.Multitool/AbsoluteUriCommand.cs
@@ -10,9 +10,16 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    internal static class AbsoluteUriCommand
+    internal class AbsoluteUriCommand
     {
-        public static int Run(AbsoluteUriOptions absoluteUriOptions)
+        private IFileSystem _fileSystem;
+
+        public AbsoluteUriCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public int Run(AbsoluteUriOptions absoluteUriOptions)
         {
             try
             {
@@ -29,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                         ? Formatting.Indented
                         : Formatting.None;
 
-                    FileHelpers.WriteSarifFile(sarifLog.Log, outputName, formatting);
+                    FileHelpers.WriteSarifFile(_fileSystem, sarifLog.Log, outputName, formatting);
                 }
             }
             catch (Exception ex)
@@ -41,13 +48,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return 0;
         }
 
-        private static IEnumerable<AbsoluteUriFile> GetSarifFiles(AbsoluteUriOptions absoluteUriOptions)
+        private IEnumerable<AbsoluteUriFile> GetSarifFiles(AbsoluteUriOptions absoluteUriOptions)
         {
             // Get files names first, as we may write more sarif logs to the same directory as we rebase them.
             HashSet<string> fileNames = FileHelpers.CreateTargetsSet(absoluteUriOptions.TargetFileSpecifiers, absoluteUriOptions.Recurse);
             foreach (var file in fileNames)
             {
-                yield return new AbsoluteUriFile() { FileName = file, Log = FileHelpers.ReadSarifFile<SarifLog>(file) };
+                yield return new AbsoluteUriFile() { FileName = file, Log = FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, file) };
             }
         }
 

--- a/src/Sarif.Multitool/MergeCommand.cs
+++ b/src/Sarif.Multitool/MergeCommand.cs
@@ -11,9 +11,16 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    internal static class MergeCommand
+    internal class MergeCommand
     {
-        public static int Run(MergeOptions mergeOptions)
+        private IFileSystem _fileSystem;
+
+        public MergeCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+    
+        public  int Run(MergeOptions mergeOptions)
         {
             try
             {
@@ -44,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 Directory.CreateDirectory(mergeOptions.OutputFolderPath);
 
-                FileHelpers.WriteSarifFile(combinedLog, outputName, formatting);
+                FileHelpers.WriteSarifFile(_fileSystem, combinedLog, outputName, formatting);
             }
             catch (Exception ex)
             {
@@ -54,11 +61,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return 0;
         }
 
-	    private static IEnumerable<SarifLog> ParseFiles(IEnumerable<string> sarifFiles)
+	    private IEnumerable<SarifLog> ParseFiles(IEnumerable<string> sarifFiles)
 	    {
             foreach (var file in sarifFiles)
             {
-                yield return FileHelpers.ReadSarifFile<SarifLog>(file);
+                yield return FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, file);
             }
         }
         

--- a/src/Sarif.Multitool/MergeCommand.cs
+++ b/src/Sarif.Multitool/MergeCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class MergeCommand
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
 
         public MergeCommand(IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -22,14 +22,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 AbsoluteUriOptions,
                 ResultMatchingOptions>(args)
               .MapResult(
-                (ValidateOptions validateOptions) => new ValidateCommand(new FileSystem()).Run(validateOptions),
+                (ValidateOptions validateOptions) => new ValidateCommand().Run(validateOptions),
                 (ConvertOptions convertOptions) => ConvertCommand.Run(convertOptions),
-                (RewriteOptions rewriteOptions) => RewriteCommand.Run(rewriteOptions),
-                (TransformOptions transformOptions) => TransformCommand.Run(transformOptions),
-                (MergeOptions mergeOptions) => MergeCommand.Run(mergeOptions),
-                (RebaseUriOptions rebaseOptions) => RebaseUriCommand.Run(rebaseOptions),
-                (AbsoluteUriOptions absoluteUriOptions) => AbsoluteUriCommand.Run(absoluteUriOptions),
-                (ResultMatchingOptions baselineOptions) => ResultMatchingCommand.Run(baselineOptions),
+                (RewriteOptions rewriteOptions) => new RewriteCommand().Run(rewriteOptions),
+                (TransformOptions transformOptions) => new TransformCommand().Run(transformOptions),
+                (MergeOptions mergeOptions) => new MergeCommand().Run(mergeOptions),
+                (RebaseUriOptions rebaseOptions) => new RebaseUriCommand().Run(rebaseOptions),
+                (AbsoluteUriOptions absoluteUriOptions) => new AbsoluteUriCommand().Run(absoluteUriOptions),
+                (ResultMatchingOptions baselineOptions) => new ResultMatchingCommand().Run(baselineOptions),
                 errs => 1);
         }
     }

--- a/src/Sarif.Multitool/RebaseUriCommand.cs
+++ b/src/Sarif.Multitool/RebaseUriCommand.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class RebaseUriCommand
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
 
         public RebaseUriCommand(IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool/RebaseUriCommand.cs
+++ b/src/Sarif.Multitool/RebaseUriCommand.cs
@@ -10,9 +10,16 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    internal static class RebaseUriCommand
+    internal class RebaseUriCommand
     {
-        public static int Run(RebaseUriOptions rebaseOptions)
+        private IFileSystem _fileSystem;
+
+        public RebaseUriCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public int Run(RebaseUriOptions rebaseOptions)
         {
             try
             {
@@ -41,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                         ? Formatting.Indented
                         : Formatting.None;
                     
-                    FileHelpers.WriteSarifFile(sarifLog.Log, outputName, formatting);
+                    FileHelpers.WriteSarifFile(_fileSystem, sarifLog.Log, outputName, formatting);
                 }
             }
             catch (Exception ex)
@@ -53,13 +60,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             return 0;
         }
         
-        private static IEnumerable<RebaseUriFile> GetSarifFiles(RebaseUriOptions mergeOptions)
+        private IEnumerable<RebaseUriFile> GetSarifFiles(RebaseUriOptions mergeOptions)
         {
             // Get files names first, as we may write more sarif logs to the same directory as we rebase them.
             HashSet<string> fileNames = FileHelpers.CreateTargetsSet(mergeOptions.TargetFileSpecifiers, mergeOptions.Recurse);
             foreach(var file in fileNames)
             {
-                yield return new RebaseUriFile() { FileName = file, Log = FileHelpers.ReadSarifFile<SarifLog>(file) };
+                yield return new RebaseUriFile() { FileName = file, Log = FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, file) };
             }
         }
         

--- a/src/Sarif.Multitool/ResultMatchingCommand.cs
+++ b/src/Sarif.Multitool/ResultMatchingCommand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class ResultMatchingCommand
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
 
         public ResultMatchingCommand(IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool/ResultMatchingCommand.cs
+++ b/src/Sarif.Multitool/ResultMatchingCommand.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.CodeAnalysis.Sarif.Baseline;
 using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 
@@ -13,14 +11,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class ResultMatchingCommand
     {
-        public static int Run(ResultMatchingOptions matchingOptions)
+        private IFileSystem _fileSystem;
+
+        public ResultMatchingCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public int Run(ResultMatchingOptions matchingOptions)
         {
             try
             {
                 SarifLog baselineFile = null;
                 if (!string.IsNullOrEmpty(matchingOptions.PreviousFilePath))
                 {
-                    baselineFile = FileHelpers.ReadSarifFile<SarifLog>(matchingOptions.PreviousFilePath);
+                    baselineFile = FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, matchingOptions.PreviousFilePath);
                 }
 
                 string outputFilePath = matchingOptions.OutputFilePath;
@@ -29,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     outputFilePath = Path.GetFileNameWithoutExtension(matchingOptions.PreviousFilePath) + "-annotated.sarif";
                 }
 
-                SarifLog currentFile = FileHelpers.ReadSarifFile<SarifLog>(matchingOptions.CurrentFilePath);
+                SarifLog currentFile = FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, matchingOptions.CurrentFilePath);
                 
                 ISarifLogMatcher matcher = ResultMatchingBaselinerFactory.GetDefaultResultMatchingBaseliner();
 
@@ -39,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                         ? Newtonsoft.Json.Formatting.Indented
                         : Newtonsoft.Json.Formatting.None;
                 
-                FileHelpers.WriteSarifFile(output, outputFilePath, formatting);
+                FileHelpers.WriteSarifFile(_fileSystem, output, outputFilePath, formatting);
             }
             catch (Exception ex)
             {

--- a/src/Sarif.Multitool/RewriteCommand.cs
+++ b/src/Sarif.Multitool/RewriteCommand.cs
@@ -11,15 +11,22 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    internal static class RewriteCommand
+    internal class RewriteCommand
     {
-        public static int Run(RewriteOptions rewriteOptions)
+        private IFileSystem _fileSystem;
+
+        public RewriteCommand(IFileSystem fileSystem = null)
+        {
+            _fileSystem = fileSystem ?? new FileSystem();
+        }
+
+        public int Run(RewriteOptions rewriteOptions)
         {
             try
             {
                 rewriteOptions = ValidateOptions(rewriteOptions);
                 
-                SarifLog actualLog = FileHelpers.ReadSarifFile<SarifLog>(rewriteOptions.InputFilePath);
+                SarifLog actualLog = FileHelpers.ReadSarifFile<SarifLog>(_fileSystem, rewriteOptions.InputFilePath);
 
                 OptionallyEmittedData dataToInsert = rewriteOptions.DataToInsert.ToFlags();
                 IDictionary<string, FileLocation> originalUriBaseIds = rewriteOptions.ConstructUriBaseIdsDictionary();
@@ -32,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     ? Formatting.Indented
                     : Formatting.None;
 
-                FileHelpers.WriteSarifFile(reformattedLog, fileName, formatting);
+                FileHelpers.WriteSarifFile(_fileSystem, reformattedLog, fileName, formatting);
             }
             catch(Exception ex)
             {

--- a/src/Sarif.Multitool/RewriteCommand.cs
+++ b/src/Sarif.Multitool/RewriteCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class RewriteCommand
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
 
         public RewriteCommand(IFileSystem fileSystem = null)
         {

--- a/src/Sarif.Multitool/TransformCommand.cs
+++ b/src/Sarif.Multitool/TransformCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     internal class TransformCommand
     {
-        private bool _testing;
+        private readonly bool _testing;
         private readonly IFileSystem _fileSystem;
 
         public TransformCommand(IFileSystem fileSystem = null, bool testing = false)

--- a/src/Sarif.Multitool/TransformCommand.cs
+++ b/src/Sarif.Multitool/TransformCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                         var visitor = new SarifCurrentToVersionOneVisitor();
                         visitor.VisitSarifLog(actualLog);
 
-                        FileHelpers.WriteSarifFile(_fileSystem, visitor.SarifLogVersionOne, fileName, formatting);
+                        FileHelpers.WriteSarifFile(_fileSystem, visitor.SarifLogVersionOne, fileName, formatting, SarifContractResolverVersionOne.Instance);
                     }
                 }
             }

--- a/src/Sarif.Multitool/TransformOptions.cs
+++ b/src/Sarif.Multitool/TransformOptions.cs
@@ -10,10 +10,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
     internal class TransformOptions : SingleFileOptionsBase
     {
         [Option(
-            't',
+            'v',
             "target-version",
             HelpText = "The SARIF version to which the input file will be transformed.",
             Default = SarifVersion.Current)]
-        public SarifVersion Version { get; internal set; }
+        public SarifVersion Version { get; set; }
     }
 }

--- a/src/Sarif.Multitool/TransformOptions.cs
+++ b/src/Sarif.Multitool/TransformOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             't',
             "target-version",
             HelpText = "The SARIF version to which the input file will be transformed.",
-            Default = 2)]
-        public int Version { get; internal set; }
+            Default = SarifVersion.Current)]
+        public SarifVersion Version { get; internal set; }
     }
 }

--- a/src/Sarif.Multitool/TransformOptions.cs
+++ b/src/Sarif.Multitool/TransformOptions.cs
@@ -14,6 +14,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             "target-version",
             HelpText = "The SARIF version to which the input file will be transformed.",
             Default = SarifVersion.Current)]
-        public SarifVersion Version { get; set; }
+        public SarifVersion TargetVersion { get; set; }
     }
 }

--- a/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
+++ b/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
     internal class LogModelSampleBuilder
     {
-        public const string SampleLogPath = "CodeCrawler.log.json";
+        public const string SampleLogPath = @"e:\repros\CodeCrawler.log.json";
         public const string SampleOneLinePath = "CodeCrawler.OneLine.log.json";
         public const string SampleNoCodeContextsPath = "CodeCrawler.NoCodeContexts.log.json";
         public const string SampleEmptyPath = "CodeCrawler.Empty.log.json";

--- a/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
+++ b/src/Sarif.UnitTests/Readers/SampleModel/LogModel.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers.SampleModel
 
     internal class LogModelSampleBuilder
     {
-        public const string SampleLogPath = @"e:\repros\CodeCrawler.log.json";
+        public const string SampleLogPath = @"CodeCrawler.log.json";
         public const string SampleOneLinePath = "CodeCrawler.OneLine.log.json";
         public const string SampleNoCodeContextsPath = "CodeCrawler.NoCodeContexts.log.json";
         public const string SampleEmptyPath = "CodeCrawler.Empty.log.json";

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
                 case "2.0.0-csd.2.beta.2018-10-10":
                 {
-                    // NOthing to do, this is current
+                    // Nothing to do, this is current
                     break;
                 }
 

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
                 var runId = new JObject();
 
-                if (instanceGuid != null)
+                if (instanceGuid != null && logicalId != null)
                 {
                     // We can only effectively populate the new instanceId in a case where
                     // the log is previously uniquely identified a run by a guid.

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -33,23 +33,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
             switch (version)
             {
-                // This case actually handles all SARIF v2 prerelease before we 
-                // started properly updating the schema. 
-                case "2.0.0":
-                {
-                    modifiedLog |= ApplyCoreTransformations(sarifLog);
-                    break;
-                }
 
                 case "2.0.0-csd.2.beta.2018-10-10":
                 {
-                    modifiedLog |= ApplyCoreTransformations(sarifLog);
-                    modifiedLog |= ApplyChangesSinceTechnicalCommitteeMeeting25();
+                    // NOthing to do, this is current
                     break;
                 }
 
                 default:
+                {
+                    modifiedLog |= ApplyCoreTransformations(sarifLog);
                     break;
+                }
             }
 
             return modifiedLog ? sarifLog.ToString(formatting) : prereleaseSarifLog;
@@ -530,12 +525,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
 
             return modifiedNotification;
-        }
-
-        private static bool ApplyChangesSinceTechnicalCommitteeMeeting25()
-        {
-            // No changes applied in this method
-            return false;
         }
     }
 }


### PR DESCRIPTION
This change allows users to pass a reference to a pre-release v2 SARIF file and have it transformed to current v2. As part of this, I dropped in a FileSystem reference to allow mocked unit testing and prepped other commands for this as well. The Convert command calls to underlying code that operates strictly against a stream and I didn't take the time to push any testing machinery there, we have not immediate additional testing in any case.

@lgolding @EasyRhinoMSFT 