### PR TITLE
Remove 'canPrecedeOrFollow' from relationship kind list (in schema co…

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -303,4 +303,4 @@
 
 ## **v2.0.0-csd.2.beta.2019.04-03.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.3)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.3))
 * API BREAKING: Rename `reportingDescriptor.descriptor` to `reportingDescriptor.target`. https://github.com/oasis-tcs/sarif-spec/issues/356
-
+* API NON-BREAKING: Remove `canPrecedeOrFollow` from relationship kind list. https://github.com/oasis-tcs/sarif-spec/issues/356

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public ReportingDescriptorReference Target { get; set; }
 
         /// <summary>
-        /// A set of distinct strings that categorize the relationshship. Well-known kinds include canPrecede, canFollow, canPrecedeOrFollow, willPrecede, willFollow, superset, subset, equal, disjoint, relevant, and incomparable.
+        /// A set of distinct strings that categorize the relationshship. Well-known kinds include canPrecede, canFollow, willPrecede, willFollow, superset, subset, equal, disjoint, relevant, and incomparable.
         /// </summary>
         [DataMember(Name = "kinds", IsRequired = true)]
         public IList<string> Kinds { get; set; }

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -1823,7 +1823,7 @@
         },
 
         "kinds": {
-          "description": "A set of distinct strings that categorize the relationshship. Well-known kinds include canPrecede, canFollow, canPrecedeOrFollow, willPrecede, willFollow, superset, subset, equal, disjoint, relevant, and incomparable.",
+          "description": "A set of distinct strings that categorize the relationshship. Well-known kinds include canPrecede, canFollow, willPrecede, willFollow, superset, subset, equal, disjoint, relevant, and incomparable.",
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,


### PR DESCRIPTION
…mment). @lgolding FYI

Checking this in to release to nuget.org. 