### PR TITLE
Create .1 release of 04-03 for additional bug fixes

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>csd.2.beta.2019-04-03</VersionSuffix>
-    <PackageVersionSuffix>.0</PackageVersionSuffix>
+    <PackageVersionSuffix>.1</PackageVersionSuffix>
 
     <!--
     Whenever you increment VersionPrefix or VersionSuffix, copy the old value(s)
@@ -24,8 +24,8 @@
     hides the previous package versions on nuget.org.
     -->
     <PreviousVersionPrefix>2.0.0</PreviousVersionPrefix>
-    <PreviousVersionSuffix>csd.2.beta.2019-02-20</PreviousVersionSuffix>
-    <PreviousPackageVersionSuffix></PreviousPackageVersionSuffix>
+    <PreviousVersionSuffix>csd.2.beta.2019-04-03</PreviousVersionSuffix>
+    <PreviousPackageVersionSuffix>.0</PreviousPackageVersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
@lgolding @harleenkohli 

Last call for 04/03 bug fixes. We certainly have today and tomorrow to identify/fix any schema issues that will be approved this Wednesday. We can also expect there may be tail from that meeting that delays shipping a 'final final' 04/03 until end of week.
