### PR TITLE
Bring NuGet publishing up to Microsoft requirements.

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -4,13 +4,13 @@
     <id>Sarif.Multitool</id>
     <version>$version$</version>
     <title>Microsoft SARIF Multitool (includes SARIF SDK)</title>
-    <authors>microsoft</authors>
-    <owners>microsoft,tse-securitytools</owners>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Multi-purpose command line tool for analyzing and manipulating SARIF files</description>
     <releaseNotes>Version $version$ of the .NET SARIF Multitool (for SARIF v2.0.0)</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <licenseUrl>https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/microsoft/sarif-sdk</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=2008860</iconUrl>
     <tags>SARIF command line static analysis</tags>

--- a/src/build.props
+++ b/src/build.props
@@ -77,12 +77,13 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Authors Condition=" '$(Authors)' == '' ">$(Company)</Authors>
-    <Owners Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Owners>
+    <Authors>$(Company)</Authors>
+    <Title>$(AssemblyTitle)</Title>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl Condition=" '$(PackageLicenseUrl)' == '' ">https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl Condition=" '$(PackageProjectUrl)' == '' ">https://github.com/Microsoft/sarif-sdk</PackageProjectUrl>
     <PackageIconUrl Condition=" '$(PackageIconUrl)' == '' ">https://go.microsoft.com/fwlink/?linkid=2008860</PackageIconUrl>
+    <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR brings NuGet package creation in the `master` branch up to Microsoft standards. It is similar to what I did in JSchema a couple of months ago.

We need a new version of NuGet.exe to recognize the `<license type="expression">` tag in `Sarif.Multitool.nuspec`.

In `build.props`, I removed the `<Owners>` tag because the `dotnet package` command doesn't recognize it; it always sets `owners` to `authors`.