### PR TITLE
Restore MakeUrisAbsoluteVisitor tests

### DIFF
--- a/src/Sarif.UnitTests/Visitors/MakeUriAbsoluteVisitorTest.cs
+++ b/src/Sarif.UnitTests/Visitors/MakeUriAbsoluteVisitorTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 {
     public class MakeUriAbsoluteVisitorTest
     {
-        private Run GenerateRunForTest(Dictionary<string, Uri> uriBaseIdMapping)
+        private Run GenerateRunForTest(Dictionary<string, FileLocation> uriBaseIdMapping)
         {
             Run run = new Run();
             run.Files = new List<FileData>(new[]
@@ -19,18 +19,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/file1.cs", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 0 } },
                 new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/file2.dll", UriKind.Relative), UriBaseId="%TEST2%", FileIndex = 1 } },
                 new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/archive.zip", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 2 } },
-                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/archive.zip#file3.cs", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 3 } },
-                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/archive.zip#archive2.gz", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 4 } },
-                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/archive.zip#archive2.gz/file4.cs", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 5 }, },
-                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("src/archive.zip#file5.cs", UriKind.Relative), UriBaseId="%TEST1%", FileIndex = 6 },  }
+                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("file3.cs", UriKind.Relative), FileIndex = 3 }, ParentIndex = 2 },
+                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("archive2.gz", UriKind.Relative), FileIndex = 4 }, ParentIndex = 2 },
+                new FileData() { FileLocation=new FileLocation{ Uri=new Uri("file4.cs", UriKind.Relative), FileIndex = 5 }, ParentIndex = 4 },
             });
 
             if (uriBaseIdMapping != null)
             {
                 run.Properties = new Dictionary<string, SerializedPropertyInfo>();
-
                 run.Properties[RebaseUriVisitor.BaseUriDictionaryName] = RebaseUriVisitor.ReserializePropertyDictionary(uriBaseIdMapping);
             }
+
+            run.OriginalUriBaseIds = uriBaseIdMapping;
             return run;
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     ["%TEST%"] = new FileLocation { Uri = new Uri("C:/github/sarif/") }
                 }
             };
-            
+
             // Initializes visitor with run in order to retrieve uri base id mappings
             MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
             visitor.VisitRun(run);
@@ -103,79 +103,117 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void MakeUriAbsoluteVisitor_VisitRun_SetsAbsoluteUriForAllApplicableFiles()
         {
-            Run run = GenerateRunForTest(new Dictionary<string, Uri>()
+            Run run = GenerateRunForTest(new Dictionary<string, FileLocation>()
             {
-                { "%TEST1%", new Uri(@"C:\srcroot\") },
-                { "%TEST2%", new Uri(@"D:\bld\out\") }
+                ["%TEST1%"] = new FileLocation { Uri = new Uri(@"C:\srcroot\") },
+                ["%TEST2%"] = new FileLocation { Uri = new Uri(@"D:\bld\out\") }
             });
-            
+
             MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
 
             var newRun = visitor.VisitRun(run);
+
             // Validate.
-            newRun.Files[0].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/file1.cs");
-            newRun.Files[1].FileLocation.Uri.ToString().Should().Be(@"file://D:/bld/out/src/file2.dll");
-            newRun.Files[2].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/archive.zip");
-            newRun.Files[3].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/archive.zip#file3.cs");
-            newRun.Files[4].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/archive.zip#archive2.gz");
-            newRun.Files[5].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/archive.zip#archive2.gz/file4.cs");
-            newRun.Files[6].FileLocation.Uri.ToString().Should().Be(@"file://C:/srcroot/src/archive.zip#file5.cs");
+            newRun.Files[0].FileLocation.Uri.ToString().Should().Be(@"file:///C:/srcroot/src/file1.cs");
+            newRun.Files[1].FileLocation.Uri.ToString().Should().Be(@"file:///D:/bld/out/src/file2.dll");
+            newRun.Files[2].FileLocation.Uri.ToString().Should().Be(@"file:///C:/srcroot/src/archive.zip");
+            newRun.Files[3].FileLocation.Uri.ToString().Should().Be(@"file3.cs");
+            newRun.Files[4].FileLocation.Uri.ToString().Should().Be(@"archive2.gz");
+            newRun.Files[5].FileLocation.Uri.ToString().Should().Be(@"file4.cs");
 
             // Operation should zap all uri base ids
-            newRun.Files.Select(f => f.FileLocation.UriBaseId != null).Any().Should().BeFalse();
+            newRun.Files.Where(f => f.FileLocation.UriBaseId != null).Any().Should().BeFalse();
         }
 
         [Fact]
         public void MakeUriAbsoluteVisitor_VisitRun_DoesNotSetAbsoluteUriIfNotApplicable()
         {
-            Dictionary<string, Uri> uriMapping = new Dictionary<string, Uri>()
+            Dictionary<string, FileLocation> uriMapping = new Dictionary<string, FileLocation>()
             {
-                { "%TEST3%", new Uri(@"C:\srcroot\") },
-                { "%TEST4%", new Uri(@"D:\bld\out\") },
+                ["%TEST3%"] = new FileLocation { Uri = new Uri(@"C:\srcroot\") },
+                ["%TEST4%"] = new FileLocation { Uri = new Uri(@"D:\bld\out\") }
             };
 
             Run expectedRun = GenerateRunForTest(uriMapping);
             Run actualRun = expectedRun.DeepClone();
 
-
             MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
             var newRun = visitor.VisitRun(actualRun);
 
-            expectedRun.Should().Be(actualRun);
-        }
-
-        [Fact]
-        public void MakeUriAbsoluteVisitor_VisitRun_ThrowsIfPropertiesAreWrong()
-        {
-            Run run = GenerateRunForTest(null);
-            run.Properties = new Dictionary<string, SerializedPropertyInfo>();
-            run.Properties[RebaseUriVisitor.BaseUriDictionaryName] = new SerializedPropertyInfo("\"this is a string\"", true);
-            
-            MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
-            Assert.Throws<InvalidOperationException>(()=> visitor.VisitRun(run));
+            expectedRun.ValueEquals(actualRun).Should().BeTrue();
         }
 
         [Fact]
         public void MakeUriAbsoluteVisitor_VisitSarifLog_MultipleRunsWithDifferentProperties_RebasesProperly()
         {
-            Run runA = GenerateRunForTest(new Dictionary<string, Uri>()
+            Run runA = GenerateRunForTest(new Dictionary<string, FileLocation>()
             {
-                { "%TEST1%", new Uri(@"C:\srcroot\") },
-                { "%TEST2%", new Uri(@"D:\bld\out\") },
+                ["%TEST1%"] = new FileLocation { Uri = new Uri(@"C:\srcroot\") },
+                ["%TEST2%"] = new FileLocation { Uri = new Uri(@"D:\bld\out\") }
             });
-            Run runB = GenerateRunForTest(new Dictionary<string, Uri>()
+            Run runB = GenerateRunForTest(new Dictionary<string, FileLocation>()
             {
-                { "%TEST1%", new Uri(@"C:\src\abc") },
-                { "%TEST2%", new Uri(@"D:\bld\123\") },
+                ["%TEST1%"] = new FileLocation { Uri = new Uri(@"C:\src\abc\") },
+                ["%TEST2%"] = new FileLocation { Uri = new Uri(@"D:\bld\123\") }
             });
             MakeUrisAbsoluteVisitor visitor = new MakeUrisAbsoluteVisitor();
 
-            SarifLog log = new SarifLog() { Runs=new Run[] { runA, runB } };
+            SarifLog log = new SarifLog() { Runs = new Run[] { runA, runB } };
             SarifLog newLog = visitor.VisitSarifLog(log);
 
             // Validate
             newLog.Runs.Should().HaveCount(2);
             newLog.Runs[0].Files.Should().NotIntersectWith(newLog.Runs[1].Files);
+        }
+
+        [Fact]
+        public void MakeUriAbsoluteVisitor_CombineUriFunctionsProperly()
+        {
+            var testCases = new Tuple<string, string, string>[]
+            {
+                new Tuple<string, string, string>
+                    (@"https://base/", @"relative/file.cpp",  "https://base/relative/file.cpp")
+            };
+
+            foreach (Tuple<string, string, string> testCase in testCases)
+            {
+                MakeUrisAbsoluteVisitor.CombineUris(
+                    absoluteBaseUri: new Uri(testCase.Item1, UriKind.Absolute),
+                    relativeUri: new Uri(testCase.Item2, UriKind.Relative))
+                        .Should().Be(testCase.Item3);
+            }
+        }
+
+        [Fact]
+        public void MakeUriAbsoluteVisitor_CombineUriValidatesArgumentsProperly()
+        {
+            Uri absoluteUri = new Uri("https://absolute.example.com", UriKind.Absolute);
+            Uri relativeUri = new Uri("relative/someResource", UriKind.Relative);
+
+            // First, ensure that our test data succeeds when used properly
+            MakeUrisAbsoluteVisitor.CombineUris(
+                absoluteBaseUri: absoluteUri,
+                relativeUri: relativeUri);
+            
+            // Pass relative uri where absolute expected
+            var action = new Action(() => 
+                {
+                    MakeUrisAbsoluteVisitor.CombineUris(
+                        absoluteBaseUri: relativeUri,
+                        relativeUri: relativeUri);
+                });
+
+            action.Should().Throw<ArgumentException>();
+
+            // Pass absolute uri where relative expected
+            action = new Action(() =>
+            {
+                MakeUrisAbsoluteVisitor.CombineUris(
+                    absoluteBaseUri: absoluteUri,
+                    relativeUri: absoluteUri);
+            });
+
+            action.Should().Throw<ArgumentException>();
         }
     }
 }

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -19,7 +19,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public Uri GetExpandedUriBaseIdValue(string key, string currentValue = null)
         {
-            throw new InvalidOperationException("Author this code along with tests");
+            FileLocation fileLocation = this.OriginalUriBaseIds[key];
+
+            if (fileLocation.UriBaseId == null)
+            {
+                return fileLocation.Uri;
+            }
+            throw new InvalidOperationException("Author this code along with tests for originalUriBaseIds that are nested");
         }
 
         public int GetFileIndex(

--- a/src/Sarif/Visitors/MakeUrisAbsoluteVisitor.cs
+++ b/src/Sarif/Visitors/MakeUrisAbsoluteVisitor.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
             if ( _run.OriginalUriBaseIds!= null &&
                 !string.IsNullOrEmpty(node?.UriBaseId) &&
-                _run.OriginalUriBaseIds.ContainsKey(node.UriBaseId))
+                _run.OriginalUriBaseIds.ContainsKey(node.UriBaseId) && 
+                !_run.OriginalUriBaseIds.Values.Contains(node))
             {
                 Uri baseUri = _run.GetExpandedUriBaseIdValue(node.UriBaseId);
                 node.Uri = CombineUris(baseUri, node.Uri);
@@ -29,9 +30,22 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             return node;
         }
 
-        private Uri CombineUris(Uri baseUri, Uri uri)
+        internal static Uri CombineUris(Uri absoluteBaseUri, Uri relativeUri)
         {
-            throw new NotImplementedException();
+            if (!absoluteBaseUri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("absoluteBaseUri is not an absolute Uri", nameof(absoluteBaseUri));
+            }
+
+            if (relativeUri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("relativeUri is not a relative Uri", nameof(relativeUri));
+            }
+
+            Uri test = new Uri("src/archive.zip#archive2.gz", UriKind.Relative);
+
+            Uri result =  new Uri(absoluteBaseUri, relativeUri);
+            return result;
         }
     }
 }

--- a/src/Sarif/Visitors/RebaseUriVisitor.cs
+++ b/src/Sarif/Visitors/RebaseUriVisitor.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         /// <summary>
         /// Internal as used in testing as a helper.
         /// </summary>
-        internal static SerializedPropertyInfo ReserializePropertyDictionary(Dictionary<string, Uri> dictionary)
+        internal static SerializedPropertyInfo ReserializePropertyDictionary(Dictionary<string, FileLocation> dictionary)
         {
             return new SerializedPropertyInfo(JsonConvert.SerializeObject(dictionary), false);
         }


### PR DESCRIPTION
@lgolding (accidentally opened previous PR against develop. I note you did the same yesterday. I have therefore temporarily set the default branch to 'files-array'. )

This change updates the visitor that expands uriBaseIds in the presence of originalUriBaseIds. Turns out there was technical debt here, because out tests provides originalUriBaseId equivalents in the property bag (because we had no official SARIF slot for them). I did not notice this gap when we made the schema change to add originalUriBaseIds.

There are some confusing things in this change I can't account for currently. I've flagged them for research. Maybe you understand what's happening off the top of your head. Commenting now...