### PR TITLE
Update to jschema 0.64.0. Rename `reportingDescriptorRelationship.des…

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -301,12 +301,6 @@
 * API BREAKING: Update how reporting descriptors describe their taxonomic relationships. https://github.com/oasis-tcs/sarif-spec/issues/356
 * API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. https://github.com/oasis-tcs/sarif-spec/issues/168
 
-## **v2.0.0-csd.2.beta.2019.04-03.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.2))
-* API NON-BREAKING: Add `module` to `address.kind`. https://github.com/oasis-tcs/sarif-spec/issues/353
-* API BREAKING: `address.baseAddress` & `address.offset` to int. https://github.com/oasis-tcs/sarif-spec/issues/353
-* API BREAKING: Update how reporting descriptors describe their taxonomic relationships. https://github.com/oasis-tcs/sarif-spec/issues/356
-* API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. https://github.com/oasis-tcs/sarif-spec/issues/168
-
 ## **v2.0.0-csd.2.beta.2019.04-03.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.3)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.3))
 * API BREAKING: Rename `reportingDescriptor.descriptor` to `reportingDescriptor.target`. https://github.com/oasis-tcs/sarif-spec/issues/356
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -301,3 +301,12 @@
 * API BREAKING: Update how reporting descriptors describe their taxonomic relationships. https://github.com/oasis-tcs/sarif-spec/issues/356
 * API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. https://github.com/oasis-tcs/sarif-spec/issues/168
 
+## **v2.0.0-csd.2.beta.2019.04-03.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.2))
+* API NON-BREAKING: Add `module` to `address.kind`. https://github.com/oasis-tcs/sarif-spec/issues/353
+* API BREAKING: `address.baseAddress` & `address.offset` to int. https://github.com/oasis-tcs/sarif-spec/issues/353
+* API BREAKING: Update how reporting descriptors describe their taxonomic relationships. https://github.com/oasis-tcs/sarif-spec/issues/356
+* API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. https://github.com/oasis-tcs/sarif-spec/issues/168
+
+## **v2.0.0-csd.2.beta.2019.04-03.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.3)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.3))
+* API BREAKING: Rename `reportingDescriptor.descriptor` to `reportingDescriptor.target`. https://github.com/oasis-tcs/sarif-spec/issues/356
+

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Json.Pointer" Version="0.63.0" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="0.63.0" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="0.63.0" />
+    <PackageReference Include="Microsoft.Json.Pointer" Version="0.64.0" />
+    <PackageReference Include="Microsoft.Json.Schema" Version="0.64.0" />
+    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="0.64.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
+++ b/src/Sarif.ValidationTests/Sarif.ValidationTests.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="Microsoft.Json.Schema" Version="0.63.0" />
-    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="0.63.0" />
+    <PackageReference Include="Microsoft.Json.Schema" Version="0.64.0" />
+    <PackageReference Include="Microsoft.Json.Schema.Validation" Version="0.64.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// A reference to the related reporting descriptor.
         /// </summary>
-        [DataMember(Name = "descriptor", IsRequired = true)]
-        public ReportingDescriptorReference Descriptor { get; set; }
+        [DataMember(Name = "target", IsRequired = true)]
+        public ReportingDescriptorReference Target { get; set; }
 
         /// <summary>
         /// A set of distinct strings that categorize the relationshship. Well-known kinds include canPrecede, canFollow, canPrecedeOrFollow, willPrecede, willFollow, superset, subset, equal, disjoint, relevant, and incomparable.
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Initializes a new instance of the <see cref="ReportingDescriptorRelationship" /> class from the supplied values.
         /// </summary>
-        /// <param name="descriptor">
-        /// An initialization value for the <see cref="P:Descriptor" /> property.
+        /// <param name="target">
+        /// An initialization value for the <see cref="P:Target" /> property.
         /// </param>
         /// <param name="kinds">
         /// An initialization value for the <see cref="P:Kinds" /> property.
@@ -69,9 +69,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public ReportingDescriptorRelationship(ReportingDescriptorReference descriptor, IEnumerable<string> kinds, IDictionary<string, SerializedPropertyInfo> properties)
+        public ReportingDescriptorRelationship(ReportingDescriptorReference target, IEnumerable<string> kinds, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(descriptor, kinds, properties);
+            Init(target, kinds, properties);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Descriptor, other.Kinds, other.Properties);
+            Init(other.Target, other.Kinds, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -111,11 +111,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new ReportingDescriptorRelationship(this);
         }
 
-        private void Init(ReportingDescriptorReference descriptor, IEnumerable<string> kinds, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(ReportingDescriptorReference target, IEnumerable<string> kinds, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            if (descriptor != null)
+            if (target != null)
             {
-                Descriptor = new ReportingDescriptorReference(descriptor);
+                Target = new ReportingDescriptorReference(target);
             }
 
             if (kinds != null)

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationshipEqualityComparer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (!ReportingDescriptorReference.ValueComparer.Equals(left.Descriptor, right.Descriptor))
+            if (!ReportingDescriptorReference.ValueComparer.Equals(left.Target, right.Target))
             {
                 return false;
             }
@@ -89,9 +89,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             int result = 17;
             unchecked
             {
-                if (obj.Descriptor != null)
+                if (obj.Target != null)
                 {
-                    result = (result * 31) + obj.Descriptor.ValueGetHashCode();
+                    result = (result * 31) + obj.Target.ValueGetHashCode();
                 }
 
                 if (obj.Kinds != null)

--- a/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
+++ b/src/Sarif/Autogenerated/SarifRewritingVisitor.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             if (node != null)
             {
-                node.Descriptor = VisitNullChecked(node.Descriptor);
+                node.Target = VisitNullChecked(node.Target);
             }
 
             return node;

--- a/src/Sarif/Core/ReportingDescriptor.cs
+++ b/src/Sarif/Core/ReportingDescriptor.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return this.DeprecatedNames.HasAtLeastOneNonNullValue();
         }
 
+        public bool ShouldSerializedRelationships()
+        {
+            return this.Relationships.HasAtLeastOneNonDefaultValue(ReportingDescriptorRelationship.ValueComparer);
+        }
+
         public bool ShouldSerializeDefaultConfiguration()
         {
             return this.DefaultConfiguration != null && !this.DefaultConfiguration.ValueEquals(ReportingConfiguration.Empty);

--- a/src/Sarif/Core/ReportingDescriptor.cs
+++ b/src/Sarif/Core/ReportingDescriptor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return this.DeprecatedNames.HasAtLeastOneNonNullValue();
         }
 
-        public bool ShouldSerializedRelationships()
+        public bool ShouldSerializeRelationships()
         {
             return this.Relationships.HasAtLeastOneNonDefaultValue(ReportingDescriptorRelationship.ValueComparer);
         }

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -1817,7 +1817,7 @@
       "additionalProperties": false,
       "properties": {
 
-        "descriptor": {
+        "target": {
           "description": "A reference to the related reporting descriptor.",
           "$ref": "#/definitions/reportingDescriptorReference"
         },
@@ -1837,7 +1837,7 @@
           "$ref": "#/definitions/propertyBag"
         }
       },
-      "required": [ "descriptor", "kinds" ]
+      "required": [ "target", "kinds" ]
     },
 
 
@@ -1853,7 +1853,7 @@
         },
 
         "ruleIndex": {
-          "description": "The index within the run resources array of the rule object associated with this result.",
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
           "type": "integer",
           "default": -1,
           "minimum": -1

--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>csd.2.beta.2019-04-03</VersionSuffix>
-    <PackageVersionSuffix>.2</PackageVersionSuffix>
+    <PackageVersionSuffix>.3</PackageVersionSuffix>
 
     <!--
     Whenever you increment VersionPrefix or VersionSuffix, copy the old value(s)


### PR DESCRIPTION
…criptor` to `reportingDescriptorRelationship.target`. Update `result.ruleIndex` schema description comment.

@lgolding please merge! thanks!