### PR TITLE
Fix #1255 Multitool payload signing

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -18,8 +18,19 @@
   <files>
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net461\**"
           target="tools\net461"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net461\Sarif*"
           />
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.0\**"
+          target="tools\netcoreapp2.0"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.0\Sarif*.dll"
+          />
+    <file src="bld\bin\Signing\net461\**"
+          target="tools\net461"
+          />
+    <file src="bld\bin\Signing\netcoreapp2.0\**"
+          target="tools\netcoreapp2.0"
+          />
+    <file src="bld\bin\Signing\netstandard2.0\**"
           target="tools\netcoreapp2.0"
           />
 

--- a/src/Sarif/Autogenerated/SarifLog.cs
+++ b/src/Sarif/Autogenerated/SarifLog.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta-2018-11-28 JSON Schema: a standard format for the output of static analysis tools.
+    /// Static Analysis Results Format (SARIF) Version 2.0.0-csd.2.beta-2019-01-09 JSON Schema: a standard format for the output of static analysis tools.
     /// </summary>
     [DataContract]
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "0.61.0.0")]


### PR DESCRIPTION
The SARIF assemblies that are being included in the Multitool nuget package are not the signed ones.