### PR TITLE
Support for Sarif comparison

### DIFF
--- a/src/Samples/SarifToCsv/App.config
+++ b/src/Samples/SarifToCsv/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/Samples/SarifToCsv/App.config
+++ b/src/Samples/SarifToCsv/App.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+  <appSettings>
+    <add key="ColumnNames" value="RuleId, BaselineState, Location.Region.Snippet.Text, Location.Region.StartLine, Location.Region.StartColumn, Location.Uri, Message.Text, Fingerprints" />
+  </appSettings>
 </configuration>

--- a/src/Samples/SarifToCsv/CsvWriter.cs
+++ b/src/Samples/SarifToCsv/CsvWriter.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace AzureDevOpsCrawlers.Common.IO
+{
+    /// <summary>
+    ///  CsvWriter provides a simple interface to write valid Csv files.
+    ///  All strings are wrapped in quotes and quotes are doubled, which
+    ///  is the simplest way to produce a CSV conforming to RFC 4180.
+    ///  
+    ///  Usage:
+    ///  using(CsvWriter writer = new CsvWriter("Output.Csv"))
+    ///  {
+    ///     writer.SetColumns(new string[] { "Name", "Address" });
+    ///     
+    ///     foreach(...)
+    ///     {
+    ///         writer.Write(name);
+    ///         writer.Write(address);
+    ///         writer.NextRow();
+    ///     }
+    ///  }
+    /// </summary>
+    /// <remarks>
+    ///  Based on: https://github.com/Microsoft/elfie-arriba/blob/master/Elfie/Elfie/Serialization/CsvWriter.cs
+    /// </remarks>
+    public class CsvWriter : IDisposable
+    {
+        private StreamWriter _writer;
+        private bool _writeHeaderRow;
+        private int _columnCount;
+
+        private bool _inPartialColumn;
+        private int _currentRowColumnCount;
+        private int _rowCountWritten;
+
+        private char[] _copyBuffer;
+
+        public Encoding Encoding
+        {
+            get
+            {
+                return _writer.Encoding;
+            }
+        }
+
+        public CsvWriter(string filePath, bool writeHeaderRow = true) : this(new FileStream(EnsureDirectoryCreated(filePath), FileMode.Create, FileAccess.Write, FileShare.Read), writeHeaderRow)
+        { }
+
+        public CsvWriter(Stream stream, bool writeHeaderRow = true)
+        {
+            _writer = new StreamWriter(stream, Encoding.UTF8);
+            _writeHeaderRow = writeHeaderRow;
+            _rowCountWritten = 0;
+
+            _copyBuffer = new char[1024];
+        }
+
+        private static string EnsureDirectoryCreated(string filePath)
+        {
+            string directoryPath = Path.GetDirectoryName(filePath);
+            if (!String.IsNullOrEmpty(directoryPath)) { Directory.CreateDirectory(directoryPath); }
+
+            return filePath;
+        }
+
+        public int RowCountWritten => _rowCountWritten;
+
+        public void SetColumns(IEnumerable<string> columnNames)
+        {
+            _columnCount = columnNames.Count();
+
+            if (_writeHeaderRow)
+            {
+                foreach (string columnName in columnNames)
+                {
+                    Write(columnName);
+                }
+
+                NextRow();
+            }
+        }
+
+        public void NextRow()
+        {
+            WriteRowDelimiter();
+            _currentRowColumnCount = 0;
+            _rowCountWritten++;
+        }
+
+        public void Write(int value)
+        {
+            Write(value.ToString());
+        }
+
+        public void Write(string value)
+        {
+            if (_currentRowColumnCount >= _columnCount) { throw new InvalidOperationException(String.Format("Writing too many columns for row {0:n0}. Wrote {1:n0}, expected {2:n0} columns.", _rowCountWritten, _currentRowColumnCount, _columnCount)); }
+            if (_inPartialColumn) { throw new InvalidOperationException("Write was called while in a multi-part column. Call WriteValueStart, WriteValuePart, and WriteValueEnd only for partial columns."); }
+            if (_currentRowColumnCount > 0) { WriteCellDelimiter(); }
+            WriteEscaped(value);
+            _currentRowColumnCount++;
+        }
+
+        public void WriteValueStart()
+        {
+            if (_currentRowColumnCount >= _columnCount) { throw new InvalidOperationException(String.Format("Writing too many columns for row {0:n0}. Wrote {1:n0}, expected {2:n0} columns.", _rowCountWritten, _currentRowColumnCount, _columnCount)); }
+            if (_currentRowColumnCount > 0) { WriteCellDelimiter(); }
+            _inPartialColumn = true;
+        }
+
+        public void WriteValuePart(string value)
+        {
+            if (!_inPartialColumn) { throw new InvalidOperationException("WriteValueStart must be called before WriteValuePart."); }
+            WriteEscaped(value);
+        }
+
+        public void WriteValueEnd()
+        {
+            if (!_inPartialColumn) { throw new InvalidOperationException("WriteValueEnd called but WriteValueStart was never called."); }
+            _inPartialColumn = false;
+        }
+
+        private void WriteCellDelimiter()
+        {
+            _writer.Write(',');
+        }
+
+        private void WriteRowDelimiter()
+        {
+            _writer.Write("\r\n");
+        }
+
+        private void WriteEscaped(string value)
+        {
+            if (String.IsNullOrEmpty(value)) { return; }
+            int nextWriteIndex = 0;
+
+            _writer.Write('"');
+
+            for (int i = 0; i < value.Length; ++i)
+            {
+                char c = value[i];
+                if (c == '"')
+                {
+                    WriteStringPart(value, nextWriteIndex, (i + 1) - nextWriteIndex);
+                    nextWriteIndex = i;
+                }
+            }
+
+            WriteStringPart(value, nextWriteIndex);
+            _writer.Write('"');
+        }
+
+        private void WriteStringPart(string value, int index, int length = -1)
+        {
+            if (length == -1) { length = value.Length - index; }
+
+            // Ignore empty writes
+            if (length == 0) { return; }
+
+            // Ensure there's enough room to copy
+            if (length > _copyBuffer.Length) { _copyBuffer = new char[Math.Max(length, _copyBuffer.Length * 2)]; }
+
+            // Copy the string to a char[] (so it can be partially written without substring allocations
+            value.CopyTo(index, _copyBuffer, 0, length);
+
+            // Write the string part
+            _writer.Write(_copyBuffer, 0, length);
+        }
+
+        public void Dispose()
+        {
+            if (_writer != null)
+            {
+                if (_currentRowColumnCount > 0) { NextRow(); }
+                _writer.Dispose();
+                _writer = null;
+            }
+        }
+    }
+}

--- a/src/Samples/SarifToCsv/Program.cs
+++ b/src/Samples/SarifToCsv/Program.cs
@@ -1,0 +1,86 @@
+﻿using AzureDevOpsCrawlers.Common.IO;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+using Newtonsoft.Json;
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace SarifToCsv
+{
+    /// <summary>
+    ///  SarifToCsv is a simple example of converting a few key SARIF result properties to CSV format
+    ///  to allow easily viewing results compared with the 'match-results-forward' Sarif Multitool mode.
+    /// </summary>
+    /// <remarks>
+    ///  Should be modified to:
+    ///    - Make the output columns configurable.
+    ///    - Enable writing more result properties.
+    ///    - Integrate as a Sarif Multitool mode.
+    /// </remarks>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: SarifToCsv [sarifFilePath] [csvFilePath]");
+                return;
+            }
+
+            try
+            {
+                string sarifFilePath = args[0];
+                string csvFilePath = args[1];
+
+                Console.WriteLine($"Converting \"{sarifFilePath}\" to \"{csvFilePath}\"...");
+                Stopwatch w = Stopwatch.StartNew();
+
+                SarifLog log = null;
+
+                // Read the SarifLog with the deferred reader
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.ContractResolver = new SarifDeferredContractResolver();
+                using (JsonPositionedTextReader jtr = new JsonPositionedTextReader(sarifFilePath))
+                {
+                    log = serializer.Deserialize<SarifLog>(jtr);
+                }
+
+                // Convert the each result location into a row in a CSV
+                using (CsvWriter writer = new CsvWriter(csvFilePath))
+                {
+                    writer.SetColumns(new string[] { "RuleId", "BaselineState", "Location.Region.Snippet.Text", "Location.Region.StartLine", "Location.Region.StartColumn", "Location.Uri", "Message.Text", "Fingerprint" });
+
+                    foreach (var run in log.Runs)
+                    {
+                        foreach (var result in run.Results)
+                        {
+                            foreach (PhysicalLocation location in result.PhysicalLocations())
+                            {
+                                writer.Write(result.RuleId);
+                                writer.Write(result.BaselineState.ToString());
+
+                                writer.Write(location?.Region?.Snippet?.Text ?? "");
+                                writer.Write(location?.Region.StartLine ?? -1);
+                                writer.Write(location?.Region.StartColumn ?? -1);
+
+                                writer.Write(location.FileLocation.FileUri(run) ?? "");
+
+                                writer.Write(result.Message?.Text ?? "");
+                                writer.Write(result.Fingerprints.FirstOrDefault().Value ?? "");
+
+                                writer.NextRow();
+                            }
+                        }
+                    }
+
+                    Console.WriteLine($"Done. Wrote {writer.RowCountWritten:n0} rows to \"{csvFilePath}\" in {w.Elapsed.TotalSeconds:n0}s.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex}");
+            }
+        }
+    }
+}

--- a/src/Samples/SarifToCsv/Program.cs
+++ b/src/Samples/SarifToCsv/Program.cs
@@ -1,10 +1,18 @@
-﻿using AzureDevOpsCrawlers.Common.IO;
-using Microsoft.CodeAnalysis.Sarif;
-using Microsoft.CodeAnalysis.Sarif.Readers;
-using Newtonsoft.Json;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
+using System.Collections.Generic;
+using System.Configuration;
 using System.Diagnostics;
 using System.Linq;
+
+using AzureDevOpsCrawlers.Common.IO;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Readers;
+
+using Newtonsoft.Json;
 
 namespace SarifToCsv
 {
@@ -12,19 +20,18 @@ namespace SarifToCsv
     ///  SarifToCsv is a simple example of converting a few key SARIF result properties to CSV format
     ///  to allow easily viewing results compared with the 'match-results-forward' Sarif Multitool mode.
     /// </summary>
-    /// <remarks>
-    ///  Should be modified to:
-    ///    - Make the output columns configurable.
-    ///    - Enable writing more result properties.
-    ///    - Integrate as a Sarif Multitool mode.
-    /// </remarks>
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {
+            Dictionary<string, Action<CsvWriter, Result, PhysicalLocation>> writers = BuildWriters();
+
             if (args.Length < 2)
             {
                 Console.WriteLine("Usage: SarifToCsv [sarifFilePath] [csvFilePath]");
+                Console.WriteLine("  Column Names are configured in SarifToCsv.exe.config, in the 'ColumnNames' property.");
+                Console.WriteLine($"  Available Column Names: {String.Join(", ", writers.Keys)}");
+
                 return;
             }
 
@@ -32,6 +39,8 @@ namespace SarifToCsv
             {
                 string sarifFilePath = args[0];
                 string csvFilePath = args[1];
+                IEnumerable<string> columnNames = ConfigurationManager.AppSettings["ColumnNames"].Split(',').Select((value) => value.Trim());
+                IEnumerable<Action<CsvWriter, Result, PhysicalLocation>> selectedWriters = columnNames.Select((name) => writers[name]).ToArray();
 
                 Console.WriteLine($"Converting \"{sarifFilePath}\" to \"{csvFilePath}\"...");
                 Stopwatch w = Stopwatch.StartNew();
@@ -49,7 +58,7 @@ namespace SarifToCsv
                 // Convert the each result location into a row in a CSV
                 using (CsvWriter writer = new CsvWriter(csvFilePath))
                 {
-                    writer.SetColumns(new string[] { "RuleId", "BaselineState", "Location.Region.Snippet.Text", "Location.Region.StartLine", "Location.Region.StartColumn", "Location.Uri", "Message.Text", "Fingerprint" });
+                    writer.SetColumns(columnNames);
 
                     foreach (var run in log.Runs)
                     {
@@ -57,17 +66,10 @@ namespace SarifToCsv
                         {
                             foreach (PhysicalLocation location in result.PhysicalLocations())
                             {
-                                writer.Write(result.RuleId);
-                                writer.Write(result.BaselineState.ToString());
-
-                                writer.Write(location?.Region?.Snippet?.Text ?? "");
-                                writer.Write(location?.Region.StartLine ?? -1);
-                                writer.Write(location?.Region.StartColumn ?? -1);
-
-                                writer.Write(location.FileLocation.FileUri(run) ?? "");
-
-                                writer.Write(result.Message?.Text ?? "");
-                                writer.Write(result.Fingerprints.FirstOrDefault().Value ?? "");
+                                foreach(Action<CsvWriter, Result, PhysicalLocation> columnWriter in selectedWriters)
+                                {
+                                    columnWriter(writer, result, location);
+                                }
 
                                 writer.NextRow();
                             }
@@ -81,6 +83,50 @@ namespace SarifToCsv
             {
                 Console.WriteLine($"Error: {ex}");
             }
+        }
+
+        public static Dictionary<string, Action<CsvWriter, Result, PhysicalLocation>> BuildWriters()
+        {
+            Dictionary<string, Action<CsvWriter, Result, PhysicalLocation>> writers = new Dictionary<string, Action<CsvWriter, Result, PhysicalLocation>>(StringComparer.OrdinalIgnoreCase);
+
+            // Result Basic Properties
+            writers["BaselineState"] = (writer, result, pLoc) => { writer.Write(result.BaselineState.ToString()); };
+            writers["CorrelationGuid"] = (writer, result, pLoc) => { writer.Write(result.CorrelationGuid ?? ""); };
+            writers["Fingerprints"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", result.Fingerprints?.Values ?? Array.Empty<string>())); };
+            writers["HostedViewerUri"] = (writer, result, pLoc) => { writer.Write(result.HostedViewerUri?.ToString() ?? ""); };
+            writers["InstanceGuid"] = (writer, result, pLoc) => { writer.Write(result.InstanceGuid ?? ""); };
+            writers["Level"] = (writer, result, pLoc) => { writer.Write(result.Level.ToString()); };
+            writers["Message.Text"] = (writer, result, pLoc) => { writer.Write(result.Message?.Text ?? ""); };
+            writers["OccurrenceCount"] = (writer, result, pLoc) => { writer.Write(result.OccurrenceCount); };
+            writers["PartialFingerprints"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", result.PartialFingerprints?.Values ?? Array.Empty<string>())); };
+            writers["Provenance"] = (writer, result, pLoc) => { writer.Write(result.Provenance?.ToString() ?? ""); };
+            writers["Rank"] = (writer, result, pLoc) => { writer.Write(result.Rank.ToString()); };
+            writers["RuleId"] = (writer, result, pLoc) => { writer.Write(result.RuleId ?? ""); };
+            writers["RuleIndex"] = (writer, result, pLoc) => { writer.Write(result.RuleIndex); };
+            writers["SuppressionStates"] = (writer, result, pLoc) => { writer.Write(result.SuppressionStates.ToString()); };
+            writers["Tags"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", ((IEnumerable<string>)result.Tags) ?? Array.Empty<string>())); };
+            writers["WorkItemUris"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", result.WorkItemUris?.Select((uri) => uri.ToString()) ?? Array.Empty<string>())); };
+
+            // PhysicalLocation Properties
+            writers["Location.Tags"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", ((IEnumerable<string>)pLoc.Tags) ?? Array.Empty<string>())); };
+            writers["Location.Uri"] = (writer, result, pLoc) => { writer.Write(pLoc.FileLocation?.Uri?.ToString() ?? ""); };
+
+            // Region Properties
+            writers["Location.Region.ByteLength"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.ByteLength ?? -1); };
+            writers["Location.Region.ByteOffset"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.ByteOffset ?? -1); };
+            writers["Location.Region.CharLength"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.CharLength ?? -1); };
+            writers["Location.Region.CharOffset"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.CharOffset ?? -1); };
+            writers["Location.Region.EndColumn"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.EndColumn ?? -1); };
+            writers["Location.Region.EndLine"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.EndLine ?? -1); };
+            writers["Location.Region.IsBinaryRegion"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.IsBinaryRegion.ToString() ?? ""); };
+            writers["Location.Region.Message.Text"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.Message?.Text ?? ""); };
+            writers["Location.Region.Snippet.Text"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.Snippet?.Text ?? ""); };
+            writers["Location.Region.SourceLanguage"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.SourceLanguage ?? ""); };
+            writers["Location.Region.StartColumn"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.StartColumn ?? -1); };
+            writers["Location.Region.StartLine"] = (writer, result, pLoc) => { writer.Write(pLoc.Region?.StartLine ?? -1); };
+            writers["Location.Region.Tags"] = (writer, result, pLoc) => { writer.Write(String.Join("; ", ((IEnumerable<string>)pLoc.Region?.Tags) ?? Array.Empty<string>())); };
+
+            return writers;
         }
     }
 }

--- a/src/Samples/SarifToCsv/Properties/AssemblyInfo.cs
+++ b/src/Samples/SarifToCsv/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Samples/SarifToCsv/Properties/AssemblyInfo.cs
+++ b/src/Samples/SarifToCsv/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SarifToCsv")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SarifToCsv")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d308471e-c9be-4a41-b3a8-1bb04b22f6e7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Samples/SarifToCsv/SarifToCsv.csproj
+++ b/src/Samples/SarifToCsv/SarifToCsv.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SarifToCsv</RootNamespace>
+    <AssemblyName>SarifToCsv</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CsvWriter.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SdkExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Sarif\Sarif.csproj">
+      <Project>{47010491-7fc3-4063-94aa-833a99cc9352}</Project>
+      <Name>Sarif</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Samples/SarifToCsv/SarifToCsv.csproj
+++ b/src/Samples/SarifToCsv/SarifToCsv.csproj
@@ -37,6 +37,7 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Samples/SarifToCsv/SarifToCsv.sln
+++ b/src/Samples/SarifToCsv/SarifToCsv.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SarifToCsv", "SarifToCsv.csproj", "{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D308471E-C9BE-4A41-B3A8-1BB04B22F6E7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5DE3AE4B-8D29-4E46-90A4-C17C59B9EFCA}
+	EndGlobalSection
+EndGlobal

--- a/src/Samples/SarifToCsv/SdkExtensions.cs
+++ b/src/Samples/SarifToCsv/SdkExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.CodeAnalysis.Sarif;
+using System.Collections.Generic;
+
+namespace SarifToCsv
+{
+    public static class SdkExtensions
+    {
+        public static IEnumerable<PhysicalLocation> PhysicalLocations(this Result result)
+        {
+            foreach (Location location in result.Locations)
+            {
+                if (location.PhysicalLocation != null)
+                {
+                    yield return location.PhysicalLocation;
+                }
+            }
+        }
+
+        public static string FileUri(this FileLocation fileLocation, Run run)
+        {
+            if (fileLocation == null)
+            {
+                return null;
+            }
+            else if (fileLocation.Uri != null)
+            {
+                return fileLocation.Uri.ToString();
+            }
+            else if (fileLocation.FileIndex >= 0 && fileLocation.FileIndex < run.Files.Count)
+            {
+                return run.Files[fileLocation.FileIndex].FileLocation?.Uri?.ToString();
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Samples/SarifToCsv/SdkExtensions.cs
+++ b/src/Samples/SarifToCsv/SdkExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.CodeAnalysis.Sarif;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Sarif;
 using System.Collections.Generic;
 
 namespace SarifToCsv
@@ -7,11 +10,14 @@ namespace SarifToCsv
     {
         public static IEnumerable<PhysicalLocation> PhysicalLocations(this Result result)
         {
-            foreach (Location location in result.Locations)
+            if (result.Locations != null)
             {
-                if (location.PhysicalLocation != null)
+                foreach (Location location in result.Locations)
                 {
-                    yield return location.PhysicalLocation;
+                    if (location.PhysicalLocation != null)
+                    {
+                        yield return location.PhysicalLocation;
+                    }
                 }
             }
         }

--- a/src/Samples/SarifToCsv/packages.config
+++ b/src/Samples/SarifToCsv/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>

--- a/src/Sarif.Multitool/Program.cs
+++ b/src/Sarif.Multitool/Program.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 (MergeOptions mergeOptions) => new MergeCommand().Run(mergeOptions),
                 (RebaseUriOptions rebaseOptions) => new RebaseUriCommand().Run(rebaseOptions),
                 (AbsoluteUriOptions absoluteUriOptions) => new AbsoluteUriCommand().Run(absoluteUriOptions),
-                //(ResultMatchingOptions baselineOptions) => new ResultMatchingCommand().Run(baselineOptions),
+                (ResultMatchingOptions baselineOptions) => new ResultMatchingCommand().Run(baselineOptions),
                 errs => 1);
         }
     }


### PR DESCRIPTION
- Re-enabling result matching mode in Sarif.Multitool.
- Checking in sample to convert Sarif to CSV to easily review compared results.

We should make a more comprehensive Sarif to CSV converter, but I wanted to check in this simple implementation as a sample before the work to make it more configurable and integrated with the SDK can be done.