### PR TITLE
Fix ComprehensiveToolProperties test.

### DIFF
--- a/src/Sarif.UnitTests/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
+++ b/src/Sarif.UnitTests/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
@@ -15,12 +15,23 @@
             "noContent": {
               "text": "This file has no content to review."
             }
-          }
+          },
+          "ruleDescriptors": [
+            {
+              "id": "TEST1001",
+              "messageStrings": {
+                "a": {
+                  "text": "Review all image content for geopolitically sensitive graphics."
+                }
+              }
+            }
+          ]
         }
       },
       "results": [
         {
           "ruleId": "TEST1001",
+          "ruleIndex": 0,
           "message": {
             "messageId": "a"
           },
@@ -34,7 +45,8 @@
             }
           ]
         }
-      ]
+      ],
+      "columnKind": "utf16CodeUnits"
     }
   ]
 }

--- a/src/Sarif.UnitTests/TestData/PrereleaseCompatibilityTransformer/Inputs/ComprehensiveToolProperties.sarif
+++ b/src/Sarif.UnitTests/TestData/PrereleaseCompatibilityTransformer/Inputs/ComprehensiveToolProperties.sarif
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/sarif-2.0.0-csd.2.beta.2018-10-10",
-  "version": "2.0.0-csd.2.beta.2019-01-09",
+  "version": "2.0.0-csd.2.beta.2018-10-10",
   "runs": [
     {
       "tool": {


### PR DESCRIPTION
We fix a test that should have failed as a result of the previous PR (#1283, MultiformatMessageStrings) but did not.

The input file was stamped with the wrong version, so the `PrereleaseCompatibilityTransformer` didn’t properly populate `tool.driver.ruleDescriptors`. The expected output file was checked in without noticing that this property was missing, so the test "passed".

We fix the `version` property in the input file. This causes the test to fail as expected. Then we update the expected output file, where `tool.driver.ruleDescriptors` is not present.