### PR TITLE
CS: crypto-bad-mac: populate result message, location, and stack.

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -354,7 +354,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             return result;
         }
 
-        private static readonly Regex ClassNameFromCtorRegex = new Regex(@"\.([^.]+)\.\.ctor\(\)$");
+        private static readonly Regex ClassNameFromCtorRegex =
+            new Regex(@"\.(?<className>[^.]+)\.\.ctor\(\)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         private static string GetClassNameFromCtorCall(string fullyQualifiedName)
         {
@@ -363,7 +364,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // If we can't parse this as a ctor invocation, do the best we can: just return
             // the whole string.
             return match.Success
-                ? match.Groups[1].Value
+                ? match.Groups["className"].Value
                 : fullyQualifiedName;
         }
 

--- a/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
+++ b/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
@@ -261,6 +261,9 @@
             "shortDescription": {
               "text": "Verifies only strong hash algorithms are used"
             },
+            "messageStrings": {
+              "default": "'{0}' used the weak '{1}' hash algorithm."
+            },
             "configuration": {
               "defaultLevel": "warning"
             }


### PR DESCRIPTION
Finish implementing the conversion of Contrast Security's `crypto-bad-mac` finding to a SARIF result.