### PR TITLE
Properly persist run level property bags

### DIFF
--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             ResultMatchingProperties = MergeDictionaryPreferFirst(ResultMatchingProperties, OriginalResultMatchingProperties);
 
             if (PreviousResult != null &&
-                propertyBagMergeBehavior == DictionaryMergeBehavior.InitializeFromPrevious)
+                propertyBagMergeBehavior == DictionaryMergeBehavior.InitializeFromOldest)
             {
                 result.Properties = PreviousResult.Result.Properties;
             }

--- a/src/Sarif/Baseline/ResultMatching/DictionaryMergeBehaviors.cs
+++ b/src/Sarif/Baseline/ResultMatching/DictionaryMergeBehaviors.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
     {
         None = 0,                      // By default, we will always exclusively  preserve the earliest
                                        // properties that have been generated. We will not attempt any merging.
-        InitializeFromPrevious = None,
-        InitializeFromCurrent = 0x1,   // On setting this bit, we will discard earlier properties
+        InitializeFromOldest = None,
+        InitializeFromMostRecent = 0x1,// On setting this bit, we will discard earlier properties
                                        // in favor of those that are most recently generated.
     }
 }


### PR DESCRIPTION
@vScottLouvau FYI some baselining/result matching changes. Not blocking this PR as the accessibility team is waiting for it.