### PR TITLE
Get CS converter working

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.AntiCachingControlsMissing].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.AntiCachingControlsMissing),
                 RuleId = ContrastSecurityRuleIds.AntiCachingControlsMissing,
                 Locations = locations,
                 Message = new Message
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls),
                 RuleId = ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls,
                 Locations = locations,
                 Message = new Message
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.CrossSiteScripting].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.CrossSiteScripting),
                 RuleId = ContrastSecurityRuleIds.CrossSiteScripting,
                 Locations = new List<Location>()
                 {
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed),
                 RuleId = ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed,
                 Locations = new List<Location>()
                 {
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.EventValidationDisabled].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.EventValidationDisabled),
                 RuleId = ContrastSecurityRuleIds.EventValidationDisabled,
                 Locations = new List<Location>()
                 {
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.FormsAuthenticationSSL].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.FormsAuthenticationSSL),
                 RuleId = ContrastSecurityRuleIds.FormsAuthenticationSSL,
                 Locations = new List<Location>()
                 {
@@ -589,7 +589,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention),
                 RuleId = ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention,
                 Locations = locations,
                 Message = new Message
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.OverlyLongSessionTimeout].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.OverlyLongSessionTimeout),
                 RuleId = ContrastSecurityRuleIds.OverlyLongSessionTimeout,
                 Locations = new List<Location>()
                 {
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.SqlInjection].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.SqlInjection),
                 RuleId = ContrastSecurityRuleIds.SqlInjection,
                 Locations = new List<Location>()
                 {
@@ -797,7 +797,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.VersionHeaderEnabled].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.VersionHeaderEnabled),
                 RuleId = ContrastSecurityRuleIds.VersionHeaderEnabled,
                 Locations = new List<Location>()
                 {
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = _rules[ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode].DefaultConfiguration.Level,
+                Level = GetFailureLevel(ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode),
                 RuleId = ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode,
                 Locations = new List<Location>()
                 {

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Xml;
-using System.Xml.Schema;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -18,10 +17,8 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.CodeAnalysis.Sarif.Converters
 {
     /// <summary>
-    /// Converts exported Contrast Security XML report files to sarif format
+    /// Converts exported Contrast Security XML report files to SARIF format.
     /// </summary>
-    ///<remarks>
-    ///</remarks>
     internal sealed class ContrastSecurityConverter : ToolFileConverterBase
     {
         private const string ContrastSecurityRulesData = "Microsoft.CodeAnalysis.Sarif.Converters.RulesData.ContrastSecurity.sarif";
@@ -59,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Assembly assembly = typeof(ContrastSecurityConverter).Assembly;
             SarifLog sarifLog;
 
-            using (var stream = assembly.GetManifestResourceStream(ContrastSecurityConverter.ContrastSecurityRulesData))
+            using (var stream = assembly.GetManifestResourceStream(ContrastSecurityRulesData))
             using (var streamReader = new StreamReader(stream))
             {
                 string prereleaseRuleDataLogText = streamReader.ReadToEnd();
@@ -932,7 +929,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     }
 
     /// <summary>
-    /// Pluggable FxCop log reader
+    /// Pluggable Contrast Security log reader.
     /// </summary>
     internal sealed class ContrastLogReader
     {
@@ -1031,7 +1028,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         /// <summary>
-        /// COntrast Security exported xml elements and attributes
+        /// Contrast Security exported XML elements and attributes.
         /// </summary>
         private static class SchemaStrings
         {
@@ -1120,21 +1117,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         public void Read(Context context, Stream input)
         {
-            XmlSchemaSet schemaSet = new XmlSchemaSet();
-            Assembly assembly = typeof(ContrastLogReader).Assembly;
-            var settings = new XmlReaderSettings
-            {
-                DtdProcessing = DtdProcessing.Ignore,
-                XmlResolver = null
-            };
-
-            //using (var stream = assembly.GetManifestResourceStream(ContrastLogReader.ContrastSecurityReportSchema))
-            //using (var reader = XmlReader.Create(stream, settings))
-            //{
-            //    XmlSchema schema = XmlSchema.Read(reader, new ValidationEventHandler(ReportError));
-            //    schemaSet.Add(schema);
-            //}
-
             using (var sparseReader = SparseReader.CreateFromStream(_dispatchTable, input, schemaSet: null))
             {
                 if (sparseReader.LocalName.Equals(SchemaStrings.ElementFindings))

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             Result result = new Result()
             {
-                Level = GetFailureLevel(ruleId),
+                Level = GetRuleFailureLevel(ruleId),
                 RuleId = ruleId,
                 Message = new Message { Text = "TODO: missing message construction for '" + ruleId + "' rule." }
             };
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.AntiCachingControlsMissing),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.AntiCachingControlsMissing),
                 RuleId = ContrastSecurityRuleIds.AntiCachingControlsMissing,
                 Locations = locations,
                 Message = new Message
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             });
 
             result.Locations = locations;
-            result.Level = GetFailureLevel(ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule);
+            result.Level = GetRuleFailureLevel(ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule);
 
             if (locationPath == null)
             {
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls),
                 RuleId = ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls,
                 Locations = locations,
                 Message = new Message
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.CrossSiteScripting),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.CrossSiteScripting),
                 RuleId = ContrastSecurityRuleIds.CrossSiteScripting,
                 Locations = new List<Location>()
                 {
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed),
                 RuleId = ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed,
                 Locations = new List<Location>()
                 {
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.EventValidationDisabled),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.EventValidationDisabled),
                 RuleId = ContrastSecurityRuleIds.EventValidationDisabled,
                 Locations = new List<Location>()
                 {
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.FormsAuthenticationSSL),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.FormsAuthenticationSSL),
                 RuleId = ContrastSecurityRuleIds.FormsAuthenticationSSL,
                 Locations = new List<Location>()
                 {
@@ -589,7 +589,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention),
                 RuleId = ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention,
                 Locations = locations,
                 Message = new Message
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.OverlyLongSessionTimeout),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.OverlyLongSessionTimeout),
                 RuleId = ContrastSecurityRuleIds.OverlyLongSessionTimeout,
                 Locations = new List<Location>()
                 {
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.SqlInjection),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.SqlInjection),
                 RuleId = ContrastSecurityRuleIds.SqlInjection,
                 Locations = new List<Location>()
                 {
@@ -797,7 +797,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.VersionHeaderEnabled),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.VersionHeaderEnabled),
                 RuleId = ContrastSecurityRuleIds.VersionHeaderEnabled,
                 Locations = new List<Location>()
                 {
@@ -831,7 +831,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var result = new Result
             {
-                Level = GetFailureLevel(ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode),
+                Level = GetRuleFailureLevel(ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode),
                 RuleId = ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode,
                 Locations = new List<Location>()
                 {
@@ -931,7 +931,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         // Get the failure level for the rule with the specified id, defaulting to
         // "warning" if the rule does not specify a configuration.
-        private FailureLevel GetFailureLevel(string ruleId)
+        private FailureLevel GetRuleFailureLevel(string ruleId)
         {
             return _rules[ruleId].DefaultConfiguration?.Level ?? FailureLevel.Warning;
         }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             Result result = new Result()
             {
-                Level = _rules[ruleId].DefaultConfiguration.Level,
+                Level = _rules[ruleId].DefaultConfiguration?.Level ?? FailureLevel.Warning,
                 RuleId = ruleId,
                 Message = new Message { Text = "TODO: missing message construction for '" + ruleId + "' rule." }
             };

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -277,8 +277,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             // authorization-missing-deny : Authorization Rules Missing Deny Rule
 
-            Result result = new Result();
-            result.RuleId = ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule;
+            var result = new Result
+            {
+                RuleId = ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule
+            };
 
             // authorization-missing-deny instances track the following properties:
             // 
@@ -297,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             });
 
             result.Locations = locations;
-            result.Level = _rules[ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule].DefaultConfiguration.Level;
+            result.Level = _rules[ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule].DefaultConfiguration?.Level ?? FailureLevel.Warning;
 
             if (locationPath == null)
             {

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             Result result = new Result()
             {
-                Level = _rules[ruleId].DefaultConfiguration?.Level ?? FailureLevel.Warning,
+                Level = GetFailureLevel(ruleId),
                 RuleId = ruleId,
                 Message = new Message { Text = "TODO: missing message construction for '" + ruleId + "' rule." }
             };
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             });
 
             result.Locations = locations;
-            result.Level = _rules[ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule].DefaultConfiguration?.Level ?? FailureLevel.Warning;
+            result.Level = GetFailureLevel(ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule);
 
             if (locationPath == null)
             {
@@ -927,6 +927,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 result.SetProperty(key, value);
             }
+        }
+
+        // Get the failure level for the rule with the specified id, defaulting to
+        // "warning" if the rule does not specify a configuration.
+        private FailureLevel GetFailureLevel(string ruleId)
+        {
+            return _rules[ruleId].DefaultConfiguration?.Level ?? FailureLevel.Warning;
         }
     }
 

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             // secure-flag-missing : Session Cookie Has No 'secure' Flag
 
-            // default : The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}.
+            // default : The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}'.
 
             return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.SessionCookieHasNoSecureFlag);
         }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             // secure-flag-missing : Session Cookie Has No 'secure' Flag
 
-            // default : The
+            // default : The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}.
 
             return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.SessionCookieHasNoSecureFlag);
         }

--- a/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
+++ b/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
@@ -490,7 +490,7 @@
               "text": "Verifies session cookies have the secure flag."
             },
             "messageStrings": {
-              "default": "The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}."
+              "default": "The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}'."
             },
             "configuration": {
               "defaultLevel": "warning"

--- a/src/Sarif.Converters/SparseReader.cs
+++ b/src/Sarif.Converters/SparseReader.cs
@@ -72,9 +72,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 xReader = XmlReader.Create(stream, settings);
                 xReader.MoveToContent(); // If this throws, we destroy the reader in the finally block below.
-                var result = new SparseReader(dispatchTable, xReader); // nothrow
+                var sparseReader = new SparseReader(dispatchTable, xReader); // nothrow
                 xReader = null; // Ownership transfered to SparseReader; don't destroy here
-                return result;
+                return sparseReader;
             }
             finally
             {

--- a/src/Sarif.Converters/SparseReaderDispatchTable.cs
+++ b/src/Sarif.Converters/SparseReaderDispatchTable.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         }
 
         /// <summary>Handles .</summary>
-        /// <param name="elementName">Name of the element for which a handler shall be installed.</param>
+        /// <param name="elementName">Name of the element for which a handler was installed.</param>
         /// <param name="source">Source for the.</param>
         /// <param name="context">The context.</param>
         /// <returns>true if a dispatcher was registered for that element name; otherwise, false.</returns>


### PR DESCRIPTION
This change fixes a set of bugs that prevent the partially implemented Contrast Security converter from running to completion. Now that these bugs are fixed, we have a working converter to which we can add new rule conversions one at a time.

The bugs are all failures to check whether a rule's `DefaultConfiguration` is non-`null` before dereferencing it to obtain its `Level` property. If `DefaultConfiguration` is missing, `Level` should default to `FailureLevel.Warning`. So wrap up the null-checking and defaulting logic in a new helper method `FailureLevel GetRuleFailureLevel(string ruleId)`, and call it everywhere (including `ConstructNotImplementedRuleResult`).

Also:
- Fix some nits I ran across while studying the code.