### PR TITLE
CS: populate threadFlow.immutableState from headers.

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string untrustedData = BuildSourcesString(context.Sources);
             string page = context.RequestUri;
             string caller = context.PropagationEvents[context.PropagationEvents.Count - 1].Stack.Frames[0].Location.LogicalLocation?.FullyQualifiedName;
-            string controlID = context.Properties.ContainsKey(nameof(controlID)) ? context.Properties[nameof(controlID)] : null;
+            string controlId = context.Properties.ContainsKey(nameof(controlId)) ? context.Properties[nameof(controlId)] : null;
 
             const string RuleId = ContrastSecurityRuleIds.CrossSiteScripting;
             var result = new Result
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
             };
 
-            if (controlID == null)
+            if (controlId == null)
             {
                 result.Message = new Message
                 {
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {                  // A cross-site scripting vulnerability was seen as untrusted data
                         untrustedData, // '{0}' on 
                         page,          // '{1}' was accessed within 
-                        controlID      // '{2}' control and observed going into the HTTP response without validation or encoding.
+                        controlId      // '{2}' control and observed going into the HTTP response without validation or encoding.
                     }
                 };
             }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -882,12 +882,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                          {
                              new ThreadFlow
                              {
-                                  Locations = context.PropagationEvents
-                                  // TODO: Populate ImmutableState from the headers.
+                                  Locations = context.PropagationEvents,
+                                  ImmutableState = CreateImmutableState()
                              }
                          }
                     }
                 };
+        }
+
+        private object CreateImmutableState()
+        {
+            return new object();
         }
 
         private PhysicalLocation CreatePhysicalLocation(string uri, Region region = null)

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -101,11 +101,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 output.WriteLogicalLocations(LogicalLocations);
             }
 
-            //if (_rules?.Any() == true)
-            //{
-            //    output.WriteRules(_rules.Values.ToList());
-            //}
-
             output.OpenResults();
             output.WriteResults(results);
             output.CloseResults();

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -112,12 +112,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 case ContrastSecurityRuleIds.AntiCachingControlsMissing:
                 {
-                    return ConstructAntiCachingControlsMissingResult(context.Properties);
+                    return ConstructAntiCachingControlsMissingResult(context);
                 }
 
                 case ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule:
                 {
-                    return ConstructAuthorizationRulesMissingDenyResult(context.Properties);
+                    return ConstructAuthorizationRulesMissingDenyResult(context);
                 }
 
                 case ContrastSecurityRuleIds.CrossSiteScripting:
@@ -127,32 +127,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 case ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed:
                 {
-                    return ConstructDetailedErrorMessagesDisplayedResult(context.Properties);
+                    return ConstructDetailedErrorMessagesDisplayedResult(context);
                 }
 
                 case ContrastSecurityRuleIds.EventValidationDisabled:
                 {
-                    return ConstructEventValidationDisabledResult(context.Properties);
+                    return ConstructEventValidationDisabledResult(context);
                 }
 
                 case ContrastSecurityRuleIds.FormsAuthenticationSSL:
                 {
-                    return ConstructFormsAuthenticationSSLResult(context.Properties);
+                    return ConstructFormsAuthenticationSSLResult(context);
                 }
 
                 case ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention:
                 {
-                    return ConstructFormsWithoutAutocompletePreventionResult(context.Properties);
+                    return ConstructFormsWithoutAutocompletePreventionResult(context);
                 }
 
                 case ContrastSecurityRuleIds.HttpOnlyCookieFlagDisabled:
                 {
-                    return ConstructHttpOnlyCookieFlagDisabledResult(context.Properties);
+                    return ConstructHttpOnlyCookieFlagDisabledResult(context);
                 }
 
                 case ContrastSecurityRuleIds.InsecureEncryptionAlgorithms:
                 {
-                    return ConstructInsecureEncryptionAlgorithmsResult(context.Properties);
+                    return ConstructInsecureEncryptionAlgorithmsResult(context);
                 }
 
                 case ContrastSecurityRuleIds.InsecureHashAlgorithms:
@@ -162,32 +162,32 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 case ContrastSecurityRuleIds.OverlyLongSessionTimeout:
                 {
-                    return ConstructOverlyLongSessionTimeoutResult(context.Properties);
+                    return ConstructOverlyLongSessionTimeoutResult(context);
                 }
 
                 case ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls:
                 {
-                    return ConstructPagesWithoutAntiClickjackingControlsResult(context.Properties);
+                    return ConstructPagesWithoutAntiClickjackingControlsResult(context);
                 }
 
                 case ContrastSecurityRuleIds.PathTraversal:
                 {
-                    return ConstructPathTraversalResult(context.Properties);
+                    return ConstructPathTraversalResult(context);
                 }
 
                 case ContrastSecurityRuleIds.RequestValidationModeDisabled:
                 {
-                    return ConstructRequestValidationModeDisabledResult(context.Properties);
+                    return ConstructRequestValidationModeDisabledResult(context);
                 }
 
                 case ContrastSecurityRuleIds.SessionCookieHasNoSecureFlag:
                 {
-                    return ConstructSessionCookieHasNoSecureFlagResult(context.Properties);
+                    return ConstructSessionCookieHasNoSecureFlagResult(context);
                 }
 
                 case ContrastSecurityRuleIds.SessionRewriting:
                 {
-                    return ConstructSessionRewritingResult(context.Properties);
+                    return ConstructSessionRewritingResult(context);
                 }
 
                 case ContrastSecurityRuleIds.SqlInjection:
@@ -197,12 +197,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 case ContrastSecurityRuleIds.VersionHeaderEnabled:
                 {
-                    return ConstructVersionHeaderEnabledResult(context.Properties);
+                    return ConstructVersionHeaderEnabledResult(context);
                 }
 
                 case ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode:
                 {
-                    return ConstructWebApplicationDeployedinDebugModeResult(context.Properties);
+                    return ConstructWebApplicationDeployedinDebugModeResult(context);
                 }
 
                 default:
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return result;
         }
 
-        private Result ConstructAntiCachingControlsMissingResult(IDictionary<string, string> properties)
+        private Result ConstructAntiCachingControlsMissingResult(ContrastLogReader.Context context)
         {
             // cache-controls-missing : Anti-Caching Controls Missing
 
@@ -236,6 +236,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string examplePage = null;
             string exampleHeader = null;
 
+            IDictionary<string, string> properties = context.Properties;
             foreach (string key in properties.Keys)
             {
                 if (KeyIsReservedPropertyName(key)) { continue; }
@@ -251,11 +252,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             string pageCount = locations.Count.ToString();
 
-            const string RuleId = ContrastSecurityRuleIds.AntiCachingControlsMissing;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = locations,
                 Message = new Message
                 {
@@ -270,15 +270,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructAuthorizationRulesMissingDenyResult(IDictionary<string, string> properties)
+        private Result ConstructAuthorizationRulesMissingDenyResult(ContrastLogReader.Context context)
         {
             // authorization-missing-deny : Authorization Rules Missing Deny Rule
 
-            const string RuleId = ContrastSecurityRuleIds.AuthorizationRulesMissingDenyRule;
             var result = new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId)
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId)
             };
 
             // authorization-missing-deny instances track the following properties:
@@ -287,6 +286,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // <properties name="locationPath">CustomerLogin.aspx</properties>
             // <properties name="snippet">10:     &lt;system.web&gt;&#xD;</properties>
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
             string locationPath = properties.ContainsKey(nameof(locationPath)) ? properties[nameof(locationPath)] : null;
             string snippet = properties[nameof(snippet)];
@@ -328,16 +328,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private Result ConstructInsecureHashAlgorithmsResult(ContrastLogReader.Context context)
         {
-            const string RuleId = ContrastSecurityRuleIds.InsecureHashAlgorithms;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 CodeFlows = CreateCodeFlows(context)
             };
         }
 
-        private Result ConstructPagesWithoutAntiClickjackingControlsResult(IDictionary<string, string> properties)
+        private Result ConstructPagesWithoutAntiClickjackingControlsResult(ContrastLogReader.Context context)
         {
             // cache-controls-missing : Anti-Caching Controls Missing
 
@@ -346,6 +345,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var locations = new List<Location>();
 
+            IDictionary<string, string> properties = context.Properties;
             foreach (string key in properties.Keys)
             {
                 if (KeyIsReservedPropertyName(key)) { continue; }
@@ -359,11 +359,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string pageCount = locations.Count.ToString();
             string examplePage = locations[0].PhysicalLocation.ArtifactLocation.Uri.ToString();
 
-            const string RuleId = ContrastSecurityRuleIds.PagesWithoutAntiClickjackingControls;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = locations,
                 Message = new Message
                 {
@@ -393,11 +392,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string caller = context.PropagationEvents[context.PropagationEvents.Count - 1].Stack.Frames[0].Location.LogicalLocation?.FullyQualifiedName;
             string controlId = context.Properties.ContainsKey(nameof(controlId)) ? context.Properties[nameof(controlId)] : null;
 
-            const string RuleId = ContrastSecurityRuleIds.CrossSiteScripting;
             var result = new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -436,21 +434,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return result;
         }
 
-        private Result ConstructDetailedErrorMessagesDisplayedResult(IDictionary<string, string> properties)
+        private Result ConstructDetailedErrorMessagesDisplayedResult(ContrastLogReader.Context context)
         {
             // custom-errors-off : Detailed Error Messages Displayed
 
             // <properties name="path">\web.config</properties>
             // <properties name="snippet">30:   &lt;system.web&gt;&#xD;
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            const string RuleId = ContrastSecurityRuleIds.DetailedErrorMessagesDisplayed;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -469,21 +467,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructEventValidationDisabledResult(IDictionary<string, string> properties)
+        private Result ConstructEventValidationDisabledResult(ContrastLogReader.Context context)
         {
             // event-validation-disabled : Event Validation Disabled
 
             // <properties name="aspx">\Content\HeaderInjection.aspx</properties>\
             // <properties name="snippet">1: &lt;%@ Page Title="" Language="C#" ...
 
+            IDictionary<string, string> properties = context.Properties;
             string aspx = properties[nameof(aspx)];
             string snippet = properties[nameof(snippet)];
 
-            const string RuleId = ContrastSecurityRuleIds.EventValidationDisabled;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -502,21 +500,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructFormsAuthenticationSSLResult(IDictionary<string, string> properties)
+        private Result ConstructFormsAuthenticationSSLResult(ContrastLogReader.Context context)
         {
             // forms-auth-ssl : Forms Authentication SSL
 
             // <properties name="path">\web.config</properties>
             // <properties name="snippet">39:     &lt;!-- set up users --&gt;&#xD;
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            const string RuleId = ContrastSecurityRuleIds.FormsAuthenticationSSL;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -535,7 +533,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructFormsWithoutAutocompletePreventionResult(IDictionary<string, string> properties)
+        private Result ConstructFormsWithoutAutocompletePreventionResult(ContrastLogReader.Context context)
         {
             // autocomplete-missing : Forms Without Autocomplete Prevention
 
@@ -543,6 +541,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             var locations = new List<Location>();
 
+            IDictionary<string, string> properties = context.Properties;
             foreach (string key in properties.Keys)
             {
                 if (KeyIsReservedPropertyName(key)) { continue; }
@@ -585,11 +584,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string pageCount = locations.Count.ToString();
             string examplePage = locations[0].PhysicalLocation.ArtifactLocation.Uri.OriginalString;
 
-            const string RuleId = ContrastSecurityRuleIds.FormsWithoutAutocompletePrevention;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = locations,
                 Message = new Message
                 {
@@ -611,25 +609,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 key == "route-signature";
         }
 
-        private Result ConstructHttpOnlyCookieFlagDisabledResult(IDictionary<string, string> properties)
+        private Result ConstructHttpOnlyCookieFlagDisabledResult(ContrastLogReader.Context context)
         {
             // http-only-disabled : HttpOnly Cookie Flag Disabled
 
             // default : The configuration in '{0}' had 'httpOnlyCookies' set to 'false' in an <httpCookies> section.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.HttpOnlyCookieFlagDisabled);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
-        private Result ConstructInsecureEncryptionAlgorithmsResult(IDictionary<string, string> properties)
+        private Result ConstructInsecureEncryptionAlgorithmsResult(ContrastLogReader.Context context)
         {
             // crypto-bad-cyphers : Insecure Encryption Algorithms
 
             // default : '{0}' obtained a handle to the cryptographically insecure '{1}' algorithm.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.InsecureEncryptionAlgorithms);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
-        private Result ConstructOverlyLongSessionTimeoutResult(IDictionary<string, string> properties)
+        private Result ConstructOverlyLongSessionTimeoutResult(ContrastLogReader.Context context)
         {
             // session-timeout : Overly Long Session Timeout
 
@@ -637,15 +635,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // <properties name="section">sessionState</properties>
             // <properties name="snippet">52:     &lt;trace enabled="false" ...
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
             string section = properties[nameof(section)];
             string snippet = properties[nameof(snippet)];
 
-            const string RuleId = ContrastSecurityRuleIds.OverlyLongSessionTimeout;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -665,40 +663,40 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructPathTraversalResult(IDictionary<string, string> properties)
+        private Result ConstructPathTraversalResult(ContrastLogReader.Context context)
         {
             // path-traversal : Path Traversal
 
             // default : Attacker-controlled path traversal was observed from '{0}' on '{1}' page.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.PathTraversal);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
-        private Result ConstructRequestValidationModeDisabledResult(IDictionary<string, string> properties)
+        private Result ConstructRequestValidationModeDisabledResult(ContrastLogReader.Context context)
         {
             // request-validation-control-disabled : Request Validation Mode Disabled
 
             // default : The configuration in '{0}' had 'ValidateRequest' set to 'false' in the page directive. Request Validation helps prevent several types of attacks including XSS by detecting potentially dangerous character sequences. An exception is thrown by the framework when a potentially dangerous character sequence is encountered. This exception returns an error page to the user and prevents the application from processing the request. An attacker can submit malicious data to the application that may be processed without further input validation. This malicious data could contain XSS or other injection attacks that may have been prevented by ASP.NET request validation. Note that request validation does not provide 100% protection against XSS or other attacks and should be thought of as a defense-in-depth measure.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.RequestValidationModeDisabled);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
-        private Result ConstructSessionCookieHasNoSecureFlagResult(IDictionary<string, string> properties)
+        private Result ConstructSessionCookieHasNoSecureFlagResult(ContrastLogReader.Context context)
         {
             // secure-flag-missing : Session Cookie Has No 'secure' Flag
 
             // default : The value of the HttpCookie for the cookie '{0}' did not contain the 'secure' flag; the value observed was '{1}'.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.SessionCookieHasNoSecureFlag);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
-        private Result ConstructSessionRewritingResult(IDictionary<string, string> properties)
+        private Result ConstructSessionRewritingResult(ContrastLogReader.Context context)
         {
             // session-rewriting : Session Rewriting
 
             // default : The configuration the the <forms> section of '{0}' has 'UseCookies' set to a value other than 'cookieless'. As a result, the session ID (which is as good as a username and password) is logged to browser history, server logs and proxy logs. More serious, session rewriting can enable session fixcation attacks, in which an attacker causes a victim to use a well-known session id. If the victim authenticates under the attacker's chosen session ID, the attacker can present that session ID to the server and be recognized as the victim.
 
-            return ConstructNotImplementedRuleResult(ContrastSecurityRuleIds.SessionRewriting);
+            return ConstructNotImplementedRuleResult(context.RuleId);
         }
 
         private Result ConstructSqlInjectionResult(ContrastLogReader.Context context)
@@ -717,11 +715,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // default : SQL injection from untrusted source(s) '{0}' observed on '{1}' page. Untrusted data flowed from '{2}' to dangerous sink '{3}' in '{4}'.
 
-            const string RuleId = ContrastSecurityRuleIds.SqlInjection;
             var result = new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 CodeFlows = CreateCodeFlows(context),
                 Locations = new List<Location>()
                 {
@@ -761,19 +758,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return sb.ToString();
         }
 
-        private Result ConstructVersionHeaderEnabledResult(IDictionary<string, string> properties)
+        private Result ConstructVersionHeaderEnabledResult(ContrastLogReader.Context context)
         {
             // version-header-enabled : Version Header Enabled
 
             // <properties name="path">\web.config</properties>
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
 
-            const string RuleId = ContrastSecurityRuleIds.VersionHeaderEnabled;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location
@@ -792,21 +789,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private Result ConstructWebApplicationDeployedinDebugModeResult(IDictionary<string, string> properties)
+        private Result ConstructWebApplicationDeployedinDebugModeResult(ContrastLogReader.Context context)
         {
             // compilation-debug : Web Application Deployed in Debug Mode
 
             // <properties name="path">\web.config</properties>
             // <properties name="snippet">30:   &lt;system.web&gt;&#xD;
 
+            IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            const string RuleId = ContrastSecurityRuleIds.WebApplicationDeployedinDebugMode;
             return new Result
             {
-                RuleId = RuleId,
-                Level = GetRuleFailureLevel(RuleId),
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
                 Locations = new List<Location>()
                 {
                     new Location


### PR DESCRIPTION
Also:
- Avoid hard-coding the rule ids repeatedly by using the value that already exists in the context. This has the nice side effect of making all the rule handler signatures the same (they all need to take the context now, whereas before some of them could get away with passing only the properties dictionary).

I'll continue to add to this PR, adjusting the title and description as required, until one of you reviews this.