### PR TITLE
Fix: Merge failing when no OutputFolderPath.

### DIFF
--- a/src/Sarif.Multitool/MergeCommand.cs
+++ b/src/Sarif.Multitool/MergeCommand.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                     ? Formatting.Indented
                     : Formatting.None;
 
-                Directory.CreateDirectory(mergeOptions.OutputFolderPath);
+                Directory.CreateDirectory(outputDirectory);
 
                 FileHelpers.WriteSarifFile(_fileSystem, combinedLog, outputName, formatting);
             }


### PR DESCRIPTION
I assume using `outputDirectory` was the original intent.