### PR TITLE
CS: Populate request object

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -970,6 +970,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             public IDictionary<string, string> Headers { get; set; }
 
+            public IDictionary<string, string> Parameters { get; set; }
+
             internal void RefineFinding(string ruleId)
             {
                 RuleId = ruleId;
@@ -1010,6 +1012,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Headers = Headers ?? new Dictionary<string, string>();
 
                 if (!Headers.ContainsKey(name)) { Headers.Add(name, value); }
+            }
+
+            internal void ClearParameters()
+            {
+                Parameters = null;
+            }
+
+            internal void AddParameter(string name, string value)
+            {
+                Parameters = Parameters ?? new Dictionary<string, string>();
+
+                if (!Parameters.ContainsKey(name)) { Parameters.Add(name, value); }
             }
 
             internal void ClearFinding()
@@ -1196,6 +1210,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadParameters(SparseReader reader, object parent)
         {
+            Context context = (Context)parent;
+            context.ClearParameters();
+
             reader.ReadChildren(SchemaStrings.ElementParameters, parent);
         }
 
@@ -1282,6 +1299,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadP(SparseReader reader, object parent)
         {
+            string name = reader.ReadAttributeString(SchemaStrings.AttributeName);
+            string value = reader.ReadAttributeString(SchemaStrings.AttributeValue);
+
+            Context context = (Context)parent;
+            context.AddParameter(name, value);
+
             reader.ReadChildren(SchemaStrings.ElementP, parent);
         }
 

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -876,8 +876,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                          {
                              new ThreadFlow
                              {
-                                  Locations = context.PropagationEvents,
-                                  ImmutableState = context.Headers
+                                  Locations = context.PropagationEvents
                              }
                          }
                     }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -847,7 +847,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Version = context.RequestVersion,
                 Method = context.RequestMethod,
                 Target = new Uri(context.RequestTarget, UriKind.RelativeOrAbsolute),
-                Headers = context.Headers
+                Headers = context.Headers,
+                Parameters = context.Parameters
             };
         }
 
@@ -1041,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             // elements
             public const string ElementH = "h";
-            public const string ElementP = "P";
+            public const string ElementP = "p";
             public const string ElementBody = "body";
             public const string ElementArgs = "args";
             public const string ElementObject = "obj";
@@ -1295,11 +1296,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadP(SparseReader reader, object parent)
         {
+            // p elements occur in two places
+            //
+            // 1. As children of finding/request/parameters. In this context, they have
+            //    attributes "name" and "value", and should be added to the context's
+            //    Parameters dictionary.
+            //
+            // 2. As children of findings/events/propagation-event/properties, in which case
+            //    I don't know what to do with them yet.
+            //
+            // Make sure we don't confuse the one with the other.
             string name = reader.ReadAttributeString(SchemaStrings.AttributeName);
-            string value = reader.ReadAttributeString(SchemaStrings.AttributeValue);
+            if (name != null)
+            {
+                string value = reader.ReadAttributeString(SchemaStrings.AttributeValue);
 
-            Context context = (Context)parent;
-            context.AddParameter(name, value);
+                Context context = (Context)parent;
+                context.AddParameter(name, value);
+            }
 
             reader.ReadChildren(SchemaStrings.ElementP, parent);
         }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -38,12 +38,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             if (input == null)
             {
-                throw (new ArgumentNullException(nameof(input)));
+                throw new ArgumentNullException(nameof(input));
             }
 
             if (output == null)
             {
-                throw (new ArgumentNullException(nameof(output)));
+                throw new ArgumentNullException(nameof(output));
             }
 
             LogicalLocations.Clear();
@@ -291,11 +291,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string locationPath = properties.ContainsKey(nameof(locationPath)) ? properties[nameof(locationPath)] : null;
             string snippet = properties[nameof(snippet)];
 
-            IList<Location> locations = new List<Location>();
-            locations.Add(new Location
+            IList<Location> locations = new List<Location>
             {
-                PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
-            });
+                new Location
+                {
+                    PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
+                }
+            };
 
             result.Locations = locations;
 
@@ -396,7 +398,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -449,7 +451,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -567,7 +569,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                         }
                     });
 
-                locations.Add(new Location()
+                locations.Add(new Location
                 {
                     PhysicalLocation = new PhysicalLocation
                     {
@@ -644,7 +646,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -720,7 +722,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
                 CodeFlows = CreateCodeFlows(context),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -771,7 +773,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -804,7 +806,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 RuleId = context.RuleId,
                 Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                Locations = new List<Location>
                 {
                     new Location
                     {
@@ -849,7 +851,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 sb.AppendLine(lineTokens[1]);
             }
 
-            return new Region()
+            return new Region
             {
                 StartLine = startLine.Value,
                 EndLine = endLine,
@@ -1137,7 +1139,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadFindings(SparseReader reader, object parent)
         {
-            Context context = (Context)parent;
             reader.ReadChildren(SchemaStrings.ElementFindings, parent);
         }
 
@@ -1151,10 +1152,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             context.RefineFinding(ruleId);
             reader.ReadChildren(SchemaStrings.ElementFinding, parent);
 
-            if (FindingRead != null)
-            {
-                FindingRead(context);
-            }
+            FindingRead?.Invoke(context);
 
             context.ClearFinding();
         }
@@ -1298,7 +1296,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Debug.Assert(context.CurrentThreadFlowLocation == null);
             context.CurrentThreadFlowLocation = new ThreadFlowLocation
             {
-                Stack = new Stack()
+                Stack = new Stack
                 {
                     Frames = new List<StackFrame> { context.Signature }
                 }

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -252,33 +252,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             string pageCount = locations.Count.ToString();
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = locations;
+            result.Message = new Message
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = locations,
-                Message = new Message
+                Id = "default",
+                Arguments = new List<string>
                 {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {
-                        pageCount,     // {0} page Cache-Control header(s) did not contain 'no-store' or 'no-cache';
-                        examplePage,   // e.g., the value in page '{1}' 
-                        exampleHeader  // was observed to be '{2}'.
-                    }
+                    pageCount,     // {0} page Cache-Control header(s) did not contain 'no-store' or 'no-cache';
+                    examplePage,   // e.g., the value in page '{1}' 
+                    exampleHeader  // was observed to be '{2}'.
                 }
             };
+
+            return result;
         }
 
         private Result ConstructAuthorizationRulesMissingDenyResult(ContrastLogReader.Context context)
         {
             // authorization-missing-deny : Authorization Rules Missing Deny Rule
 
-            var result = new Result
-            {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId)
-            };
+            Result result = CreateResultCore(context);
 
             // authorization-missing-deny instances track the following properties:
             // 
@@ -330,12 +324,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private Result ConstructInsecureHashAlgorithmsResult(ContrastLogReader.Context context)
         {
-            return new Result
-            {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                CodeFlows = CreateCodeFlows(context)
-            };
+            return CreateResultCore(context);
         }
 
         private Result ConstructPagesWithoutAntiClickjackingControlsResult(ContrastLogReader.Context context)
@@ -361,21 +350,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string pageCount = locations.Count.ToString();
             string examplePage = locations[0].PhysicalLocation.ArtifactLocation.Uri.ToString();
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = locations;
+            result.Message = new Message
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = locations,
-                Message = new Message
+                Id = "default",
+                Arguments = new List<string>
                 {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {
-                        pageCount,  // {0} page(s) have insufficient anti-clickjacking controls, 
-                        examplePage // e.g., '{1}' 
-                    },
+                    pageCount,  // {0} page(s) have insufficient anti-clickjacking controls, 
+                    examplePage // e.g., '{1}' 
                 }
             };
+
+            return result;
         }
 
         private Result ConstructCrossSiteScriptingResult(ContrastLogReader.Context context)
@@ -394,16 +381,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string caller = context.PropagationEvents[context.PropagationEvents.Count - 1].Stack.Frames[0].Location.LogicalLocation?.FullyQualifiedName;
             string controlId = context.Properties.ContainsKey(nameof(controlId)) ? context.Properties[nameof(controlId)] : null;
 
-            var result = new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(page),
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(page),
                 }
             };
 
@@ -447,26 +430,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {                  // The configuration in 
-                        path,          // '{0}' has 'mode' set to 'Off' in the <customErrors> section.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {                  // The configuration in 
+                    path,          // '{0}' has 'mode' set to 'Off' in the <customErrors> section.
+                }
+            };
+
+            return result;
         }
 
         private Result ConstructEventValidationDisabledResult(ContrastLogReader.Context context)
@@ -480,26 +461,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string aspx = properties[nameof(aspx)];
             string snippet = properties[nameof(snippet)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>()
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(aspx, CreateRegion(snippet)),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {                  // The configuration in 
-                        aspx,          // '{0}' has 'enableEventValidation' set to 'false' in the page directive.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(aspx, CreateRegion(snippet)),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {                  // The configuration in 
+                    aspx,          // '{0}' has 'enableEventValidation' set to 'false' in the page directive.
+                }
+            };
+
+            return result;
         }
 
         private Result ConstructFormsAuthenticationSSLResult(ContrastLogReader.Context context)
@@ -513,26 +492,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>()
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>()
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {                  // The configuration in 
-                        path,          // '{0}' was configured to use forms authentication and 'resquireSSL' was not set to 'true' in an <authentication> section.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {                  // The configuration in 
+                    path,          // '{0}' was configured to use forms authentication and 'resquireSSL' was not set to 'true' in an <authentication> section.
+                }
+            };
+
+            return result;
         }
 
         private Result ConstructFormsWithoutAutocompletePreventionResult(ContrastLogReader.Context context)
@@ -586,21 +563,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string pageCount = locations.Count.ToString();
             string examplePage = locations[0].PhysicalLocation.ArtifactLocation.Uri.OriginalString;
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = locations;
+            result.Message = new Message
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = locations,
-                Message = new Message
+                Id = "default",
+                Arguments = new List<string>
                 {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {
-                        pageCount,  //'{0}' pages contain a <form> element that do
-                        examplePage, //not have 'autocomplete' set to 'off'; e.g. '{1}'.
-                    }
+                    pageCount,  //'{0}' pages contain a <form> element that do
+                    examplePage, //not have 'autocomplete' set to 'off'; e.g. '{1}'.
                 }
             };
+
+            return result;
         }
 
         private bool KeyIsReservedPropertyName(string key)
@@ -642,27 +617,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string section = properties[nameof(section)];
             string snippet = properties[nameof(snippet)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {              // The configuration in the
-                        section,   // <{0}> section of 
-                        path       // '{1}' specified a session timeout value greater than 30 minutes.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {              // The configuration in the
+                    section,   // <{0}> section of 
+                    path       // '{1}' specified a session timeout value greater than 30 minutes.
+                }
+            };
+
+            return result;
         }
 
         private Result ConstructPathTraversalResult(ContrastLogReader.Context context)
@@ -717,29 +690,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             // default : SQL injection from untrusted source(s) '{0}' observed on '{1}' page. Untrusted data flowed from '{2}' to dangerous sink '{3}' in '{4}'.
 
-            var result = new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                CodeFlows = CreateCodeFlows(context),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(page),
-                    }
-                },
-                Message = new Message
+                    PhysicalLocation = CreatePhysicalLocation(page),
+                }
+            };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
                 {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {
-                        untrustedData, // SQL injection from untrusted source(s) '{0}'
-                        page,          // observed on '{1}' page.
-                        source,        // Untrusted data flowed from '{2}'
-                        sink,          // to dangerous sink '{3}'
-                        caller         // from a call site in '{4}'.
-                    }
+                    untrustedData, // SQL injection from untrusted source(s) '{0}'
+                    page,          // observed on '{1}' page.
+                    source,        // Untrusted data flowed from '{2}'
+                    sink,          // to dangerous sink '{3}'
+                    caller         // from a call site in '{4}'.
                 }
             };
 
@@ -769,26 +737,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             IDictionary<string, string> properties = context.Properties;
             string path = properties[nameof(path)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(path),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {                  // The configuration in 
-                        path,          // '{0}' did not explicitly disable 'enableVersionHeader' in the <httpRuntime> section.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(path),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {                  // The configuration in 
+                    path,          // '{0}' did not explicitly disable 'enableVersionHeader' in the <httpRuntime> section.
+                }
+            };
+
+            return result;
         }
 
         private Result ConstructWebApplicationDeployedinDebugModeResult(ContrastLogReader.Context context)
@@ -802,26 +768,24 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             string path = properties[nameof(path)];
             string snippet = properties[nameof(snippet)];
 
-            return new Result
+            Result result = CreateResultCore(context);
+            result.Locations = new List<Location>
             {
-                RuleId = context.RuleId,
-                Level = GetRuleFailureLevel(context.RuleId),
-                Locations = new List<Location>
+                new Location
                 {
-                    new Location
-                    {
-                        PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
-                    }
-                },
-                Message = new Message
-                {
-                    Id = "default",
-                    Arguments = new List<string>
-                    {                  // The configuration in 
-                        path,          // '{0}' has 'debug' set to 'true' in the <compilation> section.
-                    }
+                    PhysicalLocation = CreatePhysicalLocation(path, CreateRegion(snippet)),
                 }
             };
+            result.Message = new Message
+            {
+                Id = "default",
+                Arguments = new List<string>
+                {                  // The configuration in 
+                    path,          // '{0}' has 'debug' set to 'true' in the <compilation> section.
+                }
+            };
+
+            return result;
         }
 
         private Region CreateRegion(string snippet)
@@ -862,6 +826,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         private string NaiveXmlDecode(string snippet)
         {
             return snippet.Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">").Replace("&quot;", "\"").Replace("&apos;", "'");
+        }
+
+        private Result CreateResultCore(ContrastLogReader.Context context)
+        {
+            return new Result
+            {
+                RuleId = context.RuleId,
+                Level = GetRuleFailureLevel(context.RuleId),
+                CodeFlows = CreateCodeFlows(context)
+            };
         }
 
         private IList<CodeFlow> CreateCodeFlows(ContrastLogReader.Context context)

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -846,7 +846,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Protocol = context.RequestProtocol,
                 Version = context.RequestVersion,
                 Method = context.RequestMethod,
-                Target = new Uri(context.RequestTarget, UriKind.RelativeOrAbsolute)
+                Target = new Uri(context.RequestTarget, UriKind.RelativeOrAbsolute),
+                Headers = context.Headers
             };
         }
 

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -848,7 +848,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 Method = context.RequestMethod,
                 Target = new Uri(context.RequestTarget, UriKind.RelativeOrAbsolute),
                 Headers = context.Headers,
-                Parameters = context.Parameters
+                Parameters = context.Parameters,
+                Body = string.IsNullOrEmpty(context.RequestBody)
+                    ? null
+                    : new ArtifactContent
+                    {
+                        Text = context.RequestBody
+                    }
             };
         }
 
@@ -936,6 +942,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             public string RequestMethod { get; set; }
 
             public string RequestTarget { get; set; }
+
+            public string RequestBody { get; set; }
 
             // Holds properties produced by both the <props> and
             // <properties> elements within Contrast XML
@@ -1183,7 +1191,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static void ReadBody(SparseReader reader, object parent)
         {
-            reader.ReadChildren(SchemaStrings.ElementBody, parent);
+            Context context = (Context)parent;
+            context.RequestBody = reader.ReadElementContentAsString();
         }
 
         private static void ReadHeaders(SparseReader reader, object parent)


### PR DESCRIPTION
We populate the new SARIF `request` object with the contents of the CS `<request>` element.

Also:
- DRY out the core result creation logic into a helper method `CreateResultCore`.
- Fix a bug that prevented `<p>` elements from being processed.