### PR TITLE
CS: crypto-bad-mac: Use message text closer to CS's text.

### DIFF
--- a/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
+++ b/src/Sarif.Converters/RulesData/ContrastSecurity.sarif
@@ -262,7 +262,7 @@
               "text": "Verifies only strong hash algorithms are used"
             },
             "messageStrings": {
-              "default": "'{0}' used the weak '{1}' hash algorithm."
+              "default": "'{0}' obtained a handle to the '{1}' hash algorithm, which is considered insecure."
             },
             "configuration": {
               "defaultLevel": "warning"

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -11346,7 +11346,7 @@
               },
               "messageStrings": {
                 "default": {
-                  "text": "'{0}' used the weak '{1}' hash algorithm."
+                  "text": "'{0}' obtained a handle to the '{1}' hash algorithm, which is considered insecure."
                 }
               }
             },


### PR DESCRIPTION
This ties up a loose end. When I converted the `crypto-bad-mac` rule, I didn't have an account that gave me access to CS's message text, so I made up a message based on the `crypto-bad-cypher` rule. It turns out the actual text is even closer to the text of the `crypto-bad-cypher` rule.