### PR TITLE
Fix Fortify FPR converter bugs #1127 and #1128

### DIFF
--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     _reader.Read();
 
                     // If we don't have a label, get the <Action> value
-                    if (string.IsNullOrWhiteSpace(nodeLabel))
+                    if (string.IsNullOrWhiteSpace(nodeLabel) && AtStartOf(_strings.Action))
                     {
                         nodeLabel = _reader.ReadElementContentAsString();
                     }
@@ -410,13 +410,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         Location = new Location
                         {
-                            Message = new Message
-                            {
-                                Text = nodeLabel
-                            },
                             PhysicalLocation = physicalLocation
                         }
                     };
+
+                    if (!string.IsNullOrWhiteSpace(nodeLabel))
+                    {
+                        tfl.Location.Message = new Message
+                        {
+                            Text = nodeLabel
+                        };
+                    }
 
                     // Remember the id of the snippet associated with this location.
                     // We'll use it to fill the snippet text when we read the Snippets element later on.
@@ -455,7 +459,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 result.RelatedLocations.Last().PhysicalLocation.Id = 1;
 
-                if (!string.IsNullOrEmpty(lastNodeId))
+                if (!string.IsNullOrEmpty(lastNodeId) && !_resultToSnippetIdDictionary.ContainsKey(result))
                 {
                     _resultToSnippetIdDictionary.Add(result, lastNodeId);
                 }

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -330,10 +330,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 Locations = new List<Location>(),
                 RelatedLocations = new List<Location>(),
-                CodeFlows = new []
-                {
-                    SarifUtilities.CreateSingleThreadedCodeFlow()
-                }
+                CodeFlows = new List<CodeFlow>()
             };
 
             _reader.Read();
@@ -349,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
                 else if (AtStartOfNonEmpty(_strings.Trace))
                 {
-                    ParseLocationFromTrace(result);
+                    ParseLocationsFromTraces(result);
                 }
 
                 _reader.Read();
@@ -358,83 +355,116 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             _results.Add(result);
         }
 
-        private void ParseLocationFromTrace(Result result)
+        private void ParseLocationsFromTraces(Result result)
         {
-            CodeFlow codeFlow = result.CodeFlows.First();
+            CodeFlow codeFlow = null;
             string nodeLabel = null;
             string lastNodeId = null;
 
-            _reader.Read();
-
-            while (!AtEndOf(_strings.Trace))
+            while (!AtEndOf(_strings.Unified))
             {
-                if (AtStartOf(_strings.NodeRef))
+                if (AtStartOf(_strings.Trace))
                 {
-                    string nodeId = _reader.GetAttribute(_strings.IdAttribute);
+                    codeFlow = SarifUtilities.CreateSingleThreadedCodeFlow();
+                    result.CodeFlows.Add(codeFlow);
 
-                    if (!string.IsNullOrWhiteSpace(nodeId))
+                    while (!AtEndOf(_strings.Trace))
                     {
-                        var tfl = new ThreadFlowLocation
+                        if (AtStartOf(_strings.NodeRef))
                         {
-                        };
+                            string nodeId = _reader.GetAttribute(_strings.IdAttribute);
 
-                        _tflToNodeIdDictionary.Add(tfl, nodeId);
-                        codeFlow.ThreadFlows[0].Locations.Add(tfl);
-                    }
+                            if (!string.IsNullOrWhiteSpace(nodeId))
+                            {
+                                var tfl = new ThreadFlowLocation();
+                                _tflToNodeIdDictionary.Add(tfl, nodeId);
+                                codeFlow.ThreadFlows[0].Locations.Add(tfl);
+                            }
 
-                    _reader.Read();
-                }
-                else if (AtStartOf(_strings.Node))
-                {
-                    nodeLabel = _reader.GetAttribute(_strings.LabelAttribute);
-                    _reader.Read();
-                }
-                else if (AtStartOf(_strings.SourceLocation))
-                {
-                    // Note: SourceLocation is an empty element (it has only attributes),
-                    // so we can't call AtStartOfNonEmpty here.
-
-                    string snippetId = _reader.GetAttribute(_strings.SnippetAttribute);
-                    PhysicalLocation physicalLocation = ParsePhysicalLocationFromSourceInfo();
-
-                    // Step past the empty SourceLocation element.
-                    _reader.Read();
-
-                    // If we don't have a label, get the <Action> value
-                    if (string.IsNullOrWhiteSpace(nodeLabel) && AtStartOf(_strings.Action))
-                    {
-                        nodeLabel = _reader.ReadElementContentAsString();
-                    }
-
-                    var tfl = new ThreadFlowLocation
-                    {
-                        Location = new Location
-                        {
-                            PhysicalLocation = physicalLocation
+                            _reader.Read();
                         }
-                    };
-
-                    if (!string.IsNullOrWhiteSpace(nodeLabel))
-                    {
-                        tfl.Location.Message = new Message
+                        else if (AtStartOf(_strings.Node))
                         {
-                            Text = nodeLabel
-                        };
+                            nodeLabel = _reader.GetAttribute(_strings.LabelAttribute);
+                            _reader.Read();
+                        }
+                        else if (AtStartOf(_strings.SourceLocation))
+                        {
+                            // Note: SourceLocation is an empty element (it has only attributes),
+                            // so we can't call AtStartOfNonEmpty here.
+
+                            string snippetId = _reader.GetAttribute(_strings.SnippetAttribute);
+                            PhysicalLocation physicalLocation = ParsePhysicalLocationFromSourceInfo();
+
+                            // Step past the empty SourceLocation element.
+                            _reader.Read();
+
+                            // If we don't have a label, get the <Action> value
+                            if (string.IsNullOrWhiteSpace(nodeLabel) && AtStartOf(_strings.Action))
+                            {
+                                nodeLabel = _reader.ReadElementContentAsString();
+                            }
+
+                            var tfl = new ThreadFlowLocation
+                            {
+                                Location = new Location
+                                {
+                                    PhysicalLocation = physicalLocation
+                                }
+                            };
+
+                            if (!string.IsNullOrWhiteSpace(nodeLabel))
+                            {
+                                tfl.Location.Message = new Message
+                                {
+                                    Text = nodeLabel
+                                };
+                            }
+
+                            // Remember the id of the snippet associated with this location.
+                            // We'll use it to fill the snippet text when we read the Snippets element later on.
+                            if (!string.IsNullOrEmpty(snippetId))
+                            {
+                                _tflToSnippetIdDictionary.Add(tfl, snippetId);
+                            }
+
+                            codeFlow.ThreadFlows[0].Locations.Add(tfl);
+
+                            // Keep track of the snippet associated with the last location in the
+                            // last CodeFlow; that's the snippet that we'll associate with the Result
+                            // as a whole.
+                            lastNodeId = snippetId;
+                        }
+                        else
+                        {
+                            _reader.Read();
+                        }
                     }
 
-                    // Remember the id of the snippet associated with this location.
-                    // We'll use it to fill the snippet text when we read the Snippets element later on.
-                    if (!string.IsNullOrEmpty(snippetId))
+                    if (codeFlow.ThreadFlows[0].Locations.Any())
                     {
-                        _tflToSnippetIdDictionary.Add(tfl, snippetId);
+                        Location location = new Location
+                        {
+                            PhysicalLocation = codeFlow.ThreadFlows[0].Locations.Last().Location?.PhysicalLocation
+                        };
+
+                        // Make sure we don't already have this location in the lists
+                        if (!result.Locations.Contains(location, Location.ValueComparer))
+                        {
+                            result.Locations.Add(new Location
+                            {
+                                // TODO: Confirm that the traces are ordered chronologically
+                                // (so that we really do want to use the last one as the
+                                // overall result location).
+                                PhysicalLocation = location.PhysicalLocation.DeepClone()
+                            });
+                            result.RelatedLocations.Add(new Location
+                            {
+                                // Links embedded in the result message refer to related physicalLocation.id
+                                PhysicalLocation = location.PhysicalLocation.DeepClone()
+                            });
+                        }
                     }
-
-                    codeFlow.ThreadFlows[0].Locations.Add(tfl);
-
-                    // Keep track of the snippet associated with the last location in the
-                    // CodeFlow; that's the snippet that we'll associate with the Result
-                    // as a whole.
-                    lastNodeId = snippetId;
                 }
                 else
                 {
@@ -442,27 +472,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             }
 
-            if (codeFlow.ThreadFlows[0].Locations.Any())
+            if (result.RelatedLocations.Any())
             {
-                result.Locations.Add(new Location
-                {
-                    // TODO: Confirm that the traces are ordered chronologically
-                    // (so that we really do want to use the last one as the
-                    // overall result location).
-                    PhysicalLocation = codeFlow.ThreadFlows[0].Locations.Last().Location?.PhysicalLocation.DeepClone()
-                });
-                result.RelatedLocations.Add(new Location
-                {
-                    // Links embedded in the result message refer to related physicalLocation.id
-                    PhysicalLocation = codeFlow.ThreadFlows[0].Locations.Last().Location?.PhysicalLocation.DeepClone()
-                });
+                Location relatedLocation = result.RelatedLocations.Last();
 
-                result.RelatedLocations.Last().PhysicalLocation.Id = 1;
-
-                if (!string.IsNullOrEmpty(lastNodeId) && !_resultToSnippetIdDictionary.ContainsKey(result))
+                if (relatedLocation != null)
                 {
-                    _resultToSnippetIdDictionary.Add(result, lastNodeId);
+                    relatedLocation.PhysicalLocation.Id = 1;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(lastNodeId))
+            {
+                _resultToSnippetIdDictionary.Add(result, lastNodeId);
             }
         }
 

--- a/src/Sarif.Converters/FortifyFprStrings.cs
+++ b/src/Sarif.Converters/FortifyFprStrings.cs
@@ -69,6 +69,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         /// <summary>The string constant "value"</summary>
         public readonly string ValueAttribute;
 
+        /// <summary>The string constant "Unified"</summary>
+        public readonly string Unified;
+
         /// <summary>The string constant "Trace"</summary>
         public readonly string Trace;
 
@@ -199,6 +202,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Def = nameTable.Add("Def");
             KeyAttribute = nameTable.Add("key");
             ValueAttribute = nameTable.Add("value");
+            Unified = nameTable.Add("Unified");
             Trace = nameTable.Add("Trace");
             Entry = nameTable.Add("Entry");
             NodeRef = nameTable.Add("NodeRef");

--- a/src/Sarif.FunctionalTests/v2/ConverterTestData/FortifyFpr/FortifyTest.fpr.sarif
+++ b/src/Sarif.FunctionalTests/v2/ConverterTestData/FortifyFpr/FortifyTest.fpr.sarif
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.0.0-csd.2.beta.2018-09-26",
-  "version": "2.0.0-csd.2.beta.2018-09-26",
+  "$schema": "http://json.schemastore.org/sarif-2.0.0-csd.2.beta.2018-10-10",
+  "version": "2.0.0-csd.2.beta.2018-10-10",
   "runs": [
     {
       "tool": {
@@ -9,7 +9,7 @@
       "invocations": [
         {
           "commandLine": "[REMOVED]insourceanalyzer.exe -b CareerGuideAdminTool -verbose -debug -logfile D:\\AgentWork\\574\\a\\sca_artifacts\\CareerGuideAdminTool_scan.log -scan -f D:\\AgentWork\\574\\a\\sca_artifacts\\CareerGuideAdminTool.fpr",
-          "startTime": "2018-06-14T05:51:41.000Z",
+          "startTimeUtc": "2018-06-14T05:51:41.000Z",
           "machine": "ACESDLFORT00005",
           "account": "fortbld",
           "properties": {
@@ -69,7 +69,6 @@
                 {
                   "locations": [
                     {
-                      "step": 1,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -96,7 +95,6 @@
                       }
                     },
                     {
-                      "step": 2,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -176,7 +174,6 @@
                 {
                   "locations": [
                     {
-                      "step": 1,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -256,7 +253,6 @@
                 {
                   "locations": [
                     {
-                      "step": 1,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -283,7 +279,6 @@
                       }
                     },
                     {
-                      "step": 2,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -310,7 +305,6 @@
                       }
                     },
                     {
-                      "step": 3,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -337,7 +331,6 @@
                       }
                     },
                     {
-                      "step": 4,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -364,7 +357,6 @@
                       }
                     },
                     {
-                      "step": 5,
                       "location": {
                         "physicalLocation": {
                           "fileLocation": {
@@ -442,7 +434,9 @@
           }
         }
       },
-      "automationLogicalId": "CareerGuideAdminTool"
+      "id": {
+        "instanceId": "CareerGuideAdminTool/"
+      }
     }
   ]
 }


### PR DESCRIPTION
This change includes a refactor that puts each <Trace> block into its own codeFlow, rather than a single codeFlow with a threadFlow for each <Trace>. I think this is the right way to translate.