### PR TITLE
CS: Implement rule http-only-disabled

### DIFF
--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -1,14 +1,8 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.1.json",
   "version": "2.1.0",
   "runs": [
     {
-      "originalUriBaseIds": {
-        "SITE_ROOT": {
-          "uri": "file:///E:/src/WebGoat.NET"
-        }
-      },
-      "columnKind": "utf16CodeUnits",
       "artifacts": [
         {
           "mimeType": "text/xml"
@@ -140,295 +134,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -439,330 +329,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -773,170 +515,644 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -1536,9 +1752,11 @@
           },
           "locations": [
             {
-              "logicalLocation": {
-                "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
-              }
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
+                }
+              ]
             }
           ],
           "stacks": [
@@ -1546,156 +1764,200 @@
               "frames": [
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "void System.Security.Cryptography.SHA1Managed..ctor()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "void System.Security.Cryptography.SHA1Managed..ctor()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                      }
+                    ]
                   }
                 },
                 {
                   "location": {
-                    "logicalLocation": {
-                      "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                    }
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                      }
+                    ]
                   }
                 }
               ]
@@ -1748,9 +2010,11 @@
           },
           "locations": [
             {
-              "logicalLocation": {
-                "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
-              }
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
+                }
+              ]
             }
           ],
           "codeFlows": [
@@ -1763,149 +2027,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Web.HttpPostedFile.get_FileName()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Web.HttpPostedFile.get_FileName()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_Files()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Files()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -1916,121 +2222,155 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -2041,142 +2381,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.IO.FileStream..ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.String,System.Boolean)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.IO.FileStream..ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.String,System.Boolean)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.IO.FileStream..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.IO.FileStream..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -2246,316 +2626,200 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -2566,156 +2830,200 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -2726,254 +3034,530 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -3034,295 +3618,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -3333,316 +3813,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Byte[] System.Text.Encoding.GetBytes(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Text.Encoding.GetString(System.Byte[])"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -3653,310 +3999,806 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Byte[] System.Text.Encoding.GetBytes(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Text.Encoding.GetString(System.Byte[])"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4034,295 +4876,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4333,295 +5071,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4632,323 +5257,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4959,163 +5452,812 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -5193,295 +6335,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -5492,330 +6530,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -5826,170 +6716,644 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -6063,302 +7427,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -6369,240 +7622,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -6613,240 +7817,620 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -6910,295 +8494,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -7209,330 +8689,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -7543,170 +8875,644 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -7784,295 +9590,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -8083,295 +9785,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -8382,330 +9971,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -8716,170 +10166,830 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -8945,50 +11055,10 @@
                   "snippet": {
                     "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 10,
-                  "endLine": 14,
-                  "snippet": {
-                    "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "authorization-missing-deny",
@@ -9011,50 +11081,10 @@
                   "snippet": {
                     "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 10,
-                  "endLine": 14,
-                  "snippet": {
-                    "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "authorization-missing-deny",
@@ -9077,50 +11107,10 @@
                   "snippet": {
                     "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 10,
-                  "endLine": 14,
-                  "snippet": {
-                    "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "authorization-missing-deny",
@@ -9143,50 +11133,10 @@
                   "snippet": {
                     "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 10,
-                  "endLine": 14,
-                  "snippet": {
-                    "text": "     <system.web>\r\n       <authorization>\r\n         <allow users=\"*\"/>\r\n       </authorization>\r\n     </system.web>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "authorization-missing-deny",
@@ -9208,50 +11158,10 @@
                   "snippet": {
                     "text": "     </authentication>\r\n     <authorization>\r\n       <allow users=\"*\" />\r\n     </authorization>\r\n     <trace enabled=\"false\" localOnly=\"true\" pageOutput=\"false\" requestLimit=\"10\" traceMode=\"SortByTime\" />\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 48,
-                  "endLine": 52,
-                  "snippet": {
-                    "text": "     </authentication>\r\n     <authorization>\r\n       <allow users=\"*\" />\r\n     </authorization>\r\n     <trace enabled=\"false\" localOnly=\"true\" pageOutput=\"false\" requestLimit=\"10\" traceMode=\"SortByTime\" />\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "compilation-debug",
@@ -9274,50 +11184,10 @@
                   "snippet": {
                     "text": "   <system.web>\r\n     <compilation defaultLanguage=\"C#\" debug=\"true\" targetFramework=\"4.0\">\r\n       <assemblies>\r\n         <!--add assembly=\"System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\" /-->\r\n       </assemblies>\r\n     </compilation>\r\n     <httpCookies httpOnlyCookies=\"false\" />\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 30,
-                  "endLine": 36,
-                  "snippet": {
-                    "text": "   <system.web>\r\n     <compilation defaultLanguage=\"C#\" debug=\"true\" targetFramework=\"4.0\">\r\n       <assemblies>\r\n         <!--add assembly=\"System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\" /-->\r\n       </assemblies>\r\n     </compilation>\r\n     <httpCookies httpOnlyCookies=\"false\" />\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "custom-errors-off",
@@ -9339,50 +11209,10 @@
                   "snippet": {
                     "text": "     <!-- show detailed error messages -->\r\n     <customErrors mode=\"Off\" />\r\n     <!-- set up users -->\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 37,
-                  "endLine": 39,
-                  "snippet": {
-                    "text": "     <!-- show detailed error messages -->\r\n     <customErrors mode=\"Off\" />\r\n     <!-- set up users -->\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "event-validation-disabled",
@@ -9404,50 +11234,10 @@
                   "snippet": {
                     "text": " <%@ Page Title=\"\" Language=\"C#\" MasterPageFile=\"~/Resources/Master-Pages/Site.Master\" AutoEventWireup=\"true\" CodeBehind=\"HeaderInjection.aspx.cs\" Inherits=\"OWASP.WebGoat.NET.HeaderInjection\" EnableEventValidation=\"false\" %>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 1,
-                  "endLine": 1,
-                  "snippet": {
-                    "text": " <%@ Page Title=\"\" Language=\"C#\" MasterPageFile=\"~/Resources/Master-Pages/Site.Master\" AutoEventWireup=\"true\" CodeBehind=\"HeaderInjection.aspx.cs\" Inherits=\"OWASP.WebGoat.NET.HeaderInjection\" EnableEventValidation=\"false\" %>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "forms-auth-ssl",
@@ -9469,57 +11259,36 @@
                   "snippet": {
                     "text": "     <!-- set up users -->\r\n     <authentication mode=\"Forms\">\r\n       <forms name=\"customer_login\" timeout=\"30\" loginUrl=\"~/WebGoatCoins/CustomerLogin.aspx\" requireSSL=\"false\" protection=\"All\" path=\"/\">\r\n         <credentials passwordFormat=\"Clear\">\r\n           <user name=\"admin\" password=\"******\" />\r\n           <user name=\"mario\" password=\"******\" />\r\n           <user name=\"bob\" password=\"******\" />\r\n         </credentials>\r\n       </forms>\r\n     </authentication>\r\n     <authorization>\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 39,
-                  "endLine": 49,
-                  "snippet": {
-                    "text": "     <!-- set up users -->\r\n     <authentication mode=\"Forms\">\r\n       <forms name=\"customer_login\" timeout=\"30\" loginUrl=\"~/WebGoatCoins/CustomerLogin.aspx\" requireSSL=\"false\" protection=\"All\" path=\"/\">\r\n         <credentials passwordFormat=\"Clear\">\r\n           <user name=\"admin\" password=\"******\" />\r\n           <user name=\"mario\" password=\"******\" />\r\n           <user name=\"bob\" password=\"******\" />\r\n         </credentials>\r\n       </forms>\r\n     </authentication>\r\n     <authorization>\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "POST",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Referer": "http://localhost/webgoat/Content/SQLInjection.aspx",
-              "Cookie": "ASP.NET_SessionId=3bvbfl2ggq3rrfq0e4cjz5lw; Server=TUJQMTUtSkxBRU1TQUU=",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Content-Length": "664",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Cache-Control": "max-age=0",
-              "Origin": "http://localhost",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9",
-              "Content-Type": "application/x-www-form-urlencoded"
-            },
-            "parameters": {
-              "ctl00$BodyContentPlaceholder$txtName": "foo",
-              "__EVENTARGUMENT": "",
-              "ctl00$BodyContentPlaceholder$btnAdd": "Find Employee",
-              "__EVENTVALIDATION": "/wEdAAXFFV2YeJ5AkvcDd4Ye3coq+3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu+TE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5+mgR0Jm+/llCb",
-              "__VIEWSTATE": "/wEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74+lNTjvvwJ9WiFbVRte23g==",
-              "__VIEWSTATEGENERATOR": "9071A776",
-              "__EVENTTARGET": ""
-            },
-            "body": {
-              "text": "__EVENTTARGET=&__EVENTARGUMENT=&__VIEWSTATE=%2FwEPDwULLTE0NDg2NDYzMjcPZBYCZg9kFgICAQ9kFgICFA9kFgICBw88KwARAQwUKwAAZBgCBR5fX0NvbnRyb2xzUmVxdWlyZVBvc3RCYWNrS2V5X18WAgUbY3RsMDAkSGVhZExvZ2luU3RhdHVzJGN0bDAxBRtjdGwwMCRIZWFkTG9naW5TdGF0dXMkY3RsMDMFJWN0bDAwJEJvZHlDb250ZW50UGxhY2Vob2xkZXIkZ3JkRW1haWwPZ2RILRXq3x4SRzyxj1IO6zt74%2BlNTjvvwJ9WiFbVRte23g%3D%3D&__VIEWSTATEGENERATOR=9071A776&__EVENTVALIDATION=%2FwEdAAXFFV2YeJ5AkvcDd4Ye3coq%2B3XrywIBK9nhpIZk9EK4VTH0GMPwcYmUwu7s0kAXW2LrmNirPZxcmkLzu%2BTE8ZRAz0w9VItIX2K86h4ePnbpFm0NvvCRVOyOp9jTyrijsKpNmDQPtH5%2BmgR0Jm%2B%2FllCb&ctl00%24BodyContentPlaceholder%24txtName=foo&ctl00%24BodyContentPlaceholder%24btnAdd=Find+Employee"
-            }
-          }
+          ]
         },
         {
           "ruleId": "http-only-disabled",
           "level": "note",
           "message": {
-            "text": "TODO: missing message construction for rule 'http-only-disabled'."
-          }
+            "id": "default",
+            "arguments": [
+              "\\web.config"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                },
+                "region": {
+                  "startLine": 35,
+                  "endLine": 37,
+                  "snippet": {
+                    "text": "     </compilation>\r\n     <httpCookies httpOnlyCookies=\"false\" />\r\n     <!-- show detailed error messages -->\r\n"
+                  }
+                }
+              }
+            }
+          ]
         },
         {
           "ruleId": "request-validation-disabled",
@@ -9561,32 +11330,10 @@
                   "snippet": {
                     "text": "     <trace enabled=\"false\" localOnly=\"true\" pageOutput=\"false\" requestLimit=\"10\" traceMode=\"SortByTime\" />\r\n     <sessionState mode=\"InProc\" cookieless=\"false\" timeout=\"20000\" />\r\n     <!-- setting cookieless = true breaks app -->\r\n"
                   }
-                },
-                "contextRegion": {
-                  "startLine": 52,
-                  "endLine": 54,
-                  "snippet": {
-                    "text": "     <trace enabled=\"false\" localOnly=\"true\" pageOutput=\"false\" requestLimit=\"10\" traceMode=\"SortByTime\" />\r\n     <sessionState mode=\"InProc\" cookieless=\"false\" timeout=\"20000\" />\r\n     <!-- setting cookieless = true breaks app -->\r\n"
-                  }
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "GET",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9"
-            }
-          }
+          ]
         },
         {
           "ruleId": "version-header-enabled",
@@ -9605,22 +11352,7 @@
                 }
               }
             }
-          ],
-          "webRequest": {
-            "protocol": "http",
-            "version": "1.1",
-            "target": "/webgoat/Content/SQLInjection.aspx",
-            "method": "GET",
-            "headers": {
-              "User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36",
-              "Connection": "keep-alive",
-              "Upgrade-Insecure-Requests": "1",
-              "Host": "localhost",
-              "Accept-Encoding": "gzip, deflate, br",
-              "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-              "Accept-Language": "en-US,en;q=0.9"
-            }
-          }
+          ]
         },
         {
           "ruleId": "sql-injection",
@@ -9654,295 +11386,191 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -9953,330 +11581,182 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -10287,170 +11767,644 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -10527,218 +12481,137 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "stack": {
-                        "frames": [
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -10749,107 +12622,137 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -10860,121 +12763,137 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
-                            }
-                          },
-                          {
-                            "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -10985,121 +12904,314 @@
                         "frames": [
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
                             }
                           },
                           {
                             "location": {
-                              "logicalLocation": {
-                                "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
-                              }
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "stack": {
+                        "frames": [
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "location": {
+                              "logicalLocations": [
+                                {
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -11722,7 +13834,14 @@
             }
           ]
         }
-      }
+      },
+      "language": "en-US",
+      "originalUriBaseIds": {
+        "SITE_ROOT": {
+          "uri": "file:///E:/src/WebGoat.NET"
+        }
+      },
+      "columnKind": "utf16CodeUnits"
     }
   ]
 }


### PR DESCRIPTION
Also:

- When the XML contains a `snippet` property, generate `physicalLocation.region`, but not `contextRegion`. There is no need to generate `contextRegion` when it is the same as `region`.
- Bug fix: We we not clearing the web request properties from the context after each `finding`. As a result, we were emitting "stale" `webRequest` objects on findings that don't have a request at all (such as `http-only-disabled`, which is how I noticed this).
- Bug fix: Don't emit an empty `webRequest` object if the XML does not define a request. (Again, `http-only-disabled` was doing this -- as were all the "NYI" rules.)