### PR TITLE
Transfer Bogdan's point fix (analysisTarget handling) from master to develop

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -198,10 +198,10 @@
 * API BREAKING CHANGE: Eliminate result.ruleMessageId (in favor of result.message.messageId)
 
 ## **v2.0.0-csd.1.0.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.1.0.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.1.0.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.1.0.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.1.0.2))
-* Bugfix to result matching algorithm where empty or null previous log sets caused a NullReferenceException.
-* Bugfix to result matching algorithm where we were incorrectly detecting duplicate data across files, and changed a "NotImplementedException" to the correct "InvalidOperationException".
+* BUGFIX: In result matching algorithm, an empty or null previous log no longer causes a NullReferenceException.
+* BUGFIX: In result matching algorithm, duplicate data is no longer incorrectly detected across files. Also: changed a "NotImplementedException" to the correct "InvalidOperationException".
 
-## **v2.0.0-csd.2.beta.2018.10.10** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018.10.10) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018.10.10) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018.10.10)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018.10.10))
+## **v2.0.0-csd.2.beta.2018-10-10** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10))
 * FEATURE:Add --sarif-version command to driver (to transform SARIF output to v1 format)
 * BUGFIX: Drop erroneous persistence of redaction tokens as files objects.
 * API NON-BREAKING: Add 'result.occurrenceCount' (denotes # of occurrences of an identical results within an analysisRun)
@@ -219,7 +219,10 @@
 * API BREAKING: Remove 'threadFlowLocation.step'
 * API BREAKING: 'invocation.workingDirectory' is now a FileLocation object (and not a URI expressed as a string)
 
-## **v2.0.0-csd.2.beta.2019.01.09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.01.09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.01.09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.01.09)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.01.09))
+## **v2.0.0-csd.2.beta.2018-10-10.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.1))
+* BUGFIX: Persist region information associated with analysis target
+
+## **v2.0.0-csd.2.beta.2019-01-09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019-01-09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019-01-09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019-01-09)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019-01-09))
 * BUGFIX: Result matching improvements in properties persistence.
 * FEATURE: Fortify FPR converter improvements.
 * API Non-BREAKING: Remove uniqueness requirement from 'result.locations'.
@@ -240,4 +243,3 @@
 * API BREAKING: Make 'run.files' an array, not a dictionary. Add fileLocation.fileIndex to point to a file object associated with the location within 'run.files'.
 * API BREAKING: Make 'resources.rules' an array, not a dictionary. Add result.ruleIndex to point to a rule object associated with the result within 'resources.rules'.
 * API BREAKING: 'run.logicalLocations' now requires unique array elements. https://github.com/oasis-tcs/sarif-spec/issues/304
-

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -223,6 +223,7 @@
 * BUGFIX: Persist region information associated with analysis target
 
 ## **v2.0.0-csd.2.beta.2018-10-10.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.2)
+* BUGFIX: Don't emit v2 analysisTarget if there is no v1 resultFile.
 * BUILD: Bring NuGet publishing scripts into conformance with new Microsoft requirements.
 
 ## **v2.0.0-csd.2.beta.2019-01-09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019-01-09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019-01-09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019-01-09) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019-01-09)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -219,10 +219,13 @@
 * API BREAKING: Remove 'threadFlowLocation.step'
 * API BREAKING: 'invocation.workingDirectory' is now a FileLocation object (and not a URI expressed as a string)
 
-## **v2.0.0-csd.2.beta.2018-10-10.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.1))
+## **v2.0.0-csd.2.beta.2018-10-10.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.1)
 * BUGFIX: Persist region information associated with analysis target
 
-## **v2.0.0-csd.2.beta.2019-01-09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019-01-09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019-01-09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019-01-09)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019-01-09))
+## **v2.0.0-csd.2.beta.2018-10-10.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.2)
+* BUILD: Bring NuGet publishing scripts into conformance with new Microsoft requirements.
+
+## **v2.0.0-csd.2.beta.2019-01-09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019-01-09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019-01-09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019-01-09) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019-01-09)
 * BUGFIX: Result matching improvements in properties persistence.
 * FEATURE: Fortify FPR converter improvements.
 * API Non-BREAKING: Remove uniqueness requirement from 'result.locations'.

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
@@ -48,6 +48,27 @@
       ],
       "results": [
         {
+          "ruleId": "C2005",
+          "message": {
+            "text": "Some testing occurred."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "fileLocation": {
+                  "uri": "file:///home/buildAgent/src/myFile.cpp"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 3,
+                  "endLine": 4,
+                  "endColumn": 5
+                }
+              }
+            }
+          ]
+        },
+        {
           "ruleId": "C2001",
           "message": {
             "messageId": "default",
@@ -174,7 +195,7 @@
               }
             }
           ],
-          "suppressionStates": ["suppressedExternally"],
+          "suppressionStates": [ "suppressedExternally" ],
           "baselineState": "existing"
         }
       ],

--- a/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/Inputs/BasicResult.sarif
+++ b/src/Sarif.UnitTests/TestData/SarifVersionOneToCurrentVisitor/Inputs/BasicResult.sarif
@@ -43,6 +43,23 @@
       },
       "results": [
         {
+          "ruleId": "C2005",
+          "message": "Some testing occurred.",
+          "locations": [
+            {
+              "analysisTarget": {
+                "uri": "file:///home/buildAgent/src/myFile.cpp",
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 3,
+                  "endLine": 4,
+                  "endColumn": 5
+                }
+              }
+            }
+          ]
+        },
+        {
           "ruleId": "C2001",
           "formattedRuleMessage": {
             "formatId": "default",

--- a/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
+++ b/src/Sarif/Visitors/SarifVersionOneToCurrentVisitor.cs
@@ -724,10 +724,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     SuppressionStates = Utilities.CreateSuppressionStates(v1Result.SuppressionStates)
                 };
 
-                // The spec says that analysisTarget is required only if it differs from the result file.
-                Uri analysisTargetUri = v1Result.Locations?[0]?.AnalysisTarget?.Uri;
-                Uri resultFileUri = v1Result.Locations?[0]?.ResultFile?.Uri;
-                if (analysisTargetUri != null && resultFileUri != null && analysisTargetUri != resultFileUri)
+                // The v2 spec says that analysisTarget is required only if it differs from the result location.
+                // On the other hand, the v1 spec says that if the result is found in the file that the tool
+                // was instructed to scan, then analysisTarget should be present and resultFile should be
+                // absent -- so we should _not_ populate the v2 analysisTarget in this case.
+                LocationVersionOne v1Location = v1Result.Locations?[0];
+                if (v1Location?.ResultFile != null && v1Location.AnalysisTarget?.Uri != v1Location.ResultFile.Uri)
                 {
                     result.AnalysisTarget = CreateFileLocation(v1Result.Locations[0].AnalysisTarget);
                 }

--- a/src/build.props
+++ b/src/build.props
@@ -23,7 +23,7 @@
     hides the previous package versions on nuget.org.
     -->
     <PreviousVersionPrefix>2.0.0</PreviousVersionPrefix>
-    <PreviousVersionSuffix>csd.1.0.3</PreviousVersionSuffix>
+    <PreviousVersionSuffix>csd.2.beta.2018-10-10.2</PreviousVersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
In preparation for merging `develop` to `master` for the publication of version 2019-01-09 (TC <span>#</span>30), we apply the recent changes in `master` to the `develop` branch. These changes fixed two bugs in the handling of `analysisTarget` in the v1-to-v2 converter (`SarifVersionOneToCurrentVisitor`).

Now `develop` is completely up to date, and when we merge `develop` to `master`, we _should_ be able to simply take the "incoming" changes on all conflicting files.