### PR TITLE
Fix v1->v2 hash transformation

### DIFF
--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/OneRunWithFiles.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v1/OneRunWithFiles.sarif
@@ -12,6 +12,10 @@
             {
               "algorithm": "sha256",
               "value": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+            },
+            {
+              "algorithm": "md5",
+              "value": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
             }
           ]
         },

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/OneRunWithFiles.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/v2/OneRunWithFiles.sarif
@@ -18,6 +18,10 @@
             {
               "value": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
               "algorithm": "sha-256"
+            },
+            {
+              "value": "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+              "algorithm": "md5"
             }
           ]
         },

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 fileData = new FileData
                 {
-                    Hashes = BuildHashesDictionary(v1FileData.Hashes),
+                    Hashes = v1FileData.Hashes?.Select(CreateHash).ToDictionary(p => p.Key, p => p.Value),
                     Length = v1FileData.Length,
                     MimeType = v1FileData.MimeType,
                     Offset = v1FileData.Offset,
@@ -198,20 +198,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             }
 
             return fileData;
-        }
-
-        private IDictionary<string, string> BuildHashesDictionary(IList<HashVersionOne> hashes)
-        {
-            if (hashes == null) { return null; }
-
-            var v2Hashes = new Dictionary<string, string>();
-
-            foreach (HashVersionOne v1Hash in hashes)
-            {
-                v2Hashes[Utilities.AlgorithmKindNameMap[v1Hash.Algorithm]] = v1Hash.Value;
-            }
-
-            return v2Hashes;
         }
 
         internal FileLocation CreateFileLocation(Uri uri, string uriBaseId)


### PR DESCRIPTION
CreateHash must be called to handle algorithm names that aren't in our translation table. Also updated a unit test to cover this case.