### PR TITLE
Caching mechanism for duped codeflow data : [https://github.com/oasis-tcs/sarif-spec/issues/320]

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -266,3 +266,4 @@
 * API BREAKING: Remove `invocation.attachments`, now replaced by `run.tool.extensions`. https://github.com/oasis-tcs/sarif-spec/issues/327
 * API BREAKING: Remove `tool.language` and localization support. https://github.com/oasis-tcs/sarif-spec/issues/325
 * API NON-BREAKING: Add additional properties to toolComponent. https://github.com/oasis-tcs/sarif-spec/issues/336
+* API NON-BREAKING: Provide a caching mechanism for duplicated code flow data. https://github.com/oasis-tcs/sarif-spec/issues/320

--- a/src/Sarif/Autogenerated/ExternalPropertyFiles.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFiles.cs
@@ -5,6 +5,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
@@ -68,6 +69,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         public IList<ExternalPropertyFile> LogicalLocations { get; set; }
 
         /// <summary>
+        /// An array of threadFlowLocation objects cached in external file.
+        /// </summary>
+        [DataMember(Name = "threadFlowLocations", IsRequired = false, EmitDefaultValue = false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public IList<ThreadFlowLocation> ThreadFlowLocations { get; set; }
+
+        /// <summary>
         /// An array of external property files containing run.results arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "results", IsRequired = false, EmitDefaultValue = false)]
@@ -107,15 +115,18 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="logicalLocations">
         /// An initialization value for the <see cref="P:LogicalLocations" /> property.
         /// </param>
+        /// <param name="threadFlowLocations">
+        /// An initialization value for the <see cref="P:ThreadFlowLocations" /> property.
+        /// </param>
         /// <param name="results">
         /// An initialization value for the <see cref="P:Results" /> property.
         /// </param>
         /// <param name="tool">
         /// An initialization value for the <see cref="P:Tool" /> property.
         /// </param>
-        public ExternalPropertyFiles(ExternalPropertyFile conversion, ExternalPropertyFile graphs, ExternalPropertyFile externalizedProperties, IEnumerable<ExternalPropertyFile> artifacts, IEnumerable<ExternalPropertyFile> invocations, IEnumerable<ExternalPropertyFile> logicalLocations, IEnumerable<ExternalPropertyFile> results, ExternalPropertyFile tool)
+        public ExternalPropertyFiles(ExternalPropertyFile conversion, ExternalPropertyFile graphs, ExternalPropertyFile externalizedProperties, IEnumerable<ExternalPropertyFile> artifacts, IEnumerable<ExternalPropertyFile> invocations, IEnumerable<ExternalPropertyFile> logicalLocations, IEnumerable<ThreadFlowLocation> threadFlowLocations, IEnumerable<ExternalPropertyFile> results, ExternalPropertyFile tool)
         {
-            Init(conversion, graphs, externalizedProperties, artifacts, invocations, logicalLocations, results, tool);
+            Init(conversion, graphs, externalizedProperties, artifacts, invocations, logicalLocations, threadFlowLocations, results, tool);
         }
 
         /// <summary>
@@ -134,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Conversion, other.Graphs, other.ExternalizedProperties, other.Artifacts, other.Invocations, other.LogicalLocations, other.Results, other.Tool);
+            Init(other.Conversion, other.Graphs, other.ExternalizedProperties, other.Artifacts, other.Invocations, other.LogicalLocations, other.ThreadFlowLocations, other.Results, other.Tool);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -155,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new ExternalPropertyFiles(this);
         }
 
-        private void Init(ExternalPropertyFile conversion, ExternalPropertyFile graphs, ExternalPropertyFile externalizedProperties, IEnumerable<ExternalPropertyFile> artifacts, IEnumerable<ExternalPropertyFile> invocations, IEnumerable<ExternalPropertyFile> logicalLocations, IEnumerable<ExternalPropertyFile> results, ExternalPropertyFile tool)
+        private void Init(ExternalPropertyFile conversion, ExternalPropertyFile graphs, ExternalPropertyFile externalizedProperties, IEnumerable<ExternalPropertyFile> artifacts, IEnumerable<ExternalPropertyFile> invocations, IEnumerable<ExternalPropertyFile> logicalLocations, IEnumerable<ThreadFlowLocation> threadFlowLocations, IEnumerable<ExternalPropertyFile> results, ExternalPropertyFile tool)
         {
             if (conversion != null)
             {
@@ -226,10 +237,10 @@ namespace Microsoft.CodeAnalysis.Sarif
                 LogicalLocations = destination_2;
             }
 
-            if (results != null)
+            if (threadFlowLocations != null)
             {
-                var destination_3 = new List<ExternalPropertyFile>();
-                foreach (var value_3 in results)
+                var destination_3 = new List<ThreadFlowLocation>();
+                foreach (var value_3 in threadFlowLocations)
                 {
                     if (value_3 == null)
                     {
@@ -237,11 +248,29 @@ namespace Microsoft.CodeAnalysis.Sarif
                     }
                     else
                     {
-                        destination_3.Add(new ExternalPropertyFile(value_3));
+                        destination_3.Add(new ThreadFlowLocation(value_3));
                     }
                 }
 
-                Results = destination_3;
+                ThreadFlowLocations = destination_3;
+            }
+
+            if (results != null)
+            {
+                var destination_4 = new List<ExternalPropertyFile>();
+                foreach (var value_4 in results)
+                {
+                    if (value_4 == null)
+                    {
+                        destination_4.Add(null);
+                    }
+                    else
+                    {
+                        destination_4.Add(new ExternalPropertyFile(value_4));
+                    }
+                }
+
+                Results = destination_4;
             }
 
             if (tool != null)

--- a/src/Sarif/Autogenerated/ExternalPropertyFilesEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFilesEqualityComparer.cs
@@ -105,6 +105,27 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
             }
 
+            if (!object.ReferenceEquals(left.ThreadFlowLocations, right.ThreadFlowLocations))
+            {
+                if (left.ThreadFlowLocations == null || right.ThreadFlowLocations == null)
+                {
+                    return false;
+                }
+
+                if (left.ThreadFlowLocations.Count != right.ThreadFlowLocations.Count)
+                {
+                    return false;
+                }
+
+                for (int index_3 = 0; index_3 < left.ThreadFlowLocations.Count; ++index_3)
+                {
+                    if (!ThreadFlowLocation.ValueComparer.Equals(left.ThreadFlowLocations[index_3], right.ThreadFlowLocations[index_3]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
             if (!object.ReferenceEquals(left.Results, right.Results))
             {
                 if (left.Results == null || right.Results == null)
@@ -117,9 +138,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                for (int index_3 = 0; index_3 < left.Results.Count; ++index_3)
+                for (int index_4 = 0; index_4 < left.Results.Count; ++index_4)
                 {
-                    if (!ExternalPropertyFile.ValueComparer.Equals(left.Results[index_3], right.Results[index_3]))
+                    if (!ExternalPropertyFile.ValueComparer.Equals(left.Results[index_4], right.Results[index_4]))
                     {
                         return false;
                     }
@@ -195,14 +216,26 @@ namespace Microsoft.CodeAnalysis.Sarif
                     }
                 }
 
-                if (obj.Results != null)
+                if (obj.ThreadFlowLocations != null)
                 {
-                    foreach (var value_3 in obj.Results)
+                    foreach (var value_3 in obj.ThreadFlowLocations)
                     {
                         result = result * 31;
                         if (value_3 != null)
                         {
                             result = (result * 31) + value_3.ValueGetHashCode();
+                        }
+                    }
+                }
+
+                if (obj.Results != null)
+                {
+                    foreach (var value_4 in obj.Results)
+                    {
+                        result = result * 31;
+                        if (value_4 != null)
+                        {
+                            result = (result * 31) + value_4.ValueGetHashCode();
                         }
                     }
                 }

--- a/src/Sarif/Autogenerated/Run.cs
+++ b/src/Sarif/Autogenerated/Run.cs
@@ -159,6 +159,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         public ExternalPropertyFiles ExternalPropertyFiles { get; set; }
 
         /// <summary>
+        /// An array of threadFlowLocation objects cached at run level.
+        /// </summary>
+        [DataMember(Name = "threadFlowLocations", IsRequired = false, EmitDefaultValue = false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public IList<ThreadFlowLocation> ThreadFlowLocations { get; set; }
+
+        /// <summary>
         /// Key/value pairs that provide additional information about the run.
         /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
@@ -238,12 +245,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="externalPropertyFiles">
         /// An initialization value for the <see cref="P:ExternalPropertyFiles" /> property.
         /// </param>
+        /// <param name="threadFlowLocations">
+        /// An initialization value for the <see cref="P:ThreadFlowLocations" /> property.
+        /// </param>
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Run(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IDictionary<string, SerializedPropertyInfo> properties)
+        public Run(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IEnumerable<ThreadFlowLocation> threadFlowLocations, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(tool, invocations, conversion, versionControlProvenance, originalUriBaseIds, artifacts, logicalLocations, graphs, results, id, aggregateIds, baselineInstanceGuid, markdownMessageMimeType, redactionToken, defaultFileEncoding, defaultSourceLanguage, newlineSequences, columnKind, externalPropertyFiles, properties);
+            Init(tool, invocations, conversion, versionControlProvenance, originalUriBaseIds, artifacts, logicalLocations, graphs, results, id, aggregateIds, baselineInstanceGuid, markdownMessageMimeType, redactionToken, defaultFileEncoding, defaultSourceLanguage, newlineSequences, columnKind, externalPropertyFiles, threadFlowLocations, properties);
         }
 
         /// <summary>
@@ -262,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Tool, other.Invocations, other.Conversion, other.VersionControlProvenance, other.OriginalUriBaseIds, other.Artifacts, other.LogicalLocations, other.Graphs, other.Results, other.Id, other.AggregateIds, other.BaselineInstanceGuid, other.MarkdownMessageMimeType, other.RedactionToken, other.DefaultFileEncoding, other.DefaultSourceLanguage, other.NewlineSequences, other.ColumnKind, other.ExternalPropertyFiles, other.Properties);
+            Init(other.Tool, other.Invocations, other.Conversion, other.VersionControlProvenance, other.OriginalUriBaseIds, other.Artifacts, other.LogicalLocations, other.Graphs, other.Results, other.Id, other.AggregateIds, other.BaselineInstanceGuid, other.MarkdownMessageMimeType, other.RedactionToken, other.DefaultFileEncoding, other.DefaultSourceLanguage, other.NewlineSequences, other.ColumnKind, other.ExternalPropertyFiles, other.ThreadFlowLocations, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -283,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Run(this);
         }
 
-        private void Init(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IEnumerable<ThreadFlowLocation> threadFlowLocations, IDictionary<string, SerializedPropertyInfo> properties)
         {
             if (tool != null)
             {
@@ -446,6 +456,24 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (externalPropertyFiles != null)
             {
                 ExternalPropertyFiles = new ExternalPropertyFiles(externalPropertyFiles);
+            }
+
+            if (threadFlowLocations != null)
+            {
+                var destination_7 = new List<ThreadFlowLocation>();
+                foreach (var value_9 in threadFlowLocations)
+                {
+                    if (value_9 == null)
+                    {
+                        destination_7.Add(null);
+                    }
+                    else
+                    {
+                        destination_7.Add(new ThreadFlowLocation(value_9));
+                    }
+                }
+
+                ThreadFlowLocations = destination_7;
             }
 
             if (properties != null)

--- a/src/Sarif/Autogenerated/RunEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/RunEqualityComparer.cs
@@ -269,6 +269,27 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (!object.ReferenceEquals(left.ThreadFlowLocations, right.ThreadFlowLocations))
+            {
+                if (left.ThreadFlowLocations == null || right.ThreadFlowLocations == null)
+                {
+                    return false;
+                }
+
+                if (left.ThreadFlowLocations.Count != right.ThreadFlowLocations.Count)
+                {
+                    return false;
+                }
+
+                for (int index_7 = 0; index_7 < left.ThreadFlowLocations.Count; ++index_7)
+                {
+                    if (!ThreadFlowLocation.ValueComparer.Equals(left.ThreadFlowLocations[index_7], right.ThreadFlowLocations[index_7]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
             if (!object.ReferenceEquals(left.Properties, right.Properties))
             {
                 if (left.Properties == null || right.Properties == null || left.Properties.Count != right.Properties.Count)
@@ -466,16 +487,28 @@ namespace Microsoft.CodeAnalysis.Sarif
                     result = (result * 31) + obj.ExternalPropertyFiles.ValueGetHashCode();
                 }
 
+                if (obj.ThreadFlowLocations != null)
+                {
+                    foreach (var value_15 in obj.ThreadFlowLocations)
+                    {
+                        result = result * 31;
+                        if (value_15 != null)
+                        {
+                            result = (result * 31) + value_15.ValueGetHashCode();
+                        }
+                    }
+                }
+
                 if (obj.Properties != null)
                 {
                     // Use xor for dictionaries to be order-independent.
                     int xor_2 = 0;
-                    foreach (var value_15 in obj.Properties)
+                    foreach (var value_16 in obj.Properties)
                     {
-                        xor_2 ^= value_15.Key.GetHashCode();
-                        if (value_15.Value != null)
+                        xor_2 ^= value_16.Key.GetHashCode();
+                        if (value_16.Value != null)
                         {
-                            xor_2 ^= value_15.Value.GetHashCode();
+                            xor_2 ^= value_16.Value.GetHashCode();
                         }
                     }
 

--- a/src/Sarif/Autogenerated/ThreadFlowLocation.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Sarif.Readers;
 using Newtonsoft.Json;
@@ -32,6 +33,14 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return SarifNodeKind.ThreadFlowLocation;
             }
         }
+
+        /// <summary>
+        /// The index within the run threadFlowLocations array.
+        /// </summary>
+        [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(-1)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public int Index { get; set; }
 
         /// <summary>
         /// The code location.
@@ -86,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is "essential", "important", "unimportant". Default: "important".
         /// </summary>
         [DataMember(Name = "importance", IsRequired = false, EmitDefaultValue = false)]
-        [JsonConverter(typeof(EnumConverter))]
+        [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
         public ThreadFlowLocationImportance Importance { get; set; }
 
         /// <summary>
@@ -100,11 +109,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         public ThreadFlowLocation()
         {
+            Index = -1;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ThreadFlowLocation" /> class from the supplied values.
         /// </summary>
+        /// <param name="index">
+        /// An initialization value for the <see cref="P:Index" /> property.
+        /// </param>
         /// <param name="location">
         /// An initialization value for the <see cref="P:Location" /> property.
         /// </param>
@@ -135,9 +148,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public ThreadFlowLocation(Location location, Stack stack, IEnumerable<string> kinds, string module, IDictionary<string, string> state, int nestingLevel, int executionOrder, DateTime executionTimeUtc, ThreadFlowLocationImportance importance, IDictionary<string, SerializedPropertyInfo> properties)
+        public ThreadFlowLocation(int index, Location location, Stack stack, IEnumerable<string> kinds, string module, IDictionary<string, string> state, int nestingLevel, int executionOrder, DateTime executionTimeUtc, ThreadFlowLocationImportance importance, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(location, stack, kinds, module, state, nestingLevel, executionOrder, executionTimeUtc, importance, properties);
+            Init(index, location, stack, kinds, module, state, nestingLevel, executionOrder, executionTimeUtc, importance, properties);
         }
 
         /// <summary>
@@ -156,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Location, other.Stack, other.Kinds, other.Module, other.State, other.NestingLevel, other.ExecutionOrder, other.ExecutionTimeUtc, other.Importance, other.Properties);
+            Init(other.Index, other.Location, other.Stack, other.Kinds, other.Module, other.State, other.NestingLevel, other.ExecutionOrder, other.ExecutionTimeUtc, other.Importance, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -177,8 +190,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new ThreadFlowLocation(this);
         }
 
-        private void Init(Location location, Stack stack, IEnumerable<string> kinds, string module, IDictionary<string, string> state, int nestingLevel, int executionOrder, DateTime executionTimeUtc, ThreadFlowLocationImportance importance, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(int index, Location location, Stack stack, IEnumerable<string> kinds, string module, IDictionary<string, string> state, int nestingLevel, int executionOrder, DateTime executionTimeUtc, ThreadFlowLocationImportance importance, IDictionary<string, SerializedPropertyInfo> properties)
         {
+            Index = index;
             if (location != null)
             {
                 Location = new Location(location);

--- a/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocationEqualityComparer.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
+            if (left.Index != right.Index)
+            {
+                return false;
+            }
+
             if (!Location.ValueComparer.Equals(left.Location, right.Location))
             {
                 return false;
@@ -141,6 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             int result = 17;
             unchecked
             {
+                result = (result * 31) + obj.Index.GetHashCode();
                 if (obj.Location != null)
                 {
                     result = (result * 31) + obj.Location.ValueGetHashCode();

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -805,7 +805,7 @@
       "arguments": {
         "namespaceName": "Newtonsoft.Json",
         "typeName": "JsonConverter",
-        "arguments": [ "typeof(EnumConverter)" ]
+        "arguments": [ "typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter)" ]
       }
     }
   ],

--- a/src/Sarif/NotYetAutoGenerated/Run.cs
+++ b/src/Sarif/NotYetAutoGenerated/Run.cs
@@ -159,6 +159,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         public ExternalPropertyFiles ExternalPropertyFiles { get; set; }
 
         /// <summary>
+        /// An array of threadFlowLocation objects cached at run level.
+        /// </summary>
+        [DataMember(Name = "threadFlowLocations", IsRequired = false, EmitDefaultValue = false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public IList<ThreadFlowLocation> ThreadFlowLocations { get; set; }
+
+        /// <summary>
         /// Key/value pairs that provide additional information about the run.
         /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
@@ -238,12 +245,15 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="externalPropertyFiles">
         /// An initialization value for the <see cref="P:ExternalPropertyFiles" /> property.
         /// </param>
+        /// <param name="threadFlowLocations">
+        /// An initialization value for the <see cref="P:ThreadFlowLocations" /> property.
+        /// </param>
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Run(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IDictionary<string, SerializedPropertyInfo> properties)
+        public Run(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IEnumerable<ThreadFlowLocation> threadFlowLocations, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(tool, invocations, conversion, versionControlProvenance, originalUriBaseIds, artifacts, logicalLocations, graphs, results, id, aggregateIds, baselineInstanceGuid, markdownMessageMimeType, redactionToken, defaultFileEncoding, defaultSourceLanguage, newlineSequences, columnKind, externalPropertyFiles, properties);
+            Init(tool, invocations, conversion, versionControlProvenance, originalUriBaseIds, artifacts, logicalLocations, graphs, results, id, aggregateIds, baselineInstanceGuid, markdownMessageMimeType, redactionToken, defaultFileEncoding, defaultSourceLanguage, newlineSequences, columnKind, externalPropertyFiles, threadFlowLocations, properties);
         }
 
         /// <summary>
@@ -262,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Tool, other.Invocations, other.Conversion, other.VersionControlProvenance, other.OriginalUriBaseIds, other.Artifacts, other.LogicalLocations, other.Graphs, other.Results, other.Id, other.AggregateIds, other.BaselineInstanceGuid, other.MarkdownMessageMimeType, other.RedactionToken, other.DefaultFileEncoding, other.DefaultSourceLanguage, other.NewlineSequences, other.ColumnKind, other.ExternalPropertyFiles, other.Properties);
+            Init(other.Tool, other.Invocations, other.Conversion, other.VersionControlProvenance, other.OriginalUriBaseIds, other.Artifacts, other.LogicalLocations, other.Graphs, other.Results, other.Id, other.AggregateIds, other.BaselineInstanceGuid, other.MarkdownMessageMimeType, other.RedactionToken, other.DefaultFileEncoding, other.DefaultSourceLanguage, other.NewlineSequences, other.ColumnKind, other.ExternalPropertyFiles, other.ThreadFlowLocations, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -283,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Run(this);
         }
 
-        private void Init(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(Tool tool, IEnumerable<Invocation> invocations, Conversion conversion, IEnumerable<VersionControlDetails> versionControlProvenance, IDictionary<string, ArtifactLocation> originalUriBaseIds, IEnumerable<Artifact> artifacts, IEnumerable<LogicalLocation> logicalLocations, IDictionary<string, Graph> graphs, IEnumerable<Result> results, RunAutomationDetails id, IEnumerable<RunAutomationDetails> aggregateIds, string baselineInstanceGuid, string markdownMessageMimeType, string redactionToken, string defaultFileEncoding, string defaultSourceLanguage, IEnumerable<string> newlineSequences, ColumnKind columnKind, ExternalPropertyFiles externalPropertyFiles, IEnumerable<ThreadFlowLocation> threadFlowLocations, IDictionary<string, SerializedPropertyInfo> properties)
         {
             if (tool != null)
             {
@@ -446,6 +456,24 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (externalPropertyFiles != null)
             {
                 ExternalPropertyFiles = new ExternalPropertyFiles(externalPropertyFiles);
+            }
+
+            if (threadFlowLocations != null)
+            {
+                var destination_7 = new List<ThreadFlowLocation>();
+                foreach (var value_9 in threadFlowLocations)
+                {
+                    if (value_9 == null)
+                    {
+                        destination_7.Add(null);
+                    }
+                    else
+                    {
+                        destination_7.Add(new ThreadFlowLocation(value_9));
+                    }
+                }
+
+                ThreadFlowLocations = destination_7;
             }
 
             if (properties != null)

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -522,7 +522,7 @@
         },
 
         "threadFlowLocations": {
-          "description": "An array of threadFlowLocation objects cached in external file.",
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
           "type": "array",
           "minItems": 0,
           "uniqueItems": true,

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -521,6 +521,17 @@
           }
         },
 
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached in external file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
         "results": {
           "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
           "type": "array",
@@ -1843,6 +1854,17 @@
           "$ref": "#/definitions/externalPropertyFiles"
         },
 
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
         "properties": {
           "description": "Key/value pairs that provide additional information about the run.",
           "$ref": "#/definitions/propertyBag"
@@ -2002,6 +2024,13 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
+
+        "index": {
+          "description": "The index within the run threadFlowLocations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
 
         "location": {
           "description": "The code location.",


### PR DESCRIPTION
Add `run.threadFlowLocations`, an array of `threadFlowLocation` objects cached at the run level, analogous to `run.files` and `run.logicalLocation`.
Add `threadFlowLocation.index`, an index into `run.threadFlowLocations`.
Add `externalPropertyFiles.threadFlowLocations`, allowing cached data to be stored in a separate file.