### PR TITLE
Fix #1514: location.logicalLocation convenience setter mishandles null

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -388,3 +388,4 @@
 * Change schema uri to secure (https) instance.
 * BUGFIX: Fix tranformer bug where schema id would not be updated if no other transformation occurred.
 * BUGFIX: `threadFlowLocation.kind` value is getting lost during pre-release transformation. https://github.com/microsoft/sarif-sdk/issues/1502
+* BUGFIX: `logicalLocation.location` convenience setter mishandles null. https://github.com/microsoft/sarif-sdk/issues/1514

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -388,4 +388,4 @@
 * Change schema uri to secure (https) instance.
 * BUGFIX: Fix tranformer bug where schema id would not be updated if no other transformation occurred.
 * BUGFIX: `threadFlowLocation.kind` value is getting lost during pre-release transformation. https://github.com/microsoft/sarif-sdk/issues/1502
-* BUGFIX: `logicalLocation.location` convenience setter mishandles null. https://github.com/microsoft/sarif-sdk/issues/1514
+* BUGFIX: `location.logicalLocation` convenience setter mishandles null. https://github.com/microsoft/sarif-sdk/issues/1514

--- a/src/Sarif/Core/Location.cs
+++ b/src/Sarif/Core/Location.cs
@@ -10,7 +10,16 @@ namespace Microsoft.CodeAnalysis.Sarif
         public LogicalLocation LogicalLocation
         {
             get { return LogicalLocations?[0]; }
-            set { LogicalLocations = new List<LogicalLocation> { value }; }
+            set {
+                if (value != null)
+                {
+                    LogicalLocations = new List<LogicalLocation> { value };
+                }
+                else
+                {
+                    LogicalLocations = null;
+                }
+            }
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/LocationTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/LocationTests.cs
@@ -1,0 +1,84 @@
+﻿using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
+{
+    public class LocationTests
+    {
+        [Fact]
+        public void Location_LogicalLocation_WhenLogicalLocationsIsAbsent_ReturnsNull()
+        {
+            var location = new Location();
+
+            location.LogicalLocation.Should().BeNull();
+        }
+
+        [Fact]
+        public void Location_LogicalLocation_WhenLogicalLocationsIsPresent_ReturnsFirstArrayElement()
+        {
+            var location = new Location
+            {
+                LogicalLocations = new LogicalLocation[]
+                {
+                    new LogicalLocation
+                    {
+                        FullyQualifiedName = "A.B"
+                    },
+                    new LogicalLocation
+                    {
+                        FullyQualifiedName = "C.D"
+                    }
+                }
+            };
+
+            location.LogicalLocation.FullyQualifiedName.Should().Be("A.B");
+        }
+
+        [Fact]
+        public void Location_LogicalLocation_WhenSetToNonNull_ReplacesLogicalLocationsArray()
+        {
+            var location = new Location
+            {
+                LogicalLocations = new LogicalLocation[]
+                {
+                    new LogicalLocation
+                    {
+                        FullyQualifiedName = "A.B"
+                    },
+                    new LogicalLocation
+                    {
+                        FullyQualifiedName = "C.D"
+                    }
+                }
+            };
+
+            location.LogicalLocation = new LogicalLocation
+            {
+                FullyQualifiedName = "X.Y"
+            };
+
+            location.LogicalLocations.Count.Should().Be(1);
+            location.LogicalLocations[0].FullyQualifiedName.Should().Be("X.Y");
+        }
+
+        [Fact]
+        public void Location_LogicalLocation_WhenSetToNull_RemovesLogicalLocationsArray()
+        {
+            var location = new Location
+            {
+                LogicalLocations = new LogicalLocation[]
+                {
+                    new LogicalLocation
+                    {
+                        FullyQualifiedName = "A.B"
+                    }
+                }
+            };
+
+            location.LogicalLocation = null;
+
+            location.LogicalLocations.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
If you set `location.LogicalLocation` to `null`, the convenience property sets `location.LogicalLocations` to an array with a single `null` element, which serializes as `"logicalLocations": [ {} ]`. The right answer is for it to set `location.LogicalLocations` to `null`, which would be omitted from the serialization.

Add unit tests for the convenience property.