### PR TITLE
Logical locations notes

### DIFF
--- a/src/Sarif.Converters.UnitTests/AndroidStudioConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/AndroidStudioConverterTests.cs
@@ -213,7 +213,7 @@ Possible resolution: delete", result.Message.Text);
             loc.PhysicalLocation.Should().BeNull();
         }
 
-        public static void ValidateLogicalLocations(IList<LogicalLocation> expectedLogicalLocations, IList<LogicalLocation> actualLogicalLocations)
+        internal static void ValidateLogicalLocations(IList<LogicalLocation> expectedLogicalLocations, IList<LogicalLocation> actualLogicalLocations)
         {
             for (int i = 0; i < expectedLogicalLocations.Count; i++)
             {

--- a/src/Sarif.Converters.UnitTests/AndroidStudioConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/AndroidStudioConverterTests.cs
@@ -213,7 +213,7 @@ Possible resolution: delete", result.Message.Text);
             loc.PhysicalLocation.Should().BeNull();
         }
 
-        private static void ValidateLogicalLocations(IList<LogicalLocation> expectedLogicalLocations, IList<LogicalLocation> actualLogicalLocations)
+        public static void ValidateLogicalLocations(IList<LogicalLocation> expectedLogicalLocations, IList<LogicalLocation> actualLogicalLocations)
         {
             for (int i = 0; i < expectedLogicalLocations.Count; i++)
             {

--- a/src/Sarif.Converters.UnitTests/FxCopConverterTests.cs
+++ b/src/Sarif.Converters.UnitTests/FxCopConverterTests.cs
@@ -330,12 +330,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     {
         private static void ValidateLogicalLocations(IList<LogicalLocation> expectedLogicalLocations, IList<LogicalLocation> actualLogicalLocations)
         {
-            actualLogicalLocations.Count.Should().Be(expectedLogicalLocations.Count);
-
-            for (int i = 0; i < expectedLogicalLocations.Count; i++)
-            {
-                expectedLogicalLocations[i].ValueEquals(actualLogicalLocations[i]).Should().BeTrue();
-            }
+            // If we end up with more shared helper code, we could extend these tests types from a common base.
+            AndroidStudioConverterTests.ValidateLogicalLocations(expectedLogicalLocations, actualLogicalLocations);
         }
 
         [Fact]

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/BasicResult.sarif
@@ -136,6 +136,18 @@
                 }
               },
               "fullyQualifiedLogicalName": "collections::list"
+            },
+            {
+              "message": "This reference to \"collections::list\" is not relevant to the problem.",
+              "physicalLocation": {
+                "uri": "file:///home/buildAgent/src/collections/list_collision.cpp",
+                "region": {
+                  "startLine": 12,
+                  "endLine": 12
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "logicalLocationKey": "collections::list-KEY_COLLISION"
             }
           ]
         }

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/BasicResult.sarif
@@ -31,12 +31,57 @@
           "kind": "type",
           "parentKey": "collections"
         },
+        "collections::list-KEY_COLLISION": {
+          "name": "list",
+          "kind": "member",
+          "parentKey": "collections"
+        },
         "collections": {
           "name": "collections",
           "kind": "namespace"
         }
       },
       "results": [
+        {
+          "ruleId": "C2001",
+          "formattedRuleMessage": {
+            "formatId": "default",
+            "arguments": [
+              "collections::list"
+            ]
+          },
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///home/buildAgent/src/collections/list.cpp"
+              },
+              "resultFile": {
+                "uri": "file:///home/buildAgent/src/collections/list.h",
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 28,
+                  "length": 27
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "decoratedName": "?add@list@@_decorated_type_name"
+            },
+            {
+              "resultFile": {
+                "uri": "file:///home/buildAgent/src/collections/list_collision.cpp",
+                "region": {
+                  "startLine": 12,
+                  "endLine": 12
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "logicalLocationKey": "collections::list-KEY_COLLISION",
+              "decoratedName": "?add@list@@_decorated_member_name"
+            }
+          ]
+        },
         {
           "ruleId": "C2001",
           "formattedRuleMessage": {
@@ -102,6 +147,13 @@
           "fullDescription": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions.",
           "messageFormats": {
             "default": "Variable \"{0}\" was used without being initialized."
+          }
+        },
+        "C2002": {
+          "id": "C2002",
+          "shortDescription": "A potentially confusing naming collision exists.",
+          "messageFormats": {
+            "default": "The fully qualified name \"{0}\" is shared between multiple constructs in this component, potentially compromising maintainability."
           }
         }
       }

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/NotificationExceptionWithStack.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/NotificationExceptionWithStack.sarif
@@ -18,7 +18,7 @@
                   "message": "Exception thrown",
                   "module": "RuleLibrary",
                   "threadId": 52,
-                  "fullyQualifiedLogicalName": "Rules.SecureHashAlgorithmRule.Evaluate",
+                  "fullyQualifiedLogicalName": "Ambiguous.Item",
                   "uri": "file:///C:/src/main.cs",
                   "address": 10092852,
                   "line": 15,
@@ -40,10 +40,10 @@
                   "offset": 10475
                 },
                 {
-                  "module": "ExecutionEngine",
+                  "module": "Target",
                   "threadId": 52,
-                  "fullyQualifiedLogicalName": "ExecutionEngine.Engine.EvaluateRule",
-                  "logicalLocationKey": "ExecutionEngine.Engine.TestTarget",
+                  "fullyQualifiedLogicalName": "Ambiguous.Item",
+                  "logicalLocationKey": "SYNTHESIZED_KEY",
                   "uri": "file:///C:/src/testtarget.cs",
                   "address": 10073356,
                   "offset": 10475
@@ -60,15 +60,15 @@
         }
       ],
       "logicalLocations": {
-        "Rules.SecureHashAlgorithmRule.Evaluate": {
-          "name": "Evaluate",
+        "Ambiguous.Item": {
+          "name": "Item",
           "kind": "some kind"
         },
         "Rules.SecureHashAlgorithmRule.Register": {
-          "name": "InvalidName"
+          "name": "Register"
         },
-        "ExecutionEngine.Engine.TestTarget": {
-          "name": "TestTarget",
+        "SYNTHESIZED_KEY": {
+          "name": "Item",
           "kind": "another kind"
         }
       },

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
@@ -156,6 +156,22 @@
               "message": {
                 "text": "Another reference to \"count\" was declared here."
               }
+            },
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///home/buildAgent/src/collections/list_collision.cpp"
+                },
+                "region": {
+                  "startLine": 12,
+                  "endLine": 12
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "logicalLocationIndex": 3,
+              "message": {
+                "text": "This reference to \"collections::list\" is not relevant to the problem."
+              }
             }
           ],
           "suppressionStates": ["suppressedExternally"],

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
@@ -33,6 +33,7 @@
         {
           "name": "add",
           "fullyQualifiedName": "collections::list::add",
+          "decoratedName": "?add@list@collections@@QAEXH@Z",
           "parentIndex": 1,
           "kind": "function"
         }

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/BasicResult.sarif
@@ -27,6 +27,7 @@
         {
           "name": "list",
           "fullyQualifiedName": "collections::list",
+          "decoratedName": "?add@list@@_decorated_type_name",
           "parentIndex": 0,
           "kind": "type"
         },
@@ -36,9 +37,59 @@
           "decoratedName": "?add@list@collections@@QAEXH@Z",
           "parentIndex": 1,
           "kind": "function"
+        },
+        {
+          "name": "list",
+          "fullyQualifiedName": "collections::list",
+          "decoratedName": "?add@list@@_decorated_member_name",
+          "parentIndex": 0,
+          "kind": "member"
         }
       ],
       "results": [
+        {
+          "ruleId": "C2001",
+          "message": {
+            "messageId": "default",
+            "arguments": [
+              "collections::list"
+            ]
+          },
+          "analysisTarget": {
+            "uri": "file:///home/buildAgent/src/collections/list.cpp"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///home/buildAgent/src/collections/list.h"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 28,
+                  "byteLength": 27
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "logicalLocationIndex": 1
+            },
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///home/buildAgent/src/collections/list_collision.cpp"
+                },
+                "region": {
+                  "startLine": 12,
+                  "endLine": 12
+                }
+              },
+              "fullyQualifiedLogicalName": "collections::list",
+              "logicalLocationIndex": 3
+            }
+          ]
+        },
         {
           "ruleId": "C2001",
           "level": "error",
@@ -123,6 +174,15 @@
             },
             "messageStrings": {
               "default": "Variable \"{0}\" was used without being initialized."
+            }
+          },
+          "C2002": {
+            "id": "C2002",
+            "shortDescription": {
+              "text": "A potentially confusing naming collision exists."
+            },
+            "messageStrings": {
+              "default": "The fully qualified name \"{0}\" is shared between multiple constructs in this component, potentially compromising maintainability."
             }
           }
         }

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/NotificationExceptionWithStack.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/NotificationExceptionWithStack.sarif
@@ -38,6 +38,7 @@
                             "endColumn": 9
                           }
                         },
+                        "fullyQualifiedLogicalName": "Ambiguous.Item",
                         "logicalLocationIndex": 0,
                         "message": {
                           "text": "Exception thrown"
@@ -54,7 +55,8 @@
                             "uri": "file:///C:/src/main.cs"
                           }
                         },
-                        "logicalLocationIndex": 0
+                        "fullyQualifiedLogicalName": "Rules.SecureHashAlgorithmRule.Register",
+                        "logicalLocationIndex": 1
                       },
                       "module": "RuleLibrary",
                       "threadId": 52,
@@ -67,7 +69,7 @@
                             "uri": "file:///C:/src/utils.cs"
                           }
                         },
-                        "logicalLocationIndex": 0
+                        "fullyQualifiedLogicalName": "ExecutionEngine.Engine.EvaluateRule"
                       },
                       "module": "ExecutionEngine",
                       "threadId": 52,
@@ -81,10 +83,10 @@
                             "uri": "file:///C:/src/testtarget.cs"
                           }
                         },
-                        "fullyQualifiedLogicalName": "ExecutionEngine.Engine.TestTarget",
-                        "logicalLocationIndex": 0
+                        "fullyQualifiedLogicalName": "Ambiguous.Item",
+                        "logicalLocationIndex": 2
                       },
-                      "module": "ExecutionEngine",
+                      "module": "Target",
                       "threadId": 52,
                       "address": 10073356,
                       "offset": 10475
@@ -106,17 +108,17 @@
       ],
       "logicalLocations": [
         {
-          "name": "Evaluate",
-          "fullyQualifiedName": "Rules.SecureHashAlgorithmRule.Evaluate",
+          "name": "Item",
+          "fullyQualifiedName": "Ambiguous.Item",
           "kind": "some kind"
         },
         {
-          "name": "InvalidName",
+          "name": "Register",
           "fullyQualifiedName": "Rules.SecureHashAlgorithmRule.Register"
         },
         {
-          "name": "TestTarget",
-          "fullyQualifiedName": "ExecutionEngine.Engine.TestTarget",
+          "name": "Item",
+          "fullyQualifiedName": "Ambiguous.Item",
           "kind": "another kind"
         }
       ],

--- a/src/Sarif.UnitTests/Visitors/SarifVersionOneToCurrentVisitorTests.cs
+++ b/src/Sarif.UnitTests/Visitors/SarifVersionOneToCurrentVisitorTests.cs
@@ -16,6 +16,12 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Transformers
 {
     public class SarifVersionOneToCurrentVisitorTests : FileDiffingTests
     {
+        // IMPORTANT: set this static member to true and rerun tests in order to reset all baselines. The test
+        // are constructed to automatically fail when baselining, to prevent this property from being mistakenly
+        // checked in as 'true'. When rebaselining, be sure to scrutinize baseline file deltas carefully to
+        // ensure any modifications are correct.
+        private static bool s_Rebaseline = true;
+
         public SarifVersionOneToCurrentVisitorTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 
         private static SarifLogVersionOne GetSarifLogVersionOne(string logText)
@@ -38,8 +44,6 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Transformers
             string v2LogText = JsonConvert.SerializeObject(v2Log, SarifTransformerUtilities.JsonSettingsIndented);
             v2LogText.Should().Be(v2LogExpectedText);
         }
-
-        private static bool s_Rebaseline = false;
 
         private void VerifyVersionOneToCurrentTransformationFromResource(string v1InputResourceName, string v2ExpectedResourceName = null)
         {

--- a/src/Sarif.UnitTests/Visitors/SarifVersionOneToCurrentVisitorTests.cs
+++ b/src/Sarif.UnitTests/Visitors/SarifVersionOneToCurrentVisitorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Transformers
         // are constructed to automatically fail when baselining, to prevent this property from being mistakenly
         // checked in as 'true'. When rebaselining, be sure to scrutinize baseline file deltas carefully to
         // ensure any modifications are correct.
-        private static bool s_Rebaseline = true;
+        private static bool s_Rebaseline = false;
 
         public SarifVersionOneToCurrentVisitorTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
 

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             Location location = null;
 
             if (v1AnnotatedCodeLocation != null)
-            {
+            {                
                 location = new Location
                 {
                     Annotations = v1AnnotatedCodeLocation.Annotations?.SelectMany(a => a.Locations,
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                                                                                                          a.Message))
                                                                       .Where(r => r != null)
                                                                       .ToList(),
-                    FullyQualifiedLogicalName = v1AnnotatedCodeLocation.LogicalLocationKey ?? v1AnnotatedCodeLocation.FullyQualifiedLogicalName,
+                    FullyQualifiedLogicalName = v1AnnotatedCodeLocation.FullyQualifiedLogicalName,
                     Message = CreateMessage(v1AnnotatedCodeLocation.Message),
                     PhysicalLocation = CreatePhysicalLocation(v1AnnotatedCodeLocation.PhysicalLocation),
                     Properties = v1AnnotatedCodeLocation.Properties

--- a/src/Sarif/Visitors/VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor.cs
+++ b/src/Sarif/Visitors/VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor.cs
@@ -12,14 +12,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     /// which is used to disambiguate logical locations in the result.logicalLocations dictionary that have a 
     /// common fully qualified name (but which are different types), the visitor creates a mapping between
     /// the logical location key and its associated fully qualified name. This allows the v2 transformation
-    /// in particular to more easily populate its logical location equivalents.
+    /// in particular to more easily populate its logical location equivalents. Additionally, the visitor 
+    /// stores a mapping from fully qualified name to decorated name, if one exists. These data (the
+    /// decorated name and fully qualified name) moved from the location object to the logical location
+    /// object in v2.
     /// </summary>
     public class VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor : SarifRewritingVisitorVersionOne
     {
         public VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor()
         {
+            FullyQualifiedNameToDecoratedNameMap = new Dictionary<string, string>();
             LogicalLocationKeyToFullyQualifiedNameMap = new Dictionary<string, string>();
         }
+        public IDictionary<string, string> FullyQualifiedNameToDecoratedNameMap { get; set; }
 
         public IDictionary<string, string> LogicalLocationKeyToFullyQualifiedNameMap { get; set; }
 
@@ -30,6 +35,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 !node.FullyQualifiedLogicalName.Equals(node.LogicalLocationKey))
             {
                 LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
+            }
+
+            if (!string.IsNullOrEmpty(node.DecoratedName))
+            {
+                string fullyQualifiedName = node.FullyQualifiedLogicalName ?? node.LogicalLocationKey;
+                FullyQualifiedNameToDecoratedNameMap[fullyQualifiedName] = node.DecoratedName;
             }
 
             return base.VisitLocationVersionOne(node);
@@ -44,6 +55,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
             }
 
+            // v1 stack frame does not reference a decorated name
+
             return base.VisitStackFrameVersionOne(node);
         }
 
@@ -55,6 +68,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
             }
+
+            // v1 stack frame does not reference a decorated name
 
             return base.VisitAnnotatedCodeLocationVersionOne(node);
         }

--- a/src/Sarif/Visitors/VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor.cs
+++ b/src/Sarif/Visitors/VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT        
+// license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Sarif.VersionOne;
+
+namespace Microsoft.CodeAnalysis.Sarif.Visitors
+{
+    /// <summary>
+    /// This class visits all locations in a SARIF v1 log file. On observing use of result.logicalLocationKey,
+    /// which is used to disambiguate logical locations in the result.logicalLocations dictionary that have a 
+    /// common fully qualified name (but which are different types), the visitor creates a mapping between
+    /// the logical location key and its associated fully qualified name. This allows the v2 transformation
+    /// in particular to more easily populate its logical location equivalents.
+    /// </summary>
+    public class VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor : SarifRewritingVisitorVersionOne
+    {
+        public VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor()
+        {
+            LogicalLocationKeyToFullyQualifiedNameMap = new Dictionary<string, string>();
+        }
+
+        public IDictionary<string, string> LogicalLocationKeyToFullyQualifiedNameMap { get; set; }
+
+        public override LocationVersionOne VisitLocationVersionOne(LocationVersionOne node)
+        {
+            if (!string.IsNullOrEmpty(node.LogicalLocationKey) &&
+                !string.IsNullOrEmpty(node.FullyQualifiedLogicalName) &&
+                !node.FullyQualifiedLogicalName.Equals(node.LogicalLocationKey))
+            {
+                LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
+            }
+
+            return base.VisitLocationVersionOne(node);
+        }
+
+        public override StackFrameVersionOne VisitStackFrameVersionOne(StackFrameVersionOne node)
+        {
+            if (!string.IsNullOrEmpty(node.LogicalLocationKey) &&
+                !string.IsNullOrEmpty(node.FullyQualifiedLogicalName) &&
+                !node.FullyQualifiedLogicalName.Equals(node.LogicalLocationKey))
+            {
+                LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
+            }
+
+            return base.VisitStackFrameVersionOne(node);
+        }
+
+        public override AnnotatedCodeLocationVersionOne VisitAnnotatedCodeLocationVersionOne(AnnotatedCodeLocationVersionOne node)
+        {
+            if (!string.IsNullOrEmpty(node.LogicalLocationKey) &&
+                !string.IsNullOrEmpty(node.FullyQualifiedLogicalName) &&
+                !node.FullyQualifiedLogicalName.Equals(node.LogicalLocationKey))
+            {
+                LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
+            }
+
+            return base.VisitAnnotatedCodeLocationVersionOne(node);
+        }
+    }
+}

--- a/src/Sarif/Visitors/VersionOneLogicalLocationKeyToLogicalLocationDataVisitor.cs
+++ b/src/Sarif/Visitors/VersionOneLogicalLocationKeyToLogicalLocationDataVisitor.cs
@@ -13,20 +13,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     /// common fully qualified name (but which are different types), the visitor creates a mapping between
     /// the logical location key and its associated fully qualified name. This allows the v2 transformation
     /// in particular to more easily populate its logical location equivalents. Additionally, the visitor 
-    /// stores a mapping from fully qualified name to decorated name, if one exists. These data (the
+    /// stores a mapping from logical location key to decorated name, if one exists. These data (the
     /// decorated name and fully qualified name) moved from the location object to the logical location
     /// object in v2.
     /// </summary>
-    public class VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor : SarifRewritingVisitorVersionOne
+    public class VersionOneLogicalLocationKeyToLogicalLocationDataVisitor : SarifRewritingVisitorVersionOne
     {
-        public VersionOneLogicalLocationKeyToFullyQualifiedNameMappingVisitor()
+        public VersionOneLogicalLocationKeyToLogicalLocationDataVisitor()
         {
-            FullyQualifiedNameToDecoratedNameMap = new Dictionary<string, string>();
+            LogicalLocationKeyToDecoratedNameMap = new Dictionary<string, string>();
             LogicalLocationKeyToFullyQualifiedNameMap = new Dictionary<string, string>();
         }
-        public IDictionary<string, string> FullyQualifiedNameToDecoratedNameMap { get; set; }
+        public IDictionary<string, string> LogicalLocationKeyToDecoratedNameMap { get; }
 
-        public IDictionary<string, string> LogicalLocationKeyToFullyQualifiedNameMap { get; set; }
+        public IDictionary<string, string> LogicalLocationKeyToFullyQualifiedNameMap { get; }
 
         public override LocationVersionOne VisitLocationVersionOne(LocationVersionOne node)
         {
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             if (!string.IsNullOrEmpty(node.DecoratedName))
             {
-                string fullyQualifiedName = node.FullyQualifiedLogicalName ?? node.LogicalLocationKey;
-                FullyQualifiedNameToDecoratedNameMap[fullyQualifiedName] = node.DecoratedName;
+                string key = node.LogicalLocationKey ?? node.FullyQualifiedLogicalName;
+                LogicalLocationKeyToDecoratedNameMap[key] = node.DecoratedName;
             }
 
             return base.VisitLocationVersionOne(node);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 LogicalLocationKeyToFullyQualifiedNameMap[node.LogicalLocationKey] = node.FullyQualifiedLogicalName;
             }
 
-            // v1 stack frame does not reference a decorated name
+            // v1 annotated code location does not reference a decorated name
 
             return base.VisitAnnotatedCodeLocationVersionOne(node);
         }

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 // location that happened to be enumerated after one of its children
                 if (fullyQualifiedLogicalNameToIndexMap.ContainsKey(logicalLocationEntry.Name)) { continue; }
 
-                fullyQualifiedLogicalNameToIndexMap = CreateLogicalLocationArrayEntry(
+                AddEntryToFullyQualifiedNameToIndexMap(
                     logicalLocations,
                     logicalLocationEntry.Name, 
                     (JObject)logicalLocationEntry.Value,
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             return new JArray(updatedArrayElements);
         }
 
-        private static Dictionary<string, int> CreateLogicalLocationArrayEntry(
+        private static void AddEntryToFullyQualifiedNameToIndexMap(
             JObject logicalLocationsDictionary,
             string keyName,
             JObject logicalLocation,
@@ -258,7 +258,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             Dictionary<JObject, int> jObjectToIndexMap,
             Dictionary<string, int> keyToIndexMap)
         {
-            keyToIndexMap = keyToIndexMap ?? new Dictionary<string, int>();
+            if (keyToIndexMap == null)
+            {
+                throw new ArgumentNullException(nameof(keyToIndexMap));
+            }
+
+            if (logicalLocation == null)
+            {
+                throw new ArgumentNullException(nameof(logicalLocation));
+            }
 
             string fullyQualifiedName = keyName;
 
@@ -280,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     // determine its index in our array. This code path results in 
                     // an array order that does not precisely match the enumeration
                     // order of the logical locations dictionary.
-                    keyToIndexMap = CreateLogicalLocationArrayEntry(
+                    AddEntryToFullyQualifiedNameToIndexMap(
                         logicalLocationsDictionary,
                         parentKey,
                         (JObject)logicalLocationsDictionary[parentKey],
@@ -319,8 +327,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 jObjectToIndexMap[logicalLocation] = index;
                 keyToIndexMap[fullyQualifiedName] = index;
             }
-
-            return keyToIndexMap;
         }
 
         private static bool RemapRuleDefaultLevelFromOpenToNote(JObject resources)


### PR DESCRIPTION
Resolves:

#1183: In which we didn't set -1 properly as logical location index in case of absent logical location. This code also mishandled flowing the v1 location.decoratedName to v1 logicalLocation.decoratedName

#1182: The definitive fully qualified name for a v1 result refers to location.fullyQualifiedName first then, if absent, consults location.logicalLocationKey. The definitive logical location dictionary key reverses this process. 

#1179: In which we failed to set logical location index properly for constructed stack frames (one of three v1 constructs, along with locations and annotated locations, that reference logical locations).

@lgolding 
