### PR TITLE
Do not emit an artificial absolute URI base

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -69,11 +69,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Run run = sarifLog.Runs[0];
             _rules = run.Tool.Driver.Rules.ToDictionary(rule => rule.Id);
 
-            run.OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
-            {
-                {  "SITE_ROOT", new ArtifactLocation { Uri = new Uri(@"E:\src\WebGoat.NET") } } 
-            };
-
             // 3. Now, parse all the contrast XML to create the complete results set.
             var results = new List<Result>();
             var reader = new ContrastLogReader();
@@ -1090,13 +1085,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private PhysicalLocation CreatePhysicalLocation(string uri, Region region = null)
         {
-            uri = @"E:\src\WebGoat.NET" + uri.Replace(@"/", @"\");
-
             return new PhysicalLocation
             {
                 ArtifactLocation = new ArtifactLocation
                 {
-                    Uri = new Uri(uri, UriKind.Absolute)
+                    Uri = new Uri(uri, UriKind.RelativeOrAbsolute)
                 },
                 Region = region
             };

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     internal sealed class ContrastSecurityConverter : ToolFileConverterBase
     {
         private const string ContrastSecurityRulesData = "Microsoft.CodeAnalysis.Sarif.Converters.RulesData.ContrastSecurity.sarif";
+        private const string SiteRootDescriptionMessageId = "SiteRootDescription";
 
         private IDictionary<string, ReportingDescriptor> _rules;
         private HashSet<Artifact> _files;
@@ -68,6 +69,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             // 2. Retain a pointer to the rules dictionary, which we will use to set rule severity.
             Run run = sarifLog.Runs[0];
             _rules = run.Tool.Driver.Rules.ToDictionary(rule => rule.Id);
+
+            run.OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
+            {
+                {
+                    "SITE_ROOT",
+                    new ArtifactLocation {
+                        Description = new Message {
+                            Id = SiteRootDescriptionMessageId
+                        }
+                    }
+                }
+            };
+
+            run.Tool.Driver.GlobalMessageStrings = new Dictionary<string, MultiformatMessageString>
+            {
+                {
+                    SiteRootDescriptionMessageId,
+                    new MultiformatMessageString
+                    {
+                        Text = ConverterResources.ContrastSecuritySiteRootDescription
+                    }
+                }
+            };
 
             // 3. Now, parse all the contrast XML to create the complete results set.
             var results = new List<Result>();

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
     internal sealed class ContrastSecurityConverter : ToolFileConverterBase
     {
         private const string ContrastSecurityRulesData = "Microsoft.CodeAnalysis.Sarif.Converters.RulesData.ContrastSecurity.sarif";
+        private const string SiteRootUriBaseIdName = "SITE_ROOT";
         private const string SiteRootDescriptionMessageId = "SiteRootDescription";
 
         private IDictionary<string, ReportingDescriptor> _rules;
@@ -616,7 +617,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     {
                         ArtifactLocation = new ArtifactLocation
                         {
-                            //UriBaseId = "RuntimeGenerated",
+                            UriBaseId = SiteRootUriBaseIdName,
                             Uri = new Uri(key, UriKind.RelativeOrAbsolute)
                         },
                         Region = new Region() { StartLine = 1 }
@@ -1113,6 +1114,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             {
                 ArtifactLocation = new ArtifactLocation
                 {
+                    UriBaseId = SiteRootUriBaseIdName,
                     Uri = new Uri(uri, UriKind.RelativeOrAbsolute)
                 },
                 Region = region

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             run.OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>
             {
                 {
-                    "SITE_ROOT",
+                    SiteRootUriBaseIdName,
                     new ArtifactLocation {
                         Description = new Message {
                             Id = SiteRootDescriptionMessageId

--- a/src/Sarif.Converters/ConverterResources.Designer.cs
+++ b/src/Sarif.Converters/ConverterResources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.CodeAnalysis.Sarif {
+namespace Microsoft.CodeAnalysis.Sarif.Converters {
     using System;
     
     

--- a/src/Sarif.Converters/ConverterResources.Designer.cs
+++ b/src/Sarif.Converters/ConverterResources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.CodeAnalysis.Sarif.Converters {
+namespace Microsoft.CodeAnalysis.Sarif {
     using System;
     
     
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ConverterResources {
@@ -147,6 +147,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters {
         internal static string AndroidStudioProblemMissingProblemClass {
             get {
                 return ResourceManager.GetString("AndroidStudioProblemMissingProblemClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The root URI of the web site that was analyzed..
+        /// </summary>
+        internal static string ContrastSecuritySiteRootDescription {
+            get {
+                return ResourceManager.GetString("ContrastSecuritySiteRootDescription", resourceCulture);
             }
         }
         

--- a/src/Sarif.Converters/ConverterResources.resx
+++ b/src/Sarif.Converters/ConverterResources.resx
@@ -207,4 +207,7 @@
   <data name="ErrorAmbiguousConverterType" xml:space="preserve">
     <value>The converter plugin assembly "{0}" contains more than one public class "{1}".</value>
   </data>
+  <data name="ContrastSecuritySiteRootDescription" xml:space="preserve">
+    <value>The root URI of the web site that was analyzed.</value>
+  </data>
 </root>

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <EmbeddedResource Update="ConverterResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
-      <CustomToolNamespace>Microsoft.CodeAnalysis.Sarif</CustomToolNamespace>
+      <CustomToolNamespace>Microsoft.CodeAnalysis.Sarif.Converters</CustomToolNamespace>
       <LastGenOutput>ConverterResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -11,6 +11,22 @@
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
+
+  <ItemGroup>
+    <EmbeddedResource Update="ConverterResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <CustomToolNamespace>Microsoft.CodeAnalysis.Sarif</CustomToolNamespace>
+      <LastGenOutput>ConverterResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="ConverterResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ConverterResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <None Remove="RulesData\ContrastSecurity.sarif" />

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -119,7 +119,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -1211,7 +1212,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1221,7 +1223,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1231,7 +1234,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Default.aspx"
+                  "uri": "/webgoat/Default.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1241,7 +1245,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1251,7 +1256,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1261,7 +1267,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/RebuildDatabase.aspx"
+                  "uri": "/webgoat/RebuildDatabase.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1271,7 +1278,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/PathManipulation.aspx"
+                  "uri": "/webgoat/Content/PathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1281,7 +1289,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1291,7 +1300,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/UploadPathManipulation.aspx"
+                  "uri": "/webgoat/Content/UploadPathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1301,7 +1311,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/MessageDigest.aspx"
+                  "uri": "/webgoat/Content/MessageDigest.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1311,7 +1322,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1321,7 +1333,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1331,7 +1344,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ExploitDebug.aspx"
+                  "uri": "/webgoat/Content/ExploitDebug.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1341,7 +1355,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1351,7 +1366,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Logout.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Logout.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1
@@ -1391,154 +1407,176 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx"
+                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Default.aspx"
+                  "uri": "/webgoat/Default.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/ProxySetup.aspx"
+                  "uri": "/webgoat/ProxySetup.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/RebuildDatabase.aspx"
+                  "uri": "/webgoat/RebuildDatabase.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/PathManipulation.aspx"
+                  "uri": "/webgoat/Content/PathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/UploadPathManipulation.aspx"
+                  "uri": "/webgoat/Content/UploadPathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/MessageDigest.aspx"
+                  "uri": "/webgoat/Content/MessageDigest.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Orders.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Orders.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ExploitDebug.aspx"
+                  "uri": "/webgoat/Content/ExploitDebug.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Logout.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Logout.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -1573,154 +1611,176 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx"
+                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Default.aspx"
+                  "uri": "/webgoat/Default.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/ProxySetup.aspx"
+                  "uri": "/webgoat/ProxySetup.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/RebuildDatabase.aspx"
+                  "uri": "/webgoat/RebuildDatabase.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/PathManipulation.aspx"
+                  "uri": "/webgoat/Content/PathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/UploadPathManipulation.aspx"
+                  "uri": "/webgoat/Content/UploadPathManipulation.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/MessageDigest.aspx"
+                  "uri": "/webgoat/Content/MessageDigest.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Orders.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Orders.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ExploitDebug.aspx"
+                  "uri": "/webgoat/Content/ExploitDebug.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Logout.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Logout.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -2611,7 +2671,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -3603,7 +3664,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -4861,7 +4923,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -6320,7 +6383,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -7412,7 +7476,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -8479,7 +8544,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -9575,7 +9641,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -11047,7 +11114,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 10,
@@ -11073,7 +11141,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 10,
@@ -11099,7 +11168,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 10,
@@ -11125,7 +11195,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 10,
@@ -11150,7 +11221,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 48,
@@ -11176,7 +11248,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 30,
@@ -11201,7 +11274,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 37,
@@ -11226,7 +11300,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/Content/HeaderInjection.aspx"
+                  "uri": "/Content/HeaderInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1,
@@ -11250,7 +11325,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 39,
@@ -11276,7 +11352,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 35,
@@ -11301,7 +11378,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/WebGoatCoins/ProductDetails.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 1,
@@ -11326,7 +11404,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -11360,7 +11439,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 39,
@@ -11387,7 +11467,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 },
                 "region": {
                   "startLine": 52,
@@ -11413,7 +11494,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/web.config"
+                  "uri": "/web.config",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -11436,7 +11518,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }
@@ -12531,7 +12614,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx",
+                  "uriBaseId": "SITE_ROOT"
                 }
               }
             }

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -119,7 +119,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx"
                 }
               }
             }
@@ -1391,154 +1391,154 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/MainPage.aspx"
+                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Default.aspx"
+                  "uri": "/webgoat/Default.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/ProxySetup.aspx"
+                  "uri": "/webgoat/ProxySetup.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/RebuildDatabase.aspx"
+                  "uri": "/webgoat/RebuildDatabase.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/PathManipulation.aspx"
+                  "uri": "/webgoat/Content/PathManipulation.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Catalog.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ChangePassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/UploadPathManipulation.aspx"
+                  "uri": "/webgoat/Content/UploadPathManipulation.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/MessageDigest.aspx"
+                  "uri": "/webgoat/Content/MessageDigest.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Orders.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Orders.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ExploitDebug.aspx"
+                  "uri": "/webgoat/Content/ExploitDebug.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Logout.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Logout.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx"
                 }
               }
             }
@@ -1566,161 +1566,161 @@
             "id": "default",
             "arguments": [
               "22",
-              "file:///E:/src/WebGoat.NET/webgoat/Content/EncryptVSEncode.aspx"
+              "/webgoat/Content/EncryptVSEncode.aspx"
             ]
           },
           "locations": [
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/MainPage.aspx"
+                  "uri": "/webgoat/WebGoatCoins/MainPage.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Default.aspx"
+                  "uri": "/webgoat/Default.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/ProxySetup.aspx"
+                  "uri": "/webgoat/ProxySetup.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/RebuildDatabase.aspx"
+                  "uri": "/webgoat/RebuildDatabase.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/PathManipulation.aspx"
+                  "uri": "/webgoat/Content/PathManipulation.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Catalog.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Catalog.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ChangePassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ChangePassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/UploadPathManipulation.aspx"
+                  "uri": "/webgoat/Content/UploadPathManipulation.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/MessageDigest.aspx"
+                  "uri": "/webgoat/Content/MessageDigest.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Orders.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Orders.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ForgotPassword.aspx"
+                  "uri": "/webgoat/Content/ForgotPassword.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ExploitDebug.aspx"
+                  "uri": "/webgoat/Content/ExploitDebug.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Logout.aspx"
+                  "uri": "/webgoat/WebGoatCoins/Logout.aspx"
                 }
               }
             },
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ProductDetails.aspx"
                 }
               }
             }
@@ -2611,7 +2611,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/ReflectedXSS.aspx"
+                  "uri": "/webgoat/Content/ReflectedXSS.aspx"
                 }
               }
             }
@@ -3603,7 +3603,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/EncryptVSEncode.aspx"
+                  "uri": "/webgoat/Content/EncryptVSEncode.aspx"
                 }
               }
             }
@@ -4861,7 +4861,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/StoredXSS.aspx"
+                  "uri": "/webgoat/Content/StoredXSS.aspx"
                 }
               }
             }
@@ -6320,7 +6320,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjectionDiscovery.aspx"
+                  "uri": "/webgoat/Content/SQLInjectionDiscovery.aspx"
                 }
               }
             }
@@ -7412,7 +7412,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
                 }
               }
             }
@@ -8479,7 +8479,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/CustomerLogin.aspx"
+                  "uri": "/webgoat/WebGoatCoins/CustomerLogin.aspx"
                 }
               }
             }
@@ -9575,7 +9575,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx"
                 }
               }
             }
@@ -11047,7 +11047,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 10,
@@ -11073,7 +11073,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 10,
@@ -11099,7 +11099,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 10,
@@ -11125,7 +11125,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 10,
@@ -11150,7 +11150,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 48,
@@ -11176,7 +11176,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 30,
@@ -11201,7 +11201,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 37,
@@ -11226,7 +11226,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/Content/HeaderInjection.aspx"
+                  "uri": "/Content/HeaderInjection.aspx"
                 },
                 "region": {
                   "startLine": 1,
@@ -11250,7 +11250,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 39,
@@ -11276,7 +11276,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 35,
@@ -11301,7 +11301,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/WebGoatCoins/ProductDetails.aspx"
+                  "uri": "/WebGoatCoins/ProductDetails.aspx"
                 },
                 "region": {
                   "startLine": 1,
@@ -11326,7 +11326,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/Content/SQLInjection.aspx"
+                  "uri": "/webgoat/Content/SQLInjection.aspx"
                 }
               }
             }
@@ -11360,7 +11360,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 39,
@@ -11387,7 +11387,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 },
                 "region": {
                   "startLine": 52,
@@ -11413,7 +11413,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/web.config"
+                  "uri": "/web.config"
                 }
               }
             }
@@ -11436,7 +11436,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/ForgotPassword.aspx"
+                  "uri": "/webgoat/WebGoatCoins/ForgotPassword.aspx"
                 }
               }
             }
@@ -12531,7 +12531,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///E:/src/WebGoat.NET/webgoat/WebGoatCoins/Autocomplete.ashx"
+                  "uri": "/webgoat/WebGoatCoins/Autocomplete.ashx"
                 }
               }
             }
@@ -13906,11 +13906,6 @@
         }
       },
       "language": "en-US",
-      "originalUriBaseIds": {
-        "SITE_ROOT": {
-          "uri": "file:///E:/src/WebGoat.NET"
-        }
-      },
       "columnKind": "utf16CodeUnits"
     }
   ]

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -13313,6 +13313,11 @@
       "tool": {
         "driver": {
           "name": "Contrast Security",
+          "globalMessageStrings": {
+            "SiteRootDescription": {
+              "text": "The root URI of the web site that was analyzed."
+            }
+          },
           "rules": [
             {
               "id": "cache-controls-missing",
@@ -13906,6 +13911,13 @@
         }
       },
       "language": "en-US",
+      "originalUriBaseIds": {
+        "SITE_ROOT": {
+          "description": {
+            "id": "SiteRootDescription"
+          }
+        }
+      },
       "columnKind": "utf16CodeUnits"
     }
   ]


### PR DESCRIPTION
I’d like you both to look at this PR, not because it has anything to do with Contrast Security, but because it corrects a misuse of the `uriBaseId` mechanism. This is generally useful guidance.

The CS converter does three things wrong:

1. It artificially prepends "E:\src\WebGoat" to the `uri` property of every `artifactLocation` object it creates. This is wrong. In general `artifactLocation.uri` should be a relative reference. (There are exceptions; this isn’t one.)
2. It also emits a `run.originalUriBaseIds` property that assigns that same prefix to `SITE_ROOT`. But the converter has no way of knowing this value; it’s not in the XML file.
3. Having set `SITE_ROOT`, the converter doesn’t actually _use_ it as the value for `uriBaseId` in the `artifactLocation` objects it creates. 

The right thing to do is:

1. Leave the `artifactLocation.uri` values as relative references.
2. Do not supply the `uri` in `run.originalUriBaseIds`, since you don’t know its value.
3. _Do_ provide a `description` in `run.originalUriBaseIds`, allowing a viewer to display a hint to the user when prompting for the value.
4. Add `"uriBaseId": "SITE_ROOT"` to every `artifactLocation` object.

