### PR TITLE
Notification rule index

### DIFF
--- a/src/Sarif.UnitTests/Visitors/InsertOptionalDataVisitorTests.cs
+++ b/src/Sarif.UnitTests/Visitors/InsertOptionalDataVisitorTests.cs
@@ -110,101 +110,241 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 OptionallyEmittedData.FlattenedMessages);
         }
 
-        [Fact]
-        public void InsertOptionalDataVisitorTests_FlattensGlobalMessageString()
-        {
-            string ruleId = nameof(ruleId);
-            string globalMessageId = nameof(globalMessageId);
-            string globalMessageValue = nameof(globalMessageValue);
+        private const int RuleIndex = 0;
+        private const string RuleId = nameof(RuleId);
+        private const string NotificationId = nameof(NotificationId);
 
+        private const string SharedMessageId = nameof(SharedMessageId);
+        private const string SharedKeyRuleMessageValue = nameof(SharedKeyRuleMessageValue);
+        private const string SharedKeyGlobalMessageValue = nameof(UniqueGlobalMessageValue);
+
+        private const string UniqueRuleMessageId = nameof(UniqueRuleMessageId);
+        private const string UniqueRuleMessageValue = nameof(UniqueRuleMessageValue);
+
+        private const string UniqueGlobalMessageId = nameof(UniqueGlobalMessageId);
+        private const string UniqueGlobalMessageValue = nameof(UniqueGlobalMessageValue);
+
+        private static Run CreateBasicRunForMessageStringLookupTesting()
+        {
+            // Returns a run object that defines unique string instances both
+            // for an individual rule and in the global strings object. Also
+            // defines values for a key that is shared between the rule object
+            // and the global table. Used for evaluating string look-up semantics.
             var run = new Run
             {
-                Results = new List<Result>
-                {
-                    new Result
-                    {
-                        RuleId = ruleId,
-                        RuleIndex = 0,
-                        Message = new Message
-                        {
-                             MessageId = globalMessageId
-                        }
-                    }
-                },
+                Results = new List<Result> { }, // add non-null collections for convenience
+                Invocations = new List<Invocation> { new Invocation { } },
                 Resources = new Resources
                 {
                     MessageStrings = new Dictionary<string, string>
                     {
-                        [globalMessageId] = globalMessageValue
+                        [UniqueGlobalMessageId] = UniqueGlobalMessageValue,
+                        [SharedMessageId] = SharedKeyGlobalMessageValue
                     },
                     Rules = new List<Rule>
                     {
                         new Rule
                         {
-                            Id = ruleId
+                            Id = RuleId,
+                            MessageStrings = new Dictionary<string, string>
+                            {
+                                [UniqueRuleMessageId] = UniqueRuleMessageValue,
+                                [SharedMessageId] = SharedKeyRuleMessageValue
+                            }
                         }
                     }
                 }
             };
 
+            run.Invocations[0].ToolNotifications = new List<Notification>();
+            run.Invocations[0].ConfigurationNotifications = new List<Notification>();
+
+            return run;
+        }
+
+        [Fact]
+        public void InsertOptionalDataVisitorTests_FlattensMessageStringsInResult()
+        {
+            Run run = CreateBasicRunForMessageStringLookupTesting();
+
+            run.Results.Add(
+                new Result
+                {
+                    RuleId = RuleId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message
+                    {
+                        MessageId = UniqueGlobalMessageId
+                    }
+                });
+
+            run.Results.Add(
+                new Result
+                {
+                    RuleId = RuleId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message
+                    {
+                        MessageId = UniqueRuleMessageId
+                    }
+                });
+
+
+            run.Results.Add(
+                new Result
+                {
+                    RuleId = RuleId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message
+                    {
+                        MessageId = SharedMessageId
+                    }
+                });
+
+
             var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
             visitor.Visit(run);
 
-            run.Results[0].Message.Text.Should().Be(globalMessageValue);
+            run.Results[0].Message.Text.Should().Be(UniqueGlobalMessageValue);
+            run.Results[1].Message.Text.Should().Be(UniqueRuleMessageValue);
+
+            // Prefer rule-specific value in the event of a message id collision
+            run.Results[2].Message.Text.Should().Be(SharedKeyRuleMessageValue);
+        }
+
+        [Fact]
+        public void InsertOptionalDataVisitorTests_FlattensMessageStringsInNotification()
+        {
+            Run run = CreateBasicRunForMessageStringLookupTesting();
+
+            IList<Notification> toolNotifications = run.Invocations[0].ToolNotifications;
+            IList<Notification> configurationNotifications = run.Invocations[0].ConfigurationNotifications;
+
+            // Shared message id with no overriding rule id
+            toolNotifications.Add(
+                new Notification
+                {
+                    Id = NotificationId,
+                    Message = new Message {  MessageId = SharedMessageId}
+                });
+            configurationNotifications.Add(toolNotifications[0]);
+
+            // Shared message id with an overriding rule id
+            run.Invocations[0].ToolNotifications.Add(
+                new Notification
+                {
+                    Id = NotificationId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message { MessageId = SharedMessageId }
+                });
+            configurationNotifications.Add(toolNotifications[1]);
+
+            run.Invocations[0].ToolNotifications.Add(
+                new Notification
+                {
+                    Id = NotificationId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message { MessageId = UniqueGlobalMessageId }
+                });
+            configurationNotifications.Add(toolNotifications[2]);
+
+            run.Invocations[0].ToolNotifications.Add(
+                new Notification
+                {
+                    Id = NotificationId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message { MessageId = UniqueRuleMessageId }
+                });
+            configurationNotifications.Add(toolNotifications[3]);
+
+
+            var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
+            visitor.Visit(run);
+
+            toolNotifications[0].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
+            configurationNotifications[0].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
+
+            toolNotifications[1].Message.Text.Should().Be(SharedKeyRuleMessageValue);
+            configurationNotifications[1].Message.Text.Should().Be(SharedKeyRuleMessageValue);
+
+            toolNotifications[2].Message.Text.Should().Be(UniqueGlobalMessageValue);
+            configurationNotifications[2].Message.Text.Should().Be(UniqueGlobalMessageValue);
+
+            toolNotifications[3].Message.Text.Should().Be(UniqueRuleMessageValue);
+            configurationNotifications[3].Message.Text.Should().Be(UniqueRuleMessageValue);
         }
 
 
         [Fact]
-        public void InsertOptionalDataVisitorTests_FlattensFixMessage()
+        public void InsertOptionalDataVisitorTests_FlattensMessageStringsInFix()
         {
-            string ruleId = nameof(ruleId);
-            string globalMessageId = nameof(globalMessageId);
-            string globalMessageValue = nameof(globalMessageValue);
+            Run run = CreateBasicRunForMessageStringLookupTesting();
 
-            var run = new Run
-            {
-                Results = new List<Result>
+            run.Results.Add(
+                new Result
                 {
-                    new Result
+                    RuleId = RuleId,
+                    RuleIndex = RuleIndex,
+                    Message = new Message
                     {
-                        RuleId = ruleId,
-                        RuleIndex = 0,
-                        Message = new Message
+                        Text = "Some testing occurred."
+                    },
+                    Fixes = new List<Fix>
+                    {
+                        new Fix
                         {
-                             Text = "Some testing occurred."
-                        },
-                        Fixes = new List<Fix>
-                        {
-                            new Fix
+                            Description = new Message
                             {
-                                Description = new Message
-                                {
-                                    MessageId = globalMessageId
-                                }
+                                MessageId = UniqueGlobalMessageId
+                            }
+                        },
+                        new Fix
+                        {
+                            Description = new Message
+                            {
+                                MessageId = UniqueRuleMessageId
+                            }
+                        },
+                        new Fix
+                        {
+                            Description = new Message
+                            {
+                                MessageId = SharedMessageId
                             }
                         }
                     }
-                },
-                Resources = new Resources
+                });
+            run.Results.Add(
+                new Result
                 {
-                    MessageStrings = new Dictionary<string, string>
+                    RuleId = "RuleWithNoRulesMetadata",
+                    Message = new Message
                     {
-                        [globalMessageId] = globalMessageValue
+                        Text = "Some testing occurred."
                     },
-                    Rules = new List<Rule>
+                    Fixes = new List<Fix>
                     {
-                        new Rule
+                        new Fix
                         {
-                            Id = ruleId
+                            Description = new Message
+                            {
+                                MessageId = SharedMessageId
+                            }
                         }
                     }
-                }
-            };
+                });
 
             var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
             visitor.Visit(run);
 
-            run.Results[0].Fixes[0].Description.Text.Should().Be(globalMessageValue);
+            run.Results[0].Fixes[0].Description.Text.Should().Be(UniqueGlobalMessageValue);
+            run.Results[0].Fixes[1].Description.Text.Should().Be(UniqueRuleMessageValue);
+
+            // Prefer rule-specific value in the event of a message id collision
+            run.Results[0].Fixes[2].Description.Text.Should().Be(SharedKeyRuleMessageValue);
+
+            // Prefer global value in the event of no rules metadata
+            run.Results[1].Fixes[0].Description.Text.Should().Be(SharedKeyGlobalMessageValue);
         }
 
         [Fact]

--- a/src/Sarif.UnitTests/Visitors/InsertOptionalDataVisitorTests.cs
+++ b/src/Sarif.UnitTests/Visitors/InsertOptionalDataVisitorTests.cs
@@ -229,8 +229,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 });
             configurationNotifications.Add(toolNotifications[0]);
 
-            // Shared message id with an overriding rule id
-            run.Invocations[0].ToolNotifications.Add(
+            // Shared message id with an overriding rule id. This message 
+            // should still be retrieved from the global strings table.
+            toolNotifications.Add(
                 new Notification
                 {
                     Id = NotificationId,
@@ -239,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 });
             configurationNotifications.Add(toolNotifications[1]);
 
-            run.Invocations[0].ToolNotifications.Add(
+            toolNotifications.Add(
                 new Notification
                 {
                     Id = NotificationId,
@@ -248,15 +249,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 });
             configurationNotifications.Add(toolNotifications[2]);
 
-            run.Invocations[0].ToolNotifications.Add(
-                new Notification
-                {
-                    Id = NotificationId,
-                    RuleIndex = RuleIndex,
-                    Message = new Message { MessageId = UniqueRuleMessageId }
-                });
-            configurationNotifications.Add(toolNotifications[3]);
-
 
             var visitor = new InsertOptionalDataVisitor(OptionallyEmittedData.FlattenedMessages);
             visitor.Visit(run);
@@ -264,14 +256,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             toolNotifications[0].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
             configurationNotifications[0].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
 
-            toolNotifications[1].Message.Text.Should().Be(SharedKeyRuleMessageValue);
-            configurationNotifications[1].Message.Text.Should().Be(SharedKeyRuleMessageValue);
+            toolNotifications[1].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
+            configurationNotifications[1].Message.Text.Should().Be(SharedKeyGlobalMessageValue);
 
             toolNotifications[2].Message.Text.Should().Be(UniqueGlobalMessageValue);
             configurationNotifications[2].Message.Text.Should().Be(UniqueGlobalMessageValue);
-
-            toolNotifications[3].Message.Text.Should().Be(UniqueRuleMessageValue);
-            configurationNotifications[3].Message.Text.Should().Be(UniqueRuleMessageValue);
         }
 
 

--- a/src/Sarif/Autogenerated/Notification.cs
+++ b/src/Sarif/Autogenerated/Notification.cs
@@ -47,6 +47,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string RuleId { get; set; }
 
         /// <summary>
+        /// The index within the run resources array of the rule object associated with this notification.
+        /// </summary>
+        [DataMember(Name = "ruleIndex", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(-1)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public int RuleIndex { get; set; }
+
+        /// <summary>
         /// The file and region relevant to this notification.
         /// </summary>
         [DataMember(Name = "physicalLocation", IsRequired = false, EmitDefaultValue = false)]
@@ -97,6 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         public Notification()
         {
+            RuleIndex = -1;
             Level = NotificationLevel.Warning;
         }
 
@@ -108,6 +117,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </param>
         /// <param name="ruleId">
         /// An initialization value for the <see cref="P:RuleId" /> property.
+        /// </param>
+        /// <param name="ruleIndex">
+        /// An initialization value for the <see cref="P:RuleIndex" /> property.
         /// </param>
         /// <param name="physicalLocation">
         /// An initialization value for the <see cref="P:PhysicalLocation" /> property.
@@ -130,9 +142,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Notification(string id, string ruleId, PhysicalLocation physicalLocation, Message message, NotificationLevel level, int threadId, DateTime timeUtc, ExceptionData exception, IDictionary<string, SerializedPropertyInfo> properties)
+        public Notification(string id, string ruleId, int ruleIndex, PhysicalLocation physicalLocation, Message message, NotificationLevel level, int threadId, DateTime timeUtc, ExceptionData exception, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(id, ruleId, physicalLocation, message, level, threadId, timeUtc, exception, properties);
+            Init(id, ruleId, ruleIndex, physicalLocation, message, level, threadId, timeUtc, exception, properties);
         }
 
         /// <summary>
@@ -151,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Id, other.RuleId, other.PhysicalLocation, other.Message, other.Level, other.ThreadId, other.TimeUtc, other.Exception, other.Properties);
+            Init(other.Id, other.RuleId, other.RuleIndex, other.PhysicalLocation, other.Message, other.Level, other.ThreadId, other.TimeUtc, other.Exception, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -172,10 +184,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Notification(this);
         }
 
-        private void Init(string id, string ruleId, PhysicalLocation physicalLocation, Message message, NotificationLevel level, int threadId, DateTime timeUtc, ExceptionData exception, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(string id, string ruleId, int ruleIndex, PhysicalLocation physicalLocation, Message message, NotificationLevel level, int threadId, DateTime timeUtc, ExceptionData exception, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Id = id;
             RuleId = ruleId;
+            RuleIndex = ruleIndex;
             if (physicalLocation != null)
             {
                 PhysicalLocation = new PhysicalLocation(physicalLocation);

--- a/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/NotificationEqualityComparer.cs
@@ -38,6 +38,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.RuleIndex != right.RuleIndex)
+            {
+                return false;
+            }
+
             if (!PhysicalLocation.ValueComparer.Equals(left.PhysicalLocation, right.PhysicalLocation))
             {
                 return false;
@@ -113,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     result = (result * 31) + obj.RuleId.GetHashCode();
                 }
 
+                result = (result * 31) + obj.RuleIndex.GetHashCode();
                 if (obj.PhysicalLocation != null)
                 {
                     result = (result * 31) + obj.PhysicalLocation.ValueGetHashCode();

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -1006,6 +1006,13 @@
           "type": "string"
         },
 
+        "ruleIndex": {
+          "description": "The index within the run resources array of the rule object associated with this notification.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
         "physicalLocation": {
           "description": "The file and region relevant to this notification.",
           "$ref": "#/definitions/physicalLocation"

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
             _dataToInsert = dataToInsert;
             _originalUriBaseIds = originalUriBaseIds;
+            _ruleIndex = -1;
         }
 
         public override Run VisitRun(Run node)
@@ -147,15 +148,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             }
 
             return base.VisitFileData(node);
-        }
-
-        public override Notification VisitNotification(Notification node)
-        {
-            _ruleIndex = node.RuleIndex;
-            node = base.VisitNotification(node);
-            _ruleIndex = -1;
-
-            return node;
         }
 
         public override Result VisitResult(Result node)

--- a/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/InsertOptionalDataVisitor.cs
@@ -149,6 +149,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             return base.VisitFileData(node);
         }
 
+        public override Notification VisitNotification(Notification node)
+        {
+            _ruleIndex = node.RuleIndex;
+            node = base.VisitNotification(node);
+            _ruleIndex = -1;
+
+            return node;
+        }
+
         public override Result VisitResult(Result node)
         {
             _ruleIndex = node.RuleIndex;


### PR DESCRIPTION
@lgolding  As discussed, notification messages pull purely from the global strings namespace in run.resources