### PR TITLE
Bug fixes: request target to string, anyOf{address, artifactLocation} 

### DIFF
--- a/scripts/New-VersionConstantsFile.ps1
+++ b/scripts/New-VersionConstantsFile.ps1
@@ -30,6 +30,7 @@ namespace $namespace
     {
         public const string Prerelease = "$versionSuffix";
         public const string AssemblyVersion = "$versionPrefix";
+        public const string PackageVersionSuffix = "$packageVersionSuffix";
         public const string FileVersion = AssemblyVersion + ".0";
     }
 }

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -309,5 +309,9 @@
 * API BREAKING: All SARIF state dictionaries now contains multiformat strings as values. https://github.com/oasis-tcs/sarif-spec/issues/361
 * API NON-BREAKING: Define `request` and `response` objects. https://github.com/oasis-tcs/sarif-spec/issues/362
 
-## **v2.1.0-beta.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.0))
+## **v2.1.0-beta.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.1))
 * API BREAKING: Change `request.uri` to `request.target`. https://github.com/oasis-tcs/sarif-spec/issues/362
+
+## **v2.1.0-beta.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.2)
+* API NON-BREAKING: Change `request.target` type to string. https://github.com/oasis-tcs/sarif-spec/issues/362
+* API BREAKING: anyOf `physicalLocation.artifactLocation` and `physicalLocation.address` is required. https://github.com/oasis-tcs/sarif-spec/issues/353

--- a/src/Sarif/Autogenerated/Request.cs
+++ b/src/Sarif/Autogenerated/Request.cs
@@ -51,10 +51,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         public string Version { get; set; }
 
         /// <summary>
-        /// The URI to which the request is directed.
+        /// The target of the request.
         /// </summary>
         [DataMember(Name = "target", IsRequired = false, EmitDefaultValue = false)]
-        public Uri Target { get; set; }
+        public string Target { get; set; }
 
         /// <summary>
         /// The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Request(int index, string protocol, string version, Uri target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        public Request(int index, string protocol, string version, string target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Init(index, protocol, version, target, method, headers, parameters, body, properties);
         }
@@ -165,16 +165,12 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Request(this);
         }
 
-        private void Init(int index, string protocol, string version, Uri target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        private void Init(int index, string protocol, string version, string target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Index = index;
             Protocol = protocol;
             Version = version;
-            if (target != null)
-            {
-                Target = new Uri(target.OriginalString, target.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative);
-            }
-
+            Target = target;
             Method = method;
             Headers = headers;
             Parameters = parameters;

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Uri(
                     SarifSchemaUriBase +
                     sarifVersion.ConvertToText() +
-                    (sarifVersion == SarifVersion.Current ? "-beta.1" : ""), UriKind.Absolute);
+                    (sarifVersion == SarifVersion.Current ? VersionConstants.PackageVersionSuffix : ""), UriKind.Absolute);
         }
 
         public static Dictionary<string, string> BuildMessageFormats(IEnumerable<string> resourceNames, ResourceManager resourceManager)

--- a/src/Sarif/Schemata/sarif-schema.json
+++ b/src/Sarif/Schemata/sarif-schema.json
@@ -1517,7 +1517,16 @@
           "description": "Key/value pairs that provide additional information about the physical location.",
           "$ref": "#/definitions/propertyBag"
         }
-      }
+      },
+
+      "anyOf": [
+        {
+          "required": [ "address" ]
+        },
+        {
+          "required": [ "artifactLocation" ]
+        }
+      ]
     },
 
     "propertyBag": {
@@ -1905,9 +1914,8 @@
         },
 
         "target": {
-          "description": "The URI to which the request is directed.",
-          "type": "string",
-          "format": "uri"
+          "description": "The target of the request.",
+          "type": "string"
         },
 
         "method": {

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     {
         public const string Prerelease = "";
         public const string AssemblyVersion = "2.1.0";
+        public const string PackageVersionSuffix = "-beta.2";
         public const string FileVersion = AssemblyVersion + ".0";
     }
 }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultBasic.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultBasic.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultWithTwoTraces.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultWithTwoTraces.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/TwoResultsWithNodeRefs.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/TwoResultsWithNodeRefs.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_ComprehensiveRegionProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_ComprehensiveRegionProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_ContextRegionSnippets.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_ContextRegionSnippets.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_FlattenedMessages.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_FlattenedMessages.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_Hashes+TextFiles+ComprehensiveRegionProperties+RegionSnippets+ContextRegionSnippets+FlattenedMessages.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_Hashes+TextFiles+ComprehensiveRegionProperties+RegionSnippets+ContextRegionSnippets+FlattenedMessages.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_Hashes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_Hashes.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_RegionSnippets.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_RegionSnippets.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_TextFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests_TextFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveFileProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveFileProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.01-24.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.01-24.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/MultiformatMessageStrings.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/MultiformatMessageStrings.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RuleIdCollisions.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RuleIdCollisions.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RunResources.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RunResources.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ToolWithLanguage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ToolWithLanguage.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithExternalPropertyFiles.01-24.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithExternalPropertyFiles.01-24.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithSuppressions.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithSuppressions.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/CodeFlows.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/CodeFlows.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/Minimum.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/Minimum.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithLanguage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithLanguage.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithPropertiesAndTags.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithPropertiesAndTags.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithTwoRuns.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithTwoRuns.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NotificationExceptionWithStack.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NotificationExceptionWithStack.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithAllReportingDescriptors.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithAllReportingDescriptors.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithBasicInvocation.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithBasicInvocation.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithInvocationAndNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithInvocationAndNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithLogicalLocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithLogicalLocations.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithNotificationsButNoInvocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithNotificationsButNoInvocations.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithRules.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithRules.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/RestoreFromPropertyBag.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/RestoreFromPropertyBag.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/TwoResultsWithFixes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/TwoResultsWithFixes.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/UriBaseId.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/UriBaseId.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.1",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-beta.2",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <PackageVersionSuffix>-beta.1</PackageVersionSuffix>
+    <PackageVersionSuffix>-beta.2</PackageVersionSuffix>
 
     <!--
     Whenever you increment VersionPrefix or VersionSuffix, copy the old value(s)


### PR DESCRIPTION
1. request.target to string (not uri)
2. anyOf clause added to PhysicalLocation object
3. adding build variable to release prefix and remove hardcoded value.