### PR TITLE
Fix #1530: CS converter doesn't produce threadFlowLocation.location.

### DIFF
--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -1536,10 +1536,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static readonly Regex LogicalLocationRegex =
             new Regex(
-                @"
-                  ([^\s]*\s+)?         # Skip over an optional leading blank-terminated return type name such as 'void '
-                  (?<fqln>[^(]+)       # Take everything up to the opening parenthesis.
-                ",
+                @"^
+                  ([^\s]*\s+)?         # Skip over an optional leading blank-terminated return type name such as 'void '.
+                  (?<fqln>.*)          # Take everything else.
+                $",
                 RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
 
         private static string RemoveReturnTypeFrom(string signature)

--- a/src/Sarif.Converters/ContrastSecurityConverter.cs
+++ b/src/Sarif.Converters/ContrastSecurityConverter.cs
@@ -1121,14 +1121,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             };
         }
 
-        private static readonly Regex LogicalLocationRegex =
-            new Regex(
-                @"
-                  ([^\s]*\s+)?         # Skip over an optional leading blank-terminated return type name such as 'void '
-                  (?<fqln>[^(]+)       # Take everything up to the opening parenthesis.
-                ",
-                RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
-
         // Find the user code method call closest to the top of the stack. This is
         // the location we should report as being responsible for the result.
         private static string GetUserCodeLocation(Stack stack)
@@ -1138,14 +1130,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             foreach (StackFrame frame in stack.Frames)
             {
                 string fullyQualifiedLogicalName = frame.Location.LogicalLocation.FullyQualifiedName;
-                Match match = LogicalLocationRegex.Match(fullyQualifiedLogicalName);
-                if (match.Success)
+                if (!fullyQualifiedLogicalName.StartsWith(SystemPrefix))
                 {
-                    fullyQualifiedLogicalName = match.Groups["fqln"].Value;
-                    if (!fullyQualifiedLogicalName.StartsWith(SystemPrefix))
-                    {
-                        return fullyQualifiedLogicalName;
-                    }
+                    return fullyQualifiedLogicalName;
                 }
             }
 
@@ -1533,16 +1520,37 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         private static StackFrame CreateStackFrameFromSignature(string signature)
         {
+            string signatureMinusReturnType = RemoveReturnTypeFrom(signature);
+
             return new StackFrame
             {
                 Location = new Location
                 {
                     LogicalLocation = new LogicalLocation
                     {
-                        FullyQualifiedName = signature
+                        FullyQualifiedName = signatureMinusReturnType
                     }
                 }
             };
+        }
+
+        private static readonly Regex LogicalLocationRegex =
+            new Regex(
+                @"
+                  ([^\s]*\s+)?         # Skip over an optional leading blank-terminated return type name such as 'void '
+                  (?<fqln>[^(]+)       # Take everything up to the opening parenthesis.
+                ",
+                RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
+
+        private static string RemoveReturnTypeFrom(string signature)
+        {
+            Match match = LogicalLocationRegex.Match(signature);
+            if (match.Success)
+            {
+                signature = match.Groups["fqln"].Value;
+            }
+
+            return signature;
         }
 
         private static void ReadObject(SparseReader reader, object parent)
@@ -1617,6 +1625,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             Debug.Assert(context.CurrentThreadFlowLocation == null);
             context.CurrentThreadFlowLocation = new ThreadFlowLocation
             {
+                Location = context.Signature.Location,
+
                 Stack = new Stack
                 {
                     Frames = new List<StackFrame> { context.Signature }

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -110,9 +110,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter",
               "/webgoat/Content/ForgotPassword.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.Concat"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.Concat(System.String,System.String,System.String)"
             ]
           },
           "locations": [
@@ -134,7 +134,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -144,7 +144,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -153,7 +153,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -162,7 +162,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -171,7 +171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -180,7 +180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -189,7 +189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -198,7 +198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -207,7 +207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -216,7 +216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -225,7 +225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -234,7 +234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -243,7 +243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -252,7 +252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -261,7 +261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -270,7 +270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -279,7 +279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -288,7 +288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -297,7 +297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -306,7 +306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -315,7 +315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -324,7 +324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -336,7 +336,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -346,7 +346,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -355,7 +355,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -364,7 +364,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -373,7 +373,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -382,7 +382,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -391,7 +391,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -400,7 +400,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -409,7 +409,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -418,7 +418,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -427,7 +427,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -436,7 +436,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -445,7 +445,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -454,7 +454,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -463,7 +463,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -472,7 +472,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -481,7 +481,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -490,7 +490,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -499,7 +499,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -508,7 +508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -517,7 +517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -529,7 +529,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                           }
                         ]
                       },
@@ -539,7 +539,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                                 }
                               ]
                             }
@@ -548,7 +548,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -557,7 +557,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -566,7 +566,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -575,7 +575,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -584,7 +584,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -593,7 +593,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -602,7 +602,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -611,7 +611,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -620,7 +620,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -629,7 +629,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -638,7 +638,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -647,7 +647,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -656,7 +656,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -665,7 +665,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -674,7 +674,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -683,7 +683,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -692,7 +692,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -701,7 +701,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -710,7 +710,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -719,7 +719,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -728,7 +728,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -740,7 +740,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -750,7 +750,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -759,7 +759,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -768,7 +768,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -777,7 +777,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -786,7 +786,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -795,7 +795,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -804,7 +804,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -813,7 +813,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -822,7 +822,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -831,7 +831,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -840,7 +840,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -849,7 +849,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -858,7 +858,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -867,7 +867,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -876,7 +876,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -885,7 +885,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -894,7 +894,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -903,7 +903,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -912,7 +912,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -921,7 +921,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -930,7 +930,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -939,7 +939,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -948,7 +948,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -957,7 +957,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -969,7 +969,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -979,7 +979,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -988,7 +988,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -997,7 +997,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -1006,7 +1006,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -1015,7 +1015,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -1024,7 +1024,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -1033,7 +1033,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -1042,7 +1042,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -1051,7 +1051,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -1060,7 +1060,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -1069,7 +1069,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -1078,7 +1078,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -1087,7 +1087,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -1096,7 +1096,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -1105,7 +1105,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -1114,7 +1114,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -1123,7 +1123,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -1132,7 +1132,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -1141,7 +1141,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -1150,7 +1150,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -1159,7 +1159,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -1168,7 +1168,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -1177,7 +1177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -1186,7 +1186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -1841,15 +1841,15 @@
           "message": {
             "id": "default",
             "arguments": [
-              "OWASP.WebGoat.NET.EncryptVSEncode.SHA",
-              "System.Security.Cryptography.SHA1Managed..ctor"
+              "OWASP.WebGoat.NET.EncryptVSEncode.SHA()",
+              "SHA1Managed"
             ]
           },
           "locations": [
             {
               "logicalLocations": [
                 {
-                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA"
+                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
                 }
               ]
             }
@@ -1861,7 +1861,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Security.Cryptography.SHA1Managed..ctor"
+                        "fullyQualifiedName": "System.Security.Cryptography.SHA1Managed..ctor()"
                       }
                     ]
                   }
@@ -1870,7 +1870,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA"
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
                       }
                     ]
                   }
@@ -1879,7 +1879,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
                       }
                     ]
                   }
@@ -1888,7 +1888,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                       }
                     ]
                   }
@@ -1897,7 +1897,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                       }
                     ]
                   }
@@ -1906,7 +1906,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                       }
                     ]
                   }
@@ -1915,7 +1915,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                       }
                     ]
                   }
@@ -1924,7 +1924,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                       }
                     ]
                   }
@@ -1933,7 +1933,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                       }
                     ]
                   }
@@ -1942,7 +1942,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                        "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                       }
                     ]
                   }
@@ -1951,7 +1951,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                        "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                       }
                     ]
                   }
@@ -1960,7 +1960,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                       }
                     ]
                   }
@@ -1969,7 +1969,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                       }
                     ]
                   }
@@ -1978,7 +1978,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                        "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                       }
                     ]
                   }
@@ -1987,7 +1987,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                        "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                       }
                     ]
                   }
@@ -1996,7 +1996,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                        "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                       }
                     ]
                   }
@@ -2005,7 +2005,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                       }
                     ]
                   }
@@ -2014,7 +2014,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                       }
                     ]
                   }
@@ -2023,7 +2023,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                       }
                     ]
                   }
@@ -2032,7 +2032,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                       }
                     ]
                   }
@@ -2041,7 +2041,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                       }
                     ]
                   }
@@ -2050,7 +2050,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                       }
                     ]
                   }
@@ -2107,7 +2107,7 @@
             {
               "logicalLocations": [
                 {
-                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
+                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
                 }
               ]
             }
@@ -2121,7 +2121,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName"
+                            "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName()"
                           }
                         ]
                       },
@@ -2131,7 +2131,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName"
+                                  "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName()"
                                 }
                               ]
                             }
@@ -2140,7 +2140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection()"
                                 }
                               ]
                             }
@@ -2149,7 +2149,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Files"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Files()"
                                 }
                               ]
                             }
@@ -2158,7 +2158,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile()"
                                 }
                               ]
                             }
@@ -2167,7 +2167,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile()"
                                 }
                               ]
                             }
@@ -2176,7 +2176,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
                                 }
                               ]
                             }
@@ -2185,7 +2185,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -2194,7 +2194,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -2203,7 +2203,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -2212,7 +2212,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2221,7 +2221,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2230,7 +2230,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2239,7 +2239,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2248,7 +2248,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -2257,7 +2257,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -2266,7 +2266,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -2275,7 +2275,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -2284,7 +2284,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2293,7 +2293,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -2302,7 +2302,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -2311,7 +2311,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2323,7 +2323,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String)"
                           }
                         ]
                       },
@@ -2333,7 +2333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String)"
                                 }
                               ]
                             }
@@ -2342,7 +2342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
                                 }
                               ]
                             }
@@ -2351,7 +2351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -2360,7 +2360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -2369,7 +2369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -2378,7 +2378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2387,7 +2387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2396,7 +2396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2405,7 +2405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2414,7 +2414,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -2423,7 +2423,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -2432,7 +2432,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -2441,7 +2441,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -2450,7 +2450,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2459,7 +2459,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -2468,7 +2468,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -2477,7 +2477,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2489,7 +2489,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.IO.FileStream..ctor"
+                            "fullyQualifiedName": "System.IO.FileStream..ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.String,System.Boolean)"
                           }
                         ]
                       },
@@ -2499,7 +2499,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.IO.FileStream..ctor"
+                                  "fullyQualifiedName": "System.IO.FileStream..ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.String,System.Boolean)"
                                 }
                               ]
                             }
@@ -2508,7 +2508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.IO.FileStream..ctor"
+                                  "fullyQualifiedName": "System.IO.FileStream..ctor()"
                                 }
                               ]
                             }
@@ -2517,7 +2517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs"
+                                  "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs()"
                                 }
                               ]
                             }
@@ -2526,7 +2526,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs()"
                                 }
                               ]
                             }
@@ -2535,7 +2535,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
                                 }
                               ]
                             }
@@ -2544,7 +2544,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -2553,7 +2553,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -2562,7 +2562,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -2571,7 +2571,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2580,7 +2580,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2589,7 +2589,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2598,7 +2598,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2607,7 +2607,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -2616,7 +2616,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -2625,7 +2625,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -2634,7 +2634,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -2643,7 +2643,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2652,7 +2652,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -2661,7 +2661,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -2670,7 +2670,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2742,7 +2742,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                           }
                         ]
                       },
@@ -2752,7 +2752,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                                 }
                               ]
                             }
@@ -2761,7 +2761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
                                 }
                               ]
                             }
@@ -2770,7 +2770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
                                 }
                               ]
                             }
@@ -2779,7 +2779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
                                 }
                               ]
                             }
@@ -2788,7 +2788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
                                 }
                               ]
                             }
@@ -2797,7 +2797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -2806,7 +2806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2815,7 +2815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2824,7 +2824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2833,7 +2833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -2842,7 +2842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -2851,7 +2851,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -2860,7 +2860,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -2869,7 +2869,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -2878,7 +2878,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2887,7 +2887,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -2896,7 +2896,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -2905,7 +2905,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2914,7 +2914,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -2923,7 +2923,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -2932,7 +2932,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -2941,7 +2941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -2953,7 +2953,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -2963,7 +2963,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -2972,7 +2972,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
                                 }
                               ]
                             }
@@ -2981,7 +2981,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
                                 }
                               ]
                             }
@@ -2990,7 +2990,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
                                 }
                               ]
                             }
@@ -2999,7 +2999,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
                                 }
                               ]
                             }
@@ -3008,7 +3008,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -3017,7 +3017,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3026,7 +3026,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3035,7 +3035,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3044,7 +3044,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3053,7 +3053,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -3062,7 +3062,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -3071,7 +3071,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -3080,7 +3080,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -3089,7 +3089,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3098,7 +3098,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -3107,7 +3107,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3116,7 +3116,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3125,7 +3125,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3134,7 +3134,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3143,7 +3143,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3152,7 +3152,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3164,7 +3164,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                           }
                         ]
                       },
@@ -3174,7 +3174,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                                 }
                               ]
                             }
@@ -3183,7 +3183,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity()"
                                 }
                               ]
                             }
@@ -3192,7 +3192,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
                                 }
                               ]
                             }
@@ -3201,7 +3201,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
                                 }
                               ]
                             }
@@ -3210,7 +3210,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
                                 }
                               ]
                             }
@@ -3219,7 +3219,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -3228,7 +3228,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3237,7 +3237,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3246,7 +3246,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3255,7 +3255,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3264,7 +3264,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -3273,7 +3273,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -3282,7 +3282,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -3291,7 +3291,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -3300,7 +3300,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3309,7 +3309,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -3318,7 +3318,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3327,7 +3327,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3336,7 +3336,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3345,7 +3345,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3354,7 +3354,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3363,7 +3363,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3375,7 +3375,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                           }
                         ]
                       },
@@ -3385,7 +3385,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                                 }
                               ]
                             }
@@ -3394,7 +3394,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
                                 }
                               ]
                             }
@@ -3403,7 +3403,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -3412,7 +3412,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -3421,7 +3421,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -3430,7 +3430,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -3439,7 +3439,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -3448,7 +3448,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -3457,7 +3457,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
                                 }
                               ]
                             }
@@ -3466,7 +3466,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
                                 }
                               ]
                             }
@@ -3475,7 +3475,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -3484,7 +3484,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -3493,7 +3493,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
                                 }
                               ]
                             }
@@ -3502,7 +3502,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -3511,7 +3511,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -3520,7 +3520,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -3529,7 +3529,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -3538,7 +3538,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -3547,7 +3547,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -3556,7 +3556,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -3565,7 +3565,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3574,7 +3574,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3583,7 +3583,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3592,7 +3592,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3601,7 +3601,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -3610,7 +3610,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -3619,7 +3619,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -3628,7 +3628,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -3637,7 +3637,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3646,7 +3646,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -3655,7 +3655,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3664,7 +3664,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3673,7 +3673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3682,7 +3682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3691,7 +3691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3700,7 +3700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3763,7 +3763,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -3773,7 +3773,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -3782,7 +3782,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -3791,7 +3791,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -3800,7 +3800,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -3809,7 +3809,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -3818,7 +3818,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3827,7 +3827,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3836,7 +3836,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3845,7 +3845,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -3854,7 +3854,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -3863,7 +3863,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -3872,7 +3872,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -3881,7 +3881,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -3890,7 +3890,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3899,7 +3899,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -3908,7 +3908,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3917,7 +3917,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3926,7 +3926,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3935,7 +3935,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -3944,7 +3944,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -3953,7 +3953,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -3965,7 +3965,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -3975,7 +3975,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -3984,7 +3984,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -3993,7 +3993,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -4002,7 +4002,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -4011,7 +4011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4020,7 +4020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4029,7 +4029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4038,7 +4038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4047,7 +4047,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -4056,7 +4056,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -4065,7 +4065,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -4074,7 +4074,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -4083,7 +4083,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4092,7 +4092,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -4101,7 +4101,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4110,7 +4110,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4119,7 +4119,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4128,7 +4128,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4137,7 +4137,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4146,7 +4146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4158,7 +4158,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Text.Encoding.GetBytes"
+                            "fullyQualifiedName": "System.Text.Encoding.GetBytes(System.String)"
                           }
                         ]
                       },
@@ -4168,7 +4168,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Text.Encoding.GetBytes"
+                                  "fullyQualifiedName": "System.Text.Encoding.GetBytes(System.String)"
                                 }
                               ]
                             }
@@ -4177,7 +4177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
                                 }
                               ]
                             }
@@ -4186,7 +4186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
                                 }
                               ]
                             }
@@ -4195,7 +4195,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -4204,7 +4204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -4213,7 +4213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -4222,7 +4222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4231,7 +4231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4240,7 +4240,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4249,7 +4249,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4258,7 +4258,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -4267,7 +4267,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -4276,7 +4276,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -4285,7 +4285,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -4294,7 +4294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4303,7 +4303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -4312,7 +4312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4321,7 +4321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4330,7 +4330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4339,7 +4339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4348,7 +4348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4357,7 +4357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4369,7 +4369,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Text.Encoding.GetString"
+                            "fullyQualifiedName": "System.Text.Encoding.GetString(System.Byte[])"
                           }
                         ]
                       },
@@ -4379,7 +4379,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Text.Encoding.GetString"
+                                  "fullyQualifiedName": "System.Text.Encoding.GetString(System.Byte[])"
                                 }
                               ]
                             }
@@ -4388,7 +4388,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
                                 }
                               ]
                             }
@@ -4397,7 +4397,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
                                 }
                               ]
                             }
@@ -4406,7 +4406,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -4415,7 +4415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -4424,7 +4424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -4433,7 +4433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4442,7 +4442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4451,7 +4451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4460,7 +4460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4469,7 +4469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -4478,7 +4478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -4487,7 +4487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -4496,7 +4496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -4505,7 +4505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4514,7 +4514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -4523,7 +4523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4532,7 +4532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4541,7 +4541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4550,7 +4550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4559,7 +4559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4568,7 +4568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4580,7 +4580,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                           }
                         ]
                       },
@@ -4590,7 +4590,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                                 }
                               ]
                             }
@@ -4599,7 +4599,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
                                 }
                               ]
                             }
@@ -4608,7 +4608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4617,7 +4617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4626,7 +4626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -4635,7 +4635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
                                 }
                               ]
                             }
@@ -4644,7 +4644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4653,7 +4653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4662,7 +4662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents()"
                                 }
                               ]
                             }
@@ -4671,7 +4671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
                                 }
                               ]
                             }
@@ -4680,7 +4680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4689,7 +4689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4698,7 +4698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -4707,7 +4707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4716,7 +4716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4725,7 +4725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -4734,7 +4734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
                                 }
                               ]
                             }
@@ -4743,7 +4743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
                                 }
                               ]
                             }
@@ -4752,7 +4752,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4761,7 +4761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4770,7 +4770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
                                 }
                               ]
                             }
@@ -4779,7 +4779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -4788,7 +4788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4797,7 +4797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4806,7 +4806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -4815,7 +4815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -4824,7 +4824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -4833,7 +4833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -4842,7 +4842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4851,7 +4851,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4860,7 +4860,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4869,7 +4869,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -4878,7 +4878,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -4887,7 +4887,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -4896,7 +4896,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -4905,7 +4905,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -4914,7 +4914,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4923,7 +4923,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -4932,7 +4932,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4941,7 +4941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -4950,7 +4950,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4959,7 +4959,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -4968,7 +4968,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -4977,7 +4977,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5033,9 +5033,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter, ctl00$BodyContentPlaceholder$txtComment: parameter",
               "/webgoat/Content/StoredXSS.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.ConcatArray"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.ConcatArray(System.String[],System.Int32)"
             ]
           },
           "locations": [
@@ -5057,7 +5057,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -5067,7 +5067,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -5076,7 +5076,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -5085,7 +5085,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -5094,7 +5094,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -5103,7 +5103,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -5112,7 +5112,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5121,7 +5121,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5130,7 +5130,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5139,7 +5139,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5148,7 +5148,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -5157,7 +5157,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -5166,7 +5166,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -5175,7 +5175,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -5184,7 +5184,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5193,7 +5193,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -5202,7 +5202,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5211,7 +5211,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5220,7 +5220,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5229,7 +5229,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5238,7 +5238,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5247,7 +5247,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5259,7 +5259,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -5269,7 +5269,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -5278,7 +5278,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -5287,7 +5287,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -5296,7 +5296,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -5305,7 +5305,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5314,7 +5314,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5323,7 +5323,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5332,7 +5332,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5341,7 +5341,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -5350,7 +5350,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -5359,7 +5359,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -5368,7 +5368,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -5377,7 +5377,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5386,7 +5386,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -5395,7 +5395,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5404,7 +5404,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5413,7 +5413,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5422,7 +5422,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5431,7 +5431,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5440,7 +5440,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5452,7 +5452,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -5462,7 +5462,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -5471,7 +5471,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -5480,7 +5480,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -5489,7 +5489,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -5498,7 +5498,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -5507,7 +5507,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5516,7 +5516,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5525,7 +5525,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5534,7 +5534,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5543,7 +5543,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -5552,7 +5552,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -5561,7 +5561,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -5570,7 +5570,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -5579,7 +5579,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5588,7 +5588,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -5597,7 +5597,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5606,7 +5606,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5615,7 +5615,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5624,7 +5624,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5633,7 +5633,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5642,7 +5642,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5654,7 +5654,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -5664,7 +5664,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -5673,7 +5673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -5682,7 +5682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -5691,7 +5691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -5700,7 +5700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5709,7 +5709,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5718,7 +5718,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5727,7 +5727,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5736,7 +5736,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -5745,7 +5745,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -5754,7 +5754,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -5763,7 +5763,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -5772,7 +5772,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5781,7 +5781,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -5790,7 +5790,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5799,7 +5799,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5808,7 +5808,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5817,7 +5817,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -5826,7 +5826,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -5835,7 +5835,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5847,7 +5847,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.ConcatArray"
+                            "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                           }
                         ]
                       },
@@ -5857,7 +5857,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.ConcatArray"
+                                  "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                                 }
                               ]
                             }
@@ -5866,7 +5866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
                                 }
                               ]
                             }
@@ -5875,7 +5875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
                                 }
                               ]
                             }
@@ -5884,7 +5884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -5893,7 +5893,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -5902,7 +5902,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -5911,7 +5911,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5920,7 +5920,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5929,7 +5929,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5938,7 +5938,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -5947,7 +5947,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -5956,7 +5956,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -5965,7 +5965,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -5974,7 +5974,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -5983,7 +5983,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -5992,7 +5992,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -6001,7 +6001,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6010,7 +6010,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6019,7 +6019,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6028,7 +6028,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6037,7 +6037,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6046,7 +6046,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6058,7 +6058,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -6068,7 +6068,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -6077,7 +6077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -6086,7 +6086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
                                 }
                               ]
                             }
@@ -6095,7 +6095,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
                                 }
                               ]
                             }
@@ -6104,7 +6104,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -6113,7 +6113,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -6122,7 +6122,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -6131,7 +6131,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6140,7 +6140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6149,7 +6149,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6158,7 +6158,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6167,7 +6167,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -6176,7 +6176,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -6185,7 +6185,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -6194,7 +6194,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -6203,7 +6203,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6212,7 +6212,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -6221,7 +6221,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6230,7 +6230,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6239,7 +6239,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6248,7 +6248,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6257,7 +6257,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6266,7 +6266,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6278,7 +6278,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -6288,7 +6288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -6297,7 +6297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -6306,7 +6306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
                                 }
                               ]
                             }
@@ -6315,7 +6315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
                                 }
                               ]
                             }
@@ -6324,7 +6324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -6333,7 +6333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -6342,7 +6342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -6351,7 +6351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6360,7 +6360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6369,7 +6369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6378,7 +6378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6387,7 +6387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -6396,7 +6396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -6405,7 +6405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -6414,7 +6414,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -6423,7 +6423,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6432,7 +6432,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -6441,7 +6441,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6450,7 +6450,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6459,7 +6459,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6468,7 +6468,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6477,7 +6477,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6486,7 +6486,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6542,9 +6542,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtID: parameter",
               "/webgoat/Content/SQLInjectionDiscovery.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.Concat"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.Concat(System.String,System.String)"
             ]
           },
           "locations": [
@@ -6566,7 +6566,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -6576,7 +6576,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -6585,7 +6585,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -6594,7 +6594,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -6603,7 +6603,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -6612,7 +6612,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -6621,7 +6621,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6630,7 +6630,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6639,7 +6639,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6648,7 +6648,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6657,7 +6657,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -6666,7 +6666,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -6675,7 +6675,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -6684,7 +6684,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -6693,7 +6693,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6702,7 +6702,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -6711,7 +6711,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6720,7 +6720,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6729,7 +6729,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6738,7 +6738,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6747,7 +6747,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6756,7 +6756,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6768,7 +6768,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -6778,7 +6778,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -6787,7 +6787,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -6796,7 +6796,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -6805,7 +6805,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -6814,7 +6814,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6823,7 +6823,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6832,7 +6832,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6841,7 +6841,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -6850,7 +6850,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -6859,7 +6859,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -6868,7 +6868,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -6877,7 +6877,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -6886,7 +6886,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6895,7 +6895,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -6904,7 +6904,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6913,7 +6913,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6922,7 +6922,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6931,7 +6931,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -6940,7 +6940,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -6949,7 +6949,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -6961,7 +6961,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String)"
                           }
                         ]
                       },
@@ -6971,7 +6971,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String)"
                                 }
                               ]
                             }
@@ -6980,7 +6980,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
                                 }
                               ]
                             }
@@ -6989,7 +6989,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
                                 }
                               ]
                             }
@@ -6998,7 +6998,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -7007,7 +7007,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -7016,7 +7016,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -7025,7 +7025,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7034,7 +7034,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7043,7 +7043,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7052,7 +7052,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7061,7 +7061,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -7070,7 +7070,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -7079,7 +7079,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -7088,7 +7088,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -7097,7 +7097,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7106,7 +7106,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -7115,7 +7115,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7124,7 +7124,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7133,7 +7133,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7142,7 +7142,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7151,7 +7151,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7160,7 +7160,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7172,7 +7172,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -7182,7 +7182,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -7191,7 +7191,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
                                 }
                               ]
                             }
@@ -7200,7 +7200,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
                                 }
                               ]
                             }
@@ -7209,7 +7209,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
                                 }
                               ]
                             }
@@ -7218,7 +7218,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
                                 }
                               ]
                             }
@@ -7227,7 +7227,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -7236,7 +7236,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -7245,7 +7245,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -7254,7 +7254,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7263,7 +7263,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7272,7 +7272,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7281,7 +7281,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7290,7 +7290,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -7299,7 +7299,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -7308,7 +7308,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -7317,7 +7317,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -7326,7 +7326,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7335,7 +7335,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -7344,7 +7344,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7353,7 +7353,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7362,7 +7362,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7371,7 +7371,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7380,7 +7380,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7389,7 +7389,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7401,7 +7401,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -7411,7 +7411,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -7420,7 +7420,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
                                 }
                               ]
                             }
@@ -7429,7 +7429,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
                                 }
                               ]
                             }
@@ -7438,7 +7438,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
                                 }
                               ]
                             }
@@ -7447,7 +7447,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
                                 }
                               ]
                             }
@@ -7456,7 +7456,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -7465,7 +7465,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -7474,7 +7474,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -7483,7 +7483,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7492,7 +7492,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7501,7 +7501,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7510,7 +7510,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7519,7 +7519,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -7528,7 +7528,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -7537,7 +7537,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -7546,7 +7546,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -7555,7 +7555,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7564,7 +7564,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -7573,7 +7573,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7582,7 +7582,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7591,7 +7591,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7600,7 +7600,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7609,7 +7609,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7618,7 +7618,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7694,7 +7694,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                           }
                         ]
                       },
@@ -7704,7 +7704,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                                 }
                               ]
                             }
@@ -7713,7 +7713,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
                                 }
                               ]
                             }
@@ -7722,7 +7722,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
                                 }
                               ]
                             }
@@ -7731,7 +7731,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
                                 }
                               ]
                             }
@@ -7740,7 +7740,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -7749,7 +7749,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7758,7 +7758,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7767,7 +7767,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7776,7 +7776,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7785,7 +7785,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -7794,7 +7794,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -7803,7 +7803,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -7812,7 +7812,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -7821,7 +7821,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7830,7 +7830,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -7839,7 +7839,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7848,7 +7848,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7857,7 +7857,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7866,7 +7866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -7875,7 +7875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -7884,7 +7884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -7896,7 +7896,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -7906,7 +7906,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -7915,7 +7915,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
                                 }
                               ]
                             }
@@ -7924,7 +7924,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
                                 }
                               ]
                             }
@@ -7933,7 +7933,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
                                 }
                               ]
                             }
@@ -7942,7 +7942,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -7951,7 +7951,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7960,7 +7960,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7969,7 +7969,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7978,7 +7978,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -7987,7 +7987,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -7996,7 +7996,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -8005,7 +8005,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -8014,7 +8014,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -8023,7 +8023,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8032,7 +8032,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -8041,7 +8041,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8050,7 +8050,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8059,7 +8059,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8068,7 +8068,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8077,7 +8077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8086,7 +8086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8098,7 +8098,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                           }
                         ]
                       },
@@ -8108,7 +8108,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                                 }
                               ]
                             }
@@ -8117,7 +8117,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
                                 }
                               ]
                             }
@@ -8126,7 +8126,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8135,7 +8135,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8144,7 +8144,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8153,7 +8153,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8162,7 +8162,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
                                 }
                               ]
                             }
@@ -8171,7 +8171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
                                 }
                               ]
                             }
@@ -8180,7 +8180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8189,7 +8189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8198,7 +8198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
                                 }
                               ]
                             }
@@ -8207,7 +8207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8216,7 +8216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8225,7 +8225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8234,7 +8234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8243,7 +8243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8252,7 +8252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8261,7 +8261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -8270,7 +8270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8279,7 +8279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8288,7 +8288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8297,7 +8297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8306,7 +8306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -8315,7 +8315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -8324,7 +8324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -8333,7 +8333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -8342,7 +8342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8351,7 +8351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -8360,7 +8360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8369,7 +8369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8378,7 +8378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8387,7 +8387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8396,7 +8396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8405,7 +8405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8417,7 +8417,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                           }
                         ]
                       },
@@ -8427,7 +8427,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write(System.String)"
                                 }
                               ]
                             }
@@ -8436,7 +8436,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
                                 }
                               ]
                             }
@@ -8445,7 +8445,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8454,7 +8454,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8463,7 +8463,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8472,7 +8472,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8481,7 +8481,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
                                 }
                               ]
                             }
@@ -8490,7 +8490,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
                                 }
                               ]
                             }
@@ -8499,7 +8499,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8508,7 +8508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8517,7 +8517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
                                 }
                               ]
                             }
@@ -8526,7 +8526,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8535,7 +8535,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8544,7 +8544,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8553,7 +8553,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
                                 }
                               ]
                             }
@@ -8562,7 +8562,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
                                 }
                               ]
                             }
@@ -8571,7 +8571,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
                                 }
                               ]
                             }
@@ -8580,7 +8580,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -8589,7 +8589,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8598,7 +8598,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8607,7 +8607,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8616,7 +8616,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8625,7 +8625,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -8634,7 +8634,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -8643,7 +8643,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -8652,7 +8652,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -8661,7 +8661,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8670,7 +8670,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -8679,7 +8679,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8688,7 +8688,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8697,7 +8697,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8706,7 +8706,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8715,7 +8715,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8724,7 +8724,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8766,9 +8766,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtUserName: parameter",
               "/webgoat/WebGoatCoins/CustomerLogin.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.ConcatArray"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.ConcatArray(System.String[],System.Int32)"
             ]
           },
           "locations": [
@@ -8790,7 +8790,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -8800,7 +8800,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -8809,7 +8809,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -8818,7 +8818,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -8827,7 +8827,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -8836,7 +8836,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -8845,7 +8845,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8854,7 +8854,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8863,7 +8863,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8872,7 +8872,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -8881,7 +8881,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -8890,7 +8890,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -8899,7 +8899,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -8908,7 +8908,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -8917,7 +8917,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8926,7 +8926,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -8935,7 +8935,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8944,7 +8944,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8953,7 +8953,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8962,7 +8962,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -8971,7 +8971,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -8980,7 +8980,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -8992,7 +8992,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -9002,7 +9002,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -9011,7 +9011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -9020,7 +9020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -9029,7 +9029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -9038,7 +9038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9047,7 +9047,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9056,7 +9056,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9065,7 +9065,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9074,7 +9074,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -9083,7 +9083,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -9092,7 +9092,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -9101,7 +9101,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -9110,7 +9110,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9119,7 +9119,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -9128,7 +9128,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9137,7 +9137,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9146,7 +9146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9155,7 +9155,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9164,7 +9164,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9173,7 +9173,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9185,7 +9185,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.ConcatArray"
+                            "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                           }
                         ]
                       },
@@ -9195,7 +9195,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.ConcatArray"
+                                  "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                                 }
                               ]
                             }
@@ -9204,7 +9204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
                                 }
                               ]
                             }
@@ -9213,7 +9213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
                                 }
                               ]
                             }
@@ -9222,7 +9222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -9231,7 +9231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -9240,7 +9240,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -9249,7 +9249,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9258,7 +9258,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9267,7 +9267,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9276,7 +9276,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9285,7 +9285,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -9294,7 +9294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -9303,7 +9303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -9312,7 +9312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -9321,7 +9321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9330,7 +9330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -9339,7 +9339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9348,7 +9348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9357,7 +9357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9366,7 +9366,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9375,7 +9375,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9384,7 +9384,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9396,7 +9396,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -9406,7 +9406,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -9415,7 +9415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -9424,7 +9424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -9433,7 +9433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
                                 }
                               ]
                             }
@@ -9442,7 +9442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
                                 }
                               ]
                             }
@@ -9451,7 +9451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -9460,7 +9460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -9469,7 +9469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -9478,7 +9478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9487,7 +9487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9496,7 +9496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9505,7 +9505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9514,7 +9514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -9523,7 +9523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -9532,7 +9532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -9541,7 +9541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -9550,7 +9550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9559,7 +9559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -9568,7 +9568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9577,7 +9577,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9586,7 +9586,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9595,7 +9595,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9604,7 +9604,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9613,7 +9613,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9625,7 +9625,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -9635,7 +9635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -9644,7 +9644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -9653,7 +9653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -9662,7 +9662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
                                 }
                               ]
                             }
@@ -9671,7 +9671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
                                 }
                               ]
                             }
@@ -9680,7 +9680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -9689,7 +9689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -9698,7 +9698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -9707,7 +9707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9716,7 +9716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9725,7 +9725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9734,7 +9734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9743,7 +9743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -9752,7 +9752,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -9761,7 +9761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -9770,7 +9770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -9779,7 +9779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9788,7 +9788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -9797,7 +9797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9806,7 +9806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9815,7 +9815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9824,7 +9824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -9833,7 +9833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -9842,7 +9842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -9898,9 +9898,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtName: parameter",
               "/webgoat/Content/SQLInjection.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.ConcatArray"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.ConcatArray(System.String[],System.Int32)"
             ]
           },
           "locations": [
@@ -9922,7 +9922,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -9932,7 +9932,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -9941,7 +9941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -9950,7 +9950,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -9959,7 +9959,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -9968,7 +9968,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -9977,7 +9977,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9986,7 +9986,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -9995,7 +9995,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10004,7 +10004,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10013,7 +10013,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -10022,7 +10022,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -10031,7 +10031,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -10040,7 +10040,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -10049,7 +10049,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10058,7 +10058,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -10067,7 +10067,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10076,7 +10076,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10085,7 +10085,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10094,7 +10094,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10103,7 +10103,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10112,7 +10112,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10124,7 +10124,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -10134,7 +10134,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -10143,7 +10143,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -10152,7 +10152,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -10161,7 +10161,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -10170,7 +10170,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10179,7 +10179,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10188,7 +10188,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10197,7 +10197,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10206,7 +10206,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -10215,7 +10215,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -10224,7 +10224,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -10233,7 +10233,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -10242,7 +10242,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10251,7 +10251,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -10260,7 +10260,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10269,7 +10269,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10278,7 +10278,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10287,7 +10287,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10296,7 +10296,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10305,7 +10305,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10317,7 +10317,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -10327,7 +10327,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -10336,7 +10336,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -10345,7 +10345,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -10354,7 +10354,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -10363,7 +10363,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -10372,7 +10372,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10381,7 +10381,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10390,7 +10390,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10399,7 +10399,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10408,7 +10408,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -10417,7 +10417,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -10426,7 +10426,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -10435,7 +10435,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -10444,7 +10444,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10453,7 +10453,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -10462,7 +10462,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10471,7 +10471,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10480,7 +10480,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10489,7 +10489,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10498,7 +10498,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10507,7 +10507,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10519,7 +10519,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -10529,7 +10529,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -10538,7 +10538,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -10547,7 +10547,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -10556,7 +10556,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -10565,7 +10565,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10574,7 +10574,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10583,7 +10583,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10592,7 +10592,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10601,7 +10601,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -10610,7 +10610,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -10619,7 +10619,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -10628,7 +10628,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -10637,7 +10637,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10646,7 +10646,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -10655,7 +10655,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10664,7 +10664,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10673,7 +10673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10682,7 +10682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10691,7 +10691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10700,7 +10700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10712,7 +10712,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.ConcatArray"
+                            "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                           }
                         ]
                       },
@@ -10722,7 +10722,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.ConcatArray"
+                                  "fullyQualifiedName": "System.String.ConcatArray(System.String[],System.Int32)"
                                 }
                               ]
                             }
@@ -10731,7 +10731,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
                                 }
                               ]
                             }
@@ -10740,7 +10740,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
                                 }
                               ]
                             }
@@ -10749,7 +10749,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -10758,7 +10758,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -10767,7 +10767,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -10776,7 +10776,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10785,7 +10785,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10794,7 +10794,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10803,7 +10803,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -10812,7 +10812,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -10821,7 +10821,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -10830,7 +10830,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -10839,7 +10839,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -10848,7 +10848,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10857,7 +10857,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -10866,7 +10866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10875,7 +10875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10884,7 +10884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10893,7 +10893,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -10902,7 +10902,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -10911,7 +10911,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -10923,7 +10923,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -10933,7 +10933,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -10942,7 +10942,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -10951,7 +10951,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -10960,7 +10960,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
                                 }
                               ]
                             }
@@ -10969,7 +10969,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
                                 }
                               ]
                             }
@@ -10978,7 +10978,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -10987,7 +10987,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -10996,7 +10996,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -11005,7 +11005,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11014,7 +11014,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11023,7 +11023,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11032,7 +11032,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11041,7 +11041,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -11050,7 +11050,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -11059,7 +11059,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -11068,7 +11068,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -11077,7 +11077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11086,7 +11086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -11095,7 +11095,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -11104,7 +11104,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11113,7 +11113,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -11122,7 +11122,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -11131,7 +11131,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -11140,7 +11140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11152,7 +11152,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -11162,7 +11162,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -11171,7 +11171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -11180,7 +11180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -11189,7 +11189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
                                 }
                               ]
                             }
@@ -11198,7 +11198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
                                 }
                               ]
                             }
@@ -11207,7 +11207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -11216,7 +11216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -11225,7 +11225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -11234,7 +11234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11243,7 +11243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11252,7 +11252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11261,7 +11261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11270,7 +11270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -11279,7 +11279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -11288,7 +11288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -11297,7 +11297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -11306,7 +11306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11315,7 +11315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -11324,7 +11324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -11333,7 +11333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11342,7 +11342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -11351,7 +11351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -11360,7 +11360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -11369,7 +11369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11824,9 +11824,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter",
               "/webgoat/WebGoatCoins/ForgotPassword.aspx",
-              "System.Web.HttpRequest.get_Form",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.Concat"
+              "System.Web.HttpRequest.get_Form()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.Concat(System.String,System.String,System.String)"
             ]
           },
           "locations": [
@@ -11848,7 +11848,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                           }
                         ]
                       },
@@ -11858,7 +11858,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form()"
                                 }
                               ]
                             }
@@ -11867,7 +11867,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
                                 }
                               ]
                             }
@@ -11876,7 +11876,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
                                 }
                               ]
                             }
@@ -11885,7 +11885,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
                                 }
                               ]
                             }
@@ -11894,7 +11894,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -11903,7 +11903,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11912,7 +11912,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11921,7 +11921,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11930,7 +11930,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -11939,7 +11939,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -11948,7 +11948,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -11957,7 +11957,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -11966,7 +11966,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -11975,7 +11975,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -11984,7 +11984,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -11993,7 +11993,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12002,7 +12002,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12011,7 +12011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12020,7 +12020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12029,7 +12029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12038,7 +12038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12050,7 +12050,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -12060,7 +12060,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -12069,7 +12069,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
                                 }
                               ]
                             }
@@ -12078,7 +12078,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
                                 }
                               ]
                             }
@@ -12087,7 +12087,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -12096,7 +12096,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12105,7 +12105,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12114,7 +12114,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12123,7 +12123,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12132,7 +12132,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -12141,7 +12141,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -12150,7 +12150,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -12159,7 +12159,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -12168,7 +12168,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12177,7 +12177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -12186,7 +12186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12195,7 +12195,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12204,7 +12204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12213,7 +12213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12222,7 +12222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12231,7 +12231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12243,7 +12243,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                           }
                         ]
                       },
@@ -12253,7 +12253,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                                 }
                               ]
                             }
@@ -12262,7 +12262,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -12271,7 +12271,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -12280,7 +12280,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -12289,7 +12289,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -12298,7 +12298,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -12307,7 +12307,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12316,7 +12316,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12325,7 +12325,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12334,7 +12334,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12343,7 +12343,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -12352,7 +12352,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -12361,7 +12361,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -12370,7 +12370,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -12379,7 +12379,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12388,7 +12388,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -12397,7 +12397,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12406,7 +12406,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12415,7 +12415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12424,7 +12424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12433,7 +12433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12442,7 +12442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12454,7 +12454,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -12464,7 +12464,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -12473,7 +12473,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -12482,7 +12482,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -12491,7 +12491,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -12500,7 +12500,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -12509,7 +12509,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -12518,7 +12518,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -12527,7 +12527,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -12536,7 +12536,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12545,7 +12545,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12554,7 +12554,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12563,7 +12563,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12572,7 +12572,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -12581,7 +12581,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -12590,7 +12590,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -12599,7 +12599,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -12608,7 +12608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12617,7 +12617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -12626,7 +12626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12635,7 +12635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12644,7 +12644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12653,7 +12653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12662,7 +12662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12671,7 +12671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12683,7 +12683,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -12693,7 +12693,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -12702,7 +12702,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -12711,7 +12711,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -12720,7 +12720,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
                                 }
                               ]
                             }
@@ -12729,7 +12729,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
                                 }
                               ]
                             }
@@ -12738,7 +12738,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
                                 }
                               ]
                             }
@@ -12747,7 +12747,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
                                 }
                               ]
                             }
@@ -12756,7 +12756,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
                                 }
                               ]
                             }
@@ -12765,7 +12765,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12774,7 +12774,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12783,7 +12783,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12792,7 +12792,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
                                 }
                               ]
                             }
@@ -12801,7 +12801,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -12810,7 +12810,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -12819,7 +12819,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -12828,7 +12828,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -12837,7 +12837,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12846,7 +12846,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -12855,7 +12855,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12864,7 +12864,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12873,7 +12873,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12882,7 +12882,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -12891,7 +12891,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -12900,7 +12900,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -12955,9 +12955,9 @@
             "arguments": [
               "other, query: parameter",
               "/webgoat/WebGoatCoins/Autocomplete.ashx",
-              "System.Web.HttpRequest.get_QueryString",
-              "System.Data.Common.DbCommand.set_CommandText",
-              "System.String.Concat"
+              "System.Web.HttpRequest.get_QueryString()",
+              "System.Data.Common.DbCommand.set_CommandText(System.String)",
+              "System.String.Concat(System.String,System.String,System.String)"
             ]
           },
           "locations": [
@@ -12979,7 +12979,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                           }
                         ]
                       },
@@ -12989,7 +12989,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString()"
                                 }
                               ]
                             }
@@ -12998,7 +12998,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
                                 }
                               ]
                             }
@@ -13007,7 +13007,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
                                 }
                               ]
                             }
@@ -13016,7 +13016,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -13025,7 +13025,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -13034,7 +13034,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -13043,7 +13043,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -13052,7 +13052,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13061,7 +13061,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -13070,7 +13070,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13079,7 +13079,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13088,7 +13088,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13097,7 +13097,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13106,7 +13106,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13115,7 +13115,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13127,7 +13127,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                           }
                         ]
                       },
@@ -13137,7 +13137,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get(System.String)"
                                 }
                               ]
                             }
@@ -13146,7 +13146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
                                 }
                               ]
                             }
@@ -13155,7 +13155,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
                                 }
                               ]
                             }
@@ -13164,7 +13164,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -13173,7 +13173,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -13182,7 +13182,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -13191,7 +13191,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -13200,7 +13200,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13209,7 +13209,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -13218,7 +13218,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13227,7 +13227,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13236,7 +13236,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13245,7 +13245,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13254,7 +13254,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13263,7 +13263,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13275,7 +13275,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.String.Concat"
+                            "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                           }
                         ]
                       },
@@ -13285,7 +13285,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String.Concat"
+                                  "fullyQualifiedName": "System.String.Concat(System.String,System.String,System.String)"
                                 }
                               ]
                             }
@@ -13294,7 +13294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
                                 }
                               ]
                             }
@@ -13303,7 +13303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
                                 }
                               ]
                             }
@@ -13312,7 +13312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -13321,7 +13321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -13330,7 +13330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -13339,7 +13339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -13348,7 +13348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13357,7 +13357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -13366,7 +13366,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13375,7 +13375,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13384,7 +13384,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13393,7 +13393,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13402,7 +13402,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13411,7 +13411,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13423,7 +13423,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -13433,7 +13433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -13442,7 +13442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -13451,7 +13451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -13460,7 +13460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
                                 }
                               ]
                             }
@@ -13469,7 +13469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
                                 }
                               ]
                             }
@@ -13478,7 +13478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -13487,7 +13487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -13496,7 +13496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -13505,7 +13505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -13514,7 +13514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13523,7 +13523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -13532,7 +13532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13541,7 +13541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13550,7 +13550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13559,7 +13559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13568,7 +13568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13577,7 +13577,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13589,7 +13589,7 @@
                       "location": {
                         "logicalLocations": [
                           {
-                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                           }
                         ]
                       },
@@ -13599,7 +13599,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText(System.String)"
                                 }
                               ]
                             }
@@ -13608,7 +13608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
                                 }
                               ]
                             }
@@ -13617,7 +13617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
                                 }
                               ]
                             }
@@ -13626,7 +13626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
                                 }
                               ]
                             }
@@ -13635,7 +13635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
                                 }
                               ]
                             }
@@ -13644,7 +13644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
                                 }
                               ]
                             }
@@ -13653,7 +13653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
                                 }
                               ]
                             }
@@ -13662,7 +13662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
                                 }
                               ]
                             }
@@ -13671,7 +13671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
                                 }
                               ]
                             }
@@ -13680,7 +13680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13689,7 +13689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
                                 }
                               ]
                             }
@@ -13698,7 +13698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13707,7 +13707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -13716,7 +13716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13725,7 +13725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
                                 }
                               ]
                             }
@@ -13734,7 +13734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
                                 }
                               ]
                             }
@@ -13743,7 +13743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
                                 }
                               ]
                             }
@@ -14379,6 +14379,7 @@
           ]
         }
       },
+      "language": "en-US",
       "originalUriBaseIds": {
         "SITE_ROOT": {
           "description": {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -110,9 +110,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter",
               "/webgoat/Content/ForgotPassword.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.Concat(System.String,System.String,System.String)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.Concat"
             ]
           },
           "locations": [
@@ -131,13 +131,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -146,7 +153,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -155,7 +162,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -164,7 +171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -173,7 +180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -182,7 +189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -191,7 +198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -200,7 +207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -209,7 +216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -218,7 +225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -227,7 +234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -236,7 +243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -245,7 +252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -254,7 +261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -263,7 +270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -272,7 +279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -281,7 +288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -290,7 +297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -299,7 +306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -308,7 +315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -317,7 +324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -326,13 +333,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -341,7 +355,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -350,7 +364,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -359,7 +373,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -368,7 +382,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -377,7 +391,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -386,7 +400,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -395,7 +409,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -404,7 +418,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -413,7 +427,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -422,7 +436,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -431,7 +445,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -440,7 +454,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -449,7 +463,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -458,7 +472,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -467,7 +481,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -476,7 +490,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -485,7 +499,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -494,7 +508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -503,7 +517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -512,13 +526,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -527,7 +548,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -536,7 +557,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -545,7 +566,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -554,7 +575,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -563,7 +584,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -572,7 +593,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -581,7 +602,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -590,7 +611,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -599,7 +620,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -608,7 +629,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -617,7 +638,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -626,7 +647,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -635,7 +656,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -644,7 +665,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -653,7 +674,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -662,7 +683,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -671,7 +692,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -680,7 +701,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -689,7 +710,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -698,7 +719,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -707,7 +728,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -716,13 +737,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -731,7 +759,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -740,7 +768,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -749,7 +777,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -758,7 +786,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -767,7 +795,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -776,7 +804,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -785,7 +813,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -794,7 +822,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -803,7 +831,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -812,7 +840,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -821,7 +849,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -830,7 +858,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -839,7 +867,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -848,7 +876,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -857,7 +885,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -866,7 +894,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -875,7 +903,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -884,7 +912,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -893,7 +921,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -902,7 +930,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -911,7 +939,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -920,7 +948,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -929,7 +957,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -938,13 +966,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -953,7 +988,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -962,7 +997,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -971,7 +1006,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -980,7 +1015,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -989,7 +1024,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -998,7 +1033,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -1007,7 +1042,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -1016,7 +1051,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -1025,7 +1060,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -1034,7 +1069,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -1043,7 +1078,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -1052,7 +1087,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -1061,7 +1096,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -1070,7 +1105,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -1079,7 +1114,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -1088,7 +1123,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -1097,7 +1132,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -1106,7 +1141,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -1115,7 +1150,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -1124,7 +1159,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -1133,7 +1168,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -1142,7 +1177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -1151,7 +1186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -1806,15 +1841,15 @@
           "message": {
             "id": "default",
             "arguments": [
-              "OWASP.WebGoat.NET.EncryptVSEncode.SHA()",
-              "SHA1Managed"
+              "OWASP.WebGoat.NET.EncryptVSEncode.SHA",
+              "System.Security.Cryptography.SHA1Managed..ctor"
             ]
           },
           "locations": [
             {
               "logicalLocations": [
                 {
-                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
+                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA"
                 }
               ]
             }
@@ -1826,7 +1861,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "void System.Security.Cryptography.SHA1Managed..ctor()"
+                        "fullyQualifiedName": "System.Security.Cryptography.SHA1Managed..ctor"
                       }
                     ]
                   }
@@ -1835,7 +1870,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA()"
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.SHA"
                       }
                     ]
                   }
@@ -1844,7 +1879,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                        "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
                       }
                     ]
                   }
@@ -1853,7 +1888,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                       }
                     ]
                   }
@@ -1862,7 +1897,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                        "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                       }
                     ]
                   }
@@ -1871,7 +1906,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                       }
                     ]
                   }
@@ -1880,7 +1915,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                       }
                     ]
                   }
@@ -1889,7 +1924,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                       }
                     ]
                   }
@@ -1898,7 +1933,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                        "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                       }
                     ]
                   }
@@ -1907,7 +1942,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                        "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                       }
                     ]
                   }
@@ -1916,7 +1951,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                        "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                       }
                     ]
                   }
@@ -1925,7 +1960,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                       }
                     ]
                   }
@@ -1934,7 +1969,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                        "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                       }
                     ]
                   }
@@ -1943,7 +1978,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                        "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                       }
                     ]
                   }
@@ -1952,7 +1987,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                        "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                       }
                     ]
                   }
@@ -1961,7 +1996,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                        "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                       }
                     ]
                   }
@@ -1970,7 +2005,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                       }
                     ]
                   }
@@ -1979,7 +2014,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                       }
                     ]
                   }
@@ -1988,7 +2023,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                       }
                     ]
                   }
@@ -1997,7 +2032,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                        "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                       }
                     ]
                   }
@@ -2006,7 +2041,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                       }
                     ]
                   }
@@ -2015,7 +2050,7 @@
                   "location": {
                     "logicalLocations": [
                       {
-                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                        "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                       }
                     ]
                   }
@@ -2083,13 +2118,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Web.HttpPostedFile.get_FileName()"
+                                  "fullyQualifiedName": "System.Web.HttpPostedFile.get_FileName"
                                 }
                               ]
                             }
@@ -2098,7 +2140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.ValidatePostedFileCollection"
                                 }
                               ]
                             }
@@ -2107,7 +2149,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Files()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Files"
                                 }
                               ]
                             }
@@ -2116,7 +2158,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_PostedFile"
                                 }
                               ]
                             }
@@ -2125,7 +2167,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.get_HasFile"
                                 }
                               ]
                             }
@@ -2134,7 +2176,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
                                 }
                               ]
                             }
@@ -2143,7 +2185,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -2152,7 +2194,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -2161,7 +2203,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -2170,7 +2212,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2179,7 +2221,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2188,7 +2230,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2197,7 +2239,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -2206,7 +2248,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -2215,7 +2257,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -2224,7 +2266,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -2233,7 +2275,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -2242,7 +2284,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2251,7 +2293,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -2260,7 +2302,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -2269,7 +2311,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2278,13 +2320,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -2293,7 +2342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
                                 }
                               ]
                             }
@@ -2302,7 +2351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -2311,7 +2360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -2320,7 +2369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -2329,7 +2378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2338,7 +2387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2347,7 +2396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2356,7 +2405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -2365,7 +2414,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -2374,7 +2423,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -2383,7 +2432,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -2392,7 +2441,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -2401,7 +2450,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2410,7 +2459,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -2419,7 +2468,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -2428,7 +2477,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2437,13 +2486,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.IO.FileStream..ctor"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.IO.FileStream..ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.String,System.Boolean)"
+                                  "fullyQualifiedName": "System.IO.FileStream..ctor"
                                 }
                               ]
                             }
@@ -2452,7 +2508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.IO.FileStream..ctor()"
+                                  "fullyQualifiedName": "System.IO.FileStream..ctor"
                                 }
                               ]
                             }
@@ -2461,7 +2517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs()"
+                                  "fullyQualifiedName": "System.Web.HttpPostedFile.SaveAs"
                                 }
                               ]
                             }
@@ -2470,7 +2526,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.FileUpload.SaveAs"
                                 }
                               ]
                             }
@@ -2479,7 +2535,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.UploadPathManipulation.btnUpload_Click"
                                 }
                               ]
                             }
@@ -2488,7 +2544,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -2497,7 +2553,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -2506,7 +2562,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -2515,7 +2571,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2524,7 +2580,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2533,7 +2589,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2542,7 +2598,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/uploadpathmanipulation.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -2551,7 +2607,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -2560,7 +2616,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -2569,7 +2625,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -2578,7 +2634,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -2587,7 +2643,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2596,7 +2652,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -2605,7 +2661,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -2614,7 +2670,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2683,13 +2739,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
                                 }
                               ]
                             }
@@ -2698,7 +2761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
                                 }
                               ]
                             }
@@ -2707,7 +2770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
                                 }
                               ]
                             }
@@ -2716,7 +2779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
                                 }
                               ]
                             }
@@ -2725,7 +2788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
                                 }
                               ]
                             }
@@ -2734,7 +2797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -2743,7 +2806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2752,7 +2815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2761,7 +2824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2770,7 +2833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -2779,7 +2842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -2788,7 +2851,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -2797,7 +2860,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -2806,7 +2869,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -2815,7 +2878,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2824,7 +2887,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -2833,7 +2896,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -2842,7 +2905,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2851,7 +2914,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -2860,7 +2923,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -2869,7 +2932,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -2878,7 +2941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -2887,13 +2950,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -2902,7 +2972,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
                                 }
                               ]
                             }
@@ -2911,7 +2981,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
                                 }
                               ]
                             }
@@ -2920,7 +2990,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
                                 }
                               ]
                             }
@@ -2929,7 +2999,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
                                 }
                               ]
                             }
@@ -2938,7 +3008,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -2947,7 +3017,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2956,7 +3026,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2965,7 +3035,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -2974,7 +3044,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -2983,7 +3053,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -2992,7 +3062,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -3001,7 +3071,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -3010,7 +3080,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -3019,7 +3089,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3028,7 +3098,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -3037,7 +3107,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3046,7 +3116,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3055,7 +3125,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3064,7 +3134,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3073,7 +3143,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3082,7 +3152,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3091,13 +3161,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -3106,7 +3183,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.LoadCity"
                                 }
                               ]
                             }
@@ -3115,7 +3192,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.ReflectedXSS.Page_Load"
                                 }
                               ]
                             }
@@ -3124,7 +3201,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
                                 }
                               ]
                             }
@@ -3133,7 +3210,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
                                 }
                               ]
                             }
@@ -3142,7 +3219,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -3151,7 +3228,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3160,7 +3237,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3169,7 +3246,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3178,7 +3255,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -3187,7 +3264,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -3196,7 +3273,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -3205,7 +3282,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -3214,7 +3291,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -3223,7 +3300,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3232,7 +3309,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -3241,7 +3318,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3250,7 +3327,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3259,7 +3336,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3268,7 +3345,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3277,7 +3354,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3286,7 +3363,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3295,13 +3372,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
                                 }
                               ]
                             }
@@ -3310,7 +3394,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
                                 }
                               ]
                             }
@@ -3319,7 +3403,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -3328,7 +3412,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -3337,7 +3421,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -3346,7 +3430,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -3355,7 +3439,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -3364,7 +3448,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -3373,7 +3457,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
                                 }
                               ]
                             }
@@ -3382,7 +3466,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
                                 }
                               ]
                             }
@@ -3391,7 +3475,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -3400,7 +3484,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -3409,7 +3493,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
                                 }
                               ]
                             }
@@ -3418,7 +3502,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -3427,7 +3511,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -3436,7 +3520,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -3445,7 +3529,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -3454,7 +3538,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -3463,7 +3547,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -3472,7 +3556,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -3481,7 +3565,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3490,7 +3574,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3499,7 +3583,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3508,7 +3592,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/reflectedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -3517,7 +3601,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -3526,7 +3610,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -3535,7 +3619,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -3544,7 +3628,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -3553,7 +3637,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3562,7 +3646,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -3571,7 +3655,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3580,7 +3664,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3589,7 +3673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3598,7 +3682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3607,7 +3691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3616,7 +3700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3676,13 +3760,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -3691,7 +3782,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -3700,7 +3791,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -3709,7 +3800,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -3718,7 +3809,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -3727,7 +3818,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3736,7 +3827,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3745,7 +3836,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3754,7 +3845,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -3763,7 +3854,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -3772,7 +3863,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -3781,7 +3872,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -3790,7 +3881,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -3799,7 +3890,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3808,7 +3899,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -3817,7 +3908,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3826,7 +3917,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3835,7 +3926,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3844,7 +3935,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -3853,7 +3944,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -3862,7 +3953,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3871,13 +3962,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -3886,7 +3984,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -3895,7 +3993,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -3904,7 +4002,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -3913,7 +4011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3922,7 +4020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3931,7 +4029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -3940,7 +4038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -3949,7 +4047,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -3958,7 +4056,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -3967,7 +4065,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -3976,7 +4074,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -3985,7 +4083,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -3994,7 +4092,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -4003,7 +4101,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4012,7 +4110,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4021,7 +4119,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4030,7 +4128,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4039,7 +4137,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4048,7 +4146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4057,13 +4155,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Text.Encoding.GetBytes"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Byte[] System.Text.Encoding.GetBytes(System.String)"
+                                  "fullyQualifiedName": "System.Text.Encoding.GetBytes"
                                 }
                               ]
                             }
@@ -4072,7 +4177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt"
                                 }
                               ]
                             }
@@ -4081,7 +4186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
                                 }
                               ]
                             }
@@ -4090,7 +4195,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -4099,7 +4204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -4108,7 +4213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -4117,7 +4222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4126,7 +4231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4135,7 +4240,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4144,7 +4249,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -4153,7 +4258,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -4162,7 +4267,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -4171,7 +4276,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -4180,7 +4285,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -4189,7 +4294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4198,7 +4303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -4207,7 +4312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4216,7 +4321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4225,7 +4330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4234,7 +4339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4243,7 +4348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4252,7 +4357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4261,13 +4366,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Text.Encoding.GetString"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Text.Encoding.GetString(System.Byte[])"
+                                  "fullyQualifiedName": "System.Text.Encoding.GetString"
                                 }
                               ]
                             }
@@ -4276,7 +4388,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.CustomCryptoEncrypt"
                                 }
                               ]
                             }
@@ -4285,7 +4397,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.EncryptVSEncode.btnGO_Click"
                                 }
                               ]
                             }
@@ -4294,7 +4406,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -4303,7 +4415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -4312,7 +4424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -4321,7 +4433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4330,7 +4442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4339,7 +4451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4348,7 +4460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -4357,7 +4469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -4366,7 +4478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -4375,7 +4487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -4384,7 +4496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -4393,7 +4505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4402,7 +4514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -4411,7 +4523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4420,7 +4532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4429,7 +4541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4438,7 +4550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4447,7 +4559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4456,7 +4568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4465,13 +4577,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
                                 }
                               ]
                             }
@@ -4480,7 +4599,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
                                 }
                               ]
                             }
@@ -4489,7 +4608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4498,7 +4617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4507,7 +4626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -4516,7 +4635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
                                 }
                               ]
                             }
@@ -4525,7 +4644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4534,7 +4653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4543,7 +4662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Table.RenderContents"
                                 }
                               ]
                             }
@@ -4552,7 +4671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.WebControl.Render"
                                 }
                               ]
                             }
@@ -4561,7 +4680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4570,7 +4689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4579,7 +4698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -4588,7 +4707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4597,7 +4716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4606,7 +4725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -4615,7 +4734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
                                 }
                               ]
                             }
@@ -4624,7 +4743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
                                 }
                               ]
                             }
@@ -4633,7 +4752,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4642,7 +4761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4651,7 +4770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
                                 }
                               ]
                             }
@@ -4660,7 +4779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -4669,7 +4788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4678,7 +4797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4687,7 +4806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -4696,7 +4815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -4705,7 +4824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -4714,7 +4833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -4723,7 +4842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4732,7 +4851,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4741,7 +4860,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4750,7 +4869,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/encryptvsencode.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -4759,7 +4878,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -4768,7 +4887,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -4777,7 +4896,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -4786,7 +4905,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -4795,7 +4914,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4804,7 +4923,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -4813,7 +4932,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4822,7 +4941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4831,7 +4950,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4840,7 +4959,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -4849,7 +4968,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -4858,7 +4977,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -4914,9 +5033,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter, ctl00$BodyContentPlaceholder$txtComment: parameter",
               "/webgoat/Content/StoredXSS.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.ConcatArray(System.String[],System.Int32)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.ConcatArray"
             ]
           },
           "locations": [
@@ -4935,13 +5054,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -4950,7 +5076,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -4959,7 +5085,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -4968,7 +5094,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -4977,7 +5103,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -4986,7 +5112,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -4995,7 +5121,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5004,7 +5130,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5013,7 +5139,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -5022,7 +5148,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -5031,7 +5157,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -5040,7 +5166,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -5049,7 +5175,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -5058,7 +5184,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5067,7 +5193,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -5076,7 +5202,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5085,7 +5211,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5094,7 +5220,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5103,7 +5229,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5112,7 +5238,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5121,7 +5247,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5130,13 +5256,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -5145,7 +5278,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -5154,7 +5287,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -5163,7 +5296,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -5172,7 +5305,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5181,7 +5314,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5190,7 +5323,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5199,7 +5332,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -5208,7 +5341,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -5217,7 +5350,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -5226,7 +5359,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -5235,7 +5368,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -5244,7 +5377,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5253,7 +5386,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -5262,7 +5395,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5271,7 +5404,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5280,7 +5413,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5289,7 +5422,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5298,7 +5431,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5307,7 +5440,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5316,13 +5449,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -5331,7 +5471,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -5340,7 +5480,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -5349,7 +5489,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -5358,7 +5498,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -5367,7 +5507,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5376,7 +5516,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5385,7 +5525,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5394,7 +5534,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -5403,7 +5543,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -5412,7 +5552,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -5421,7 +5561,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -5430,7 +5570,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -5439,7 +5579,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5448,7 +5588,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -5457,7 +5597,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5466,7 +5606,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5475,7 +5615,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5484,7 +5624,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5493,7 +5633,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5502,7 +5642,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5511,13 +5651,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -5526,7 +5673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -5535,7 +5682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -5544,7 +5691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -5553,7 +5700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5562,7 +5709,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5571,7 +5718,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5580,7 +5727,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -5589,7 +5736,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -5598,7 +5745,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -5607,7 +5754,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -5616,7 +5763,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -5625,7 +5772,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5634,7 +5781,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -5643,7 +5790,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5652,7 +5799,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5661,7 +5808,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5670,7 +5817,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5679,7 +5826,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5688,7 +5835,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5697,13 +5844,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.ConcatArray"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                  "fullyQualifiedName": "System.String.ConcatArray"
                                 }
                               ]
                             }
@@ -5712,7 +5866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
                                 }
                               ]
                             }
@@ -5721,7 +5875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
                                 }
                               ]
                             }
@@ -5730,7 +5884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -5739,7 +5893,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -5748,7 +5902,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -5757,7 +5911,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5766,7 +5920,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5775,7 +5929,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5784,7 +5938,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -5793,7 +5947,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -5802,7 +5956,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -5811,7 +5965,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -5820,7 +5974,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -5829,7 +5983,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5838,7 +5992,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -5847,7 +6001,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5856,7 +6010,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5865,7 +6019,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5874,7 +6028,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -5883,7 +6037,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -5892,7 +6046,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -5901,13 +6055,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -5916,7 +6077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -5925,7 +6086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
                                 }
                               ]
                             }
@@ -5934,7 +6095,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
                                 }
                               ]
                             }
@@ -5943,7 +6104,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -5952,7 +6113,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -5961,7 +6122,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -5970,7 +6131,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5979,7 +6140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5988,7 +6149,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -5997,7 +6158,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -6006,7 +6167,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -6015,7 +6176,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -6024,7 +6185,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -6033,7 +6194,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -6042,7 +6203,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6051,7 +6212,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -6060,7 +6221,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6069,7 +6230,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6078,7 +6239,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6087,7 +6248,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6096,7 +6257,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6105,7 +6266,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6114,13 +6275,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -6129,7 +6297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -6138,7 +6306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.AddComment"
                                 }
                               ]
                             }
@@ -6147,7 +6315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.StoredXSS.btnSave_Click"
                                 }
                               ]
                             }
@@ -6156,7 +6324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -6165,7 +6333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -6174,7 +6342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -6183,7 +6351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6192,7 +6360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6201,7 +6369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6210,7 +6378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/storedxss.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -6219,7 +6387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -6228,7 +6396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -6237,7 +6405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -6246,7 +6414,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -6255,7 +6423,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6264,7 +6432,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -6273,7 +6441,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6282,7 +6450,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6291,7 +6459,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6300,7 +6468,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6309,7 +6477,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6318,7 +6486,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6374,9 +6542,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtID: parameter",
               "/webgoat/Content/SQLInjectionDiscovery.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.Concat(System.String,System.String)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.Concat"
             ]
           },
           "locations": [
@@ -6395,13 +6563,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -6410,7 +6585,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -6419,7 +6594,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -6428,7 +6603,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -6437,7 +6612,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -6446,7 +6621,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6455,7 +6630,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6464,7 +6639,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6473,7 +6648,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -6482,7 +6657,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -6491,7 +6666,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -6500,7 +6675,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -6509,7 +6684,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -6518,7 +6693,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6527,7 +6702,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -6536,7 +6711,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6545,7 +6720,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6554,7 +6729,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6563,7 +6738,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6572,7 +6747,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6581,7 +6756,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6590,13 +6765,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -6605,7 +6787,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -6614,7 +6796,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -6623,7 +6805,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -6632,7 +6814,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6641,7 +6823,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6650,7 +6832,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6659,7 +6841,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -6668,7 +6850,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -6677,7 +6859,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -6686,7 +6868,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -6695,7 +6877,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -6704,7 +6886,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6713,7 +6895,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -6722,7 +6904,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6731,7 +6913,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6740,7 +6922,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6749,7 +6931,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6758,7 +6940,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6767,7 +6949,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6776,13 +6958,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -6791,7 +6980,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
                                 }
                               ]
                             }
@@ -6800,7 +6989,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
                                 }
                               ]
                             }
@@ -6809,7 +6998,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -6818,7 +7007,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -6827,7 +7016,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -6836,7 +7025,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6845,7 +7034,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6854,7 +7043,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -6863,7 +7052,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -6872,7 +7061,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -6881,7 +7070,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -6890,7 +7079,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -6899,7 +7088,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -6908,7 +7097,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6917,7 +7106,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -6926,7 +7115,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6935,7 +7124,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6944,7 +7133,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6953,7 +7142,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -6962,7 +7151,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -6971,7 +7160,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -6980,13 +7169,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -6995,7 +7191,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
                                 }
                               ]
                             }
@@ -7004,7 +7200,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
                                 }
                               ]
                             }
@@ -7013,7 +7209,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
                                 }
                               ]
                             }
@@ -7022,7 +7218,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
                                 }
                               ]
                             }
@@ -7031,7 +7227,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -7040,7 +7236,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -7049,7 +7245,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -7058,7 +7254,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7067,7 +7263,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7076,7 +7272,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7085,7 +7281,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -7094,7 +7290,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -7103,7 +7299,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -7112,7 +7308,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -7121,7 +7317,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -7130,7 +7326,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7139,7 +7335,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -7148,7 +7344,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7157,7 +7353,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7166,7 +7362,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7175,7 +7371,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7184,7 +7380,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7193,7 +7389,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7202,13 +7398,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -7217,7 +7420,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
                                 }
                               ]
                             }
@@ -7226,7 +7429,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlHelper.ExecuteScalar"
                                 }
                               ]
                             }
@@ -7235,7 +7438,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByCustomerNumber"
                                 }
                               ]
                             }
@@ -7244,7 +7447,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjectionDiscovery.btnFind_Click"
                                 }
                               ]
                             }
@@ -7253,7 +7456,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -7262,7 +7465,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -7271,7 +7474,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -7280,7 +7483,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7289,7 +7492,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7298,7 +7501,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7307,7 +7510,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjectiondiscovery.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -7316,7 +7519,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -7325,7 +7528,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -7334,7 +7537,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -7343,7 +7546,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -7352,7 +7555,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7361,7 +7564,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -7370,7 +7573,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7379,7 +7582,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7388,7 +7591,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7397,7 +7600,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7406,7 +7609,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7415,7 +7618,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7488,13 +7691,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
                                 }
                               ]
                             }
@@ -7503,7 +7713,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load"
                                 }
                               ]
                             }
@@ -7512,7 +7722,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
                                 }
                               ]
                             }
@@ -7521,7 +7731,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
                                 }
                               ]
                             }
@@ -7530,7 +7740,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -7539,7 +7749,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7548,7 +7758,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7557,7 +7767,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7566,7 +7776,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -7575,7 +7785,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -7584,7 +7794,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -7593,7 +7803,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -7602,7 +7812,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -7611,7 +7821,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7620,7 +7830,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -7629,7 +7839,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7638,7 +7848,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7647,7 +7857,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7656,7 +7866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7665,7 +7875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7674,7 +7884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7683,13 +7893,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -7698,7 +7915,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.Page_Load"
                                 }
                               ]
                             }
@@ -7707,7 +7924,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.OnLoad"
                                 }
                               ]
                             }
@@ -7716,7 +7933,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.LoadRecursive"
                                 }
                               ]
                             }
@@ -7725,7 +7942,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -7734,7 +7951,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7743,7 +7960,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7752,7 +7969,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -7761,7 +7978,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -7770,7 +7987,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -7779,7 +7996,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -7788,7 +8005,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -7797,7 +8014,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -7806,7 +8023,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7815,7 +8032,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -7824,7 +8041,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7833,7 +8050,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7842,7 +8059,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7851,7 +8068,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -7860,7 +8077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -7869,7 +8086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -7878,13 +8095,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -7893,7 +8117,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3"
                                 }
                               ]
                             }
@@ -7902,7 +8126,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -7911,7 +8135,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -7920,7 +8144,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -7929,7 +8153,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -7938,7 +8162,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
                                 }
                               ]
                             }
@@ -7947,7 +8171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
                                 }
                               ]
                             }
@@ -7956,7 +8180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -7965,7 +8189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -7974,7 +8198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
                                 }
                               ]
                             }
@@ -7983,7 +8207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -7992,7 +8216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8001,7 +8225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8010,7 +8234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -8019,7 +8243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8028,7 +8252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8037,7 +8261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -8046,7 +8270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8055,7 +8279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8064,7 +8288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8073,7 +8297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -8082,7 +8306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -8091,7 +8315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -8100,7 +8324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -8109,7 +8333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -8118,7 +8342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8127,7 +8351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -8136,7 +8360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8145,7 +8369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8154,7 +8378,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8163,7 +8387,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8172,7 +8396,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8181,7 +8405,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8190,13 +8414,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpWriter.Write"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Web.HttpWriter.Write(System.String)"
+                                  "fullyQualifiedName": "System.Web.HttpWriter.Write"
                                 }
                               ]
                             }
@@ -8205,7 +8436,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3(CustomerLogin.aspx:9)"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.__RenderContent3"
                                 }
                               ]
                             }
@@ -8214,7 +8445,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -8223,7 +8454,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8232,7 +8463,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8241,7 +8472,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -8250,7 +8481,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlForm.RenderChildren"
                                 }
                               ]
                             }
@@ -8259,7 +8490,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render()"
+                                  "fullyQualifiedName": "System.Web.UI.HtmlControls.HtmlContainerControl.Render"
                                 }
                               ]
                             }
@@ -8268,7 +8499,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8277,7 +8508,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8286,7 +8517,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1(Site.Master:32)"
+                                  "fullyQualifiedName": "ASP.resources_master_pages_site_master.__Render__control1"
                                 }
                               ]
                             }
@@ -8295,7 +8526,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -8304,7 +8535,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8313,7 +8544,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8322,7 +8553,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderChildrenInternal"
                                 }
                               ]
                             }
@@ -8331,7 +8562,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControlInternal"
                                 }
                               ]
                             }
@@ -8340,7 +8571,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl()"
+                                  "fullyQualifiedName": "System.Web.UI.Control.RenderControl"
                                 }
                               ]
                             }
@@ -8349,7 +8580,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -8358,7 +8589,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8367,7 +8598,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8376,7 +8607,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8385,7 +8616,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -8394,7 +8625,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -8403,7 +8634,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -8412,7 +8643,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -8421,7 +8652,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -8430,7 +8661,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8439,7 +8670,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -8448,7 +8679,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8457,7 +8688,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8466,7 +8697,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8475,7 +8706,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8484,7 +8715,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8493,7 +8724,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8535,9 +8766,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtUserName: parameter",
               "/webgoat/WebGoatCoins/CustomerLogin.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.ConcatArray(System.String[],System.Int32)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.ConcatArray"
             ]
           },
           "locations": [
@@ -8556,13 +8787,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -8571,7 +8809,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -8580,7 +8818,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -8589,7 +8827,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -8598,7 +8836,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -8607,7 +8845,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8616,7 +8854,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8625,7 +8863,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8634,7 +8872,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -8643,7 +8881,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -8652,7 +8890,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -8661,7 +8899,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -8670,7 +8908,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -8679,7 +8917,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8688,7 +8926,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -8697,7 +8935,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8706,7 +8944,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8715,7 +8953,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8724,7 +8962,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8733,7 +8971,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8742,7 +8980,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8751,13 +8989,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -8766,7 +9011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -8775,7 +9020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -8784,7 +9029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -8793,7 +9038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8802,7 +9047,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8811,7 +9056,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -8820,7 +9065,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -8829,7 +9074,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -8838,7 +9083,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -8847,7 +9092,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -8856,7 +9101,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -8865,7 +9110,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8874,7 +9119,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -8883,7 +9128,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8892,7 +9137,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8901,7 +9146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8910,7 +9155,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -8919,7 +9164,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -8928,7 +9173,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -8937,13 +9182,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.ConcatArray"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                  "fullyQualifiedName": "System.String.ConcatArray"
                                 }
                               ]
                             }
@@ -8952,7 +9204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
                                 }
                               ]
                             }
@@ -8961,7 +9213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
                                 }
                               ]
                             }
@@ -8970,7 +9222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -8979,7 +9231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -8988,7 +9240,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -8997,7 +9249,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9006,7 +9258,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9015,7 +9267,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9024,7 +9276,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -9033,7 +9285,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -9042,7 +9294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -9051,7 +9303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -9060,7 +9312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -9069,7 +9321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9078,7 +9330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -9087,7 +9339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9096,7 +9348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9105,7 +9357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9114,7 +9366,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9123,7 +9375,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9132,7 +9384,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9141,13 +9393,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -9156,7 +9415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -9165,7 +9424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -9174,7 +9433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
                                 }
                               ]
                             }
@@ -9183,7 +9442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
                                 }
                               ]
                             }
@@ -9192,7 +9451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -9201,7 +9460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -9210,7 +9469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -9219,7 +9478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9228,7 +9487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9237,7 +9496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9246,7 +9505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -9255,7 +9514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -9264,7 +9523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -9273,7 +9532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -9282,7 +9541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -9291,7 +9550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9300,7 +9559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -9309,7 +9568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9318,7 +9577,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9327,7 +9586,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9336,7 +9595,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9345,7 +9604,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9354,7 +9613,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9363,13 +9622,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -9378,7 +9644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -9387,7 +9653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -9396,7 +9662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.IsValidCustomerLogin"
                                 }
                               ]
                             }
@@ -9405,7 +9671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.CustomerLogin.ButtonLogOn_Click"
                                 }
                               ]
                             }
@@ -9414,7 +9680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -9423,7 +9689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -9432,7 +9698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -9441,7 +9707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9450,7 +9716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9459,7 +9725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9468,7 +9734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/customerlogin.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -9477,7 +9743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -9486,7 +9752,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -9495,7 +9761,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -9504,7 +9770,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -9513,7 +9779,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9522,7 +9788,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -9531,7 +9797,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9540,7 +9806,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9549,7 +9815,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9558,7 +9824,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9567,7 +9833,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9576,7 +9842,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9632,9 +9898,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtName: parameter",
               "/webgoat/Content/SQLInjection.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.ConcatArray(System.String[],System.Int32)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.ConcatArray"
             ]
           },
           "locations": [
@@ -9653,13 +9919,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -9668,7 +9941,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -9677,7 +9950,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -9686,7 +9959,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -9695,7 +9968,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -9704,7 +9977,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9713,7 +9986,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9722,7 +9995,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9731,7 +10004,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -9740,7 +10013,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -9749,7 +10022,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -9758,7 +10031,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -9767,7 +10040,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -9776,7 +10049,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9785,7 +10058,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -9794,7 +10067,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9803,7 +10076,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9812,7 +10085,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9821,7 +10094,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -9830,7 +10103,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9839,7 +10112,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9848,13 +10121,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -9863,7 +10143,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -9872,7 +10152,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -9881,7 +10161,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -9890,7 +10170,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9899,7 +10179,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9908,7 +10188,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -9917,7 +10197,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -9926,7 +10206,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -9935,7 +10215,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -9944,7 +10224,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -9953,7 +10233,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -9962,7 +10242,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9971,7 +10251,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -9980,7 +10260,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -9989,7 +10269,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -9998,7 +10278,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10007,7 +10287,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10016,7 +10296,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10025,7 +10305,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10034,13 +10314,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -10049,7 +10336,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -10058,7 +10345,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -10067,7 +10354,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -10076,7 +10363,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -10085,7 +10372,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10094,7 +10381,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10103,7 +10390,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10112,7 +10399,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -10121,7 +10408,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -10130,7 +10417,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -10139,7 +10426,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -10148,7 +10435,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -10157,7 +10444,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10166,7 +10453,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -10175,7 +10462,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10184,7 +10471,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10193,7 +10480,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10202,7 +10489,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10211,7 +10498,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10220,7 +10507,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10229,13 +10516,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -10244,7 +10538,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -10253,7 +10547,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -10262,7 +10556,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -10271,7 +10565,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10280,7 +10574,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10289,7 +10583,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10298,7 +10592,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -10307,7 +10601,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -10316,7 +10610,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -10325,7 +10619,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -10334,7 +10628,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -10343,7 +10637,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10352,7 +10646,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -10361,7 +10655,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10370,7 +10664,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10379,7 +10673,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10388,7 +10682,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10397,7 +10691,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10406,7 +10700,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10415,13 +10709,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.ConcatArray"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.ConcatArray(System.String[],System.Int32)"
+                                  "fullyQualifiedName": "System.String.ConcatArray"
                                 }
                               ]
                             }
@@ -10430,7 +10731,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
                                 }
                               ]
                             }
@@ -10439,7 +10740,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
                                 }
                               ]
                             }
@@ -10448,7 +10749,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -10457,7 +10758,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -10466,7 +10767,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -10475,7 +10776,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10484,7 +10785,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10493,7 +10794,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10502,7 +10803,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -10511,7 +10812,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -10520,7 +10821,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -10529,7 +10830,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -10538,7 +10839,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -10547,7 +10848,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10556,7 +10857,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -10565,7 +10866,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10574,7 +10875,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10583,7 +10884,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10592,7 +10893,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10601,7 +10902,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10610,7 +10911,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10619,13 +10920,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -10634,7 +10942,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -10643,7 +10951,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -10652,7 +10960,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
                                 }
                               ]
                             }
@@ -10661,7 +10969,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
                                 }
                               ]
                             }
@@ -10670,7 +10978,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -10679,7 +10987,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -10688,7 +10996,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -10697,7 +11005,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10706,7 +11014,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10715,7 +11023,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10724,7 +11032,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -10733,7 +11041,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -10742,7 +11050,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -10751,7 +11059,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -10760,7 +11068,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -10769,7 +11077,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10778,7 +11086,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -10787,7 +11095,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10796,7 +11104,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10805,7 +11113,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10814,7 +11122,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -10823,7 +11131,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -10832,7 +11140,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -10841,13 +11149,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -10856,7 +11171,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -10865,7 +11180,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -10874,7 +11189,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetEmailByName"
                                 }
                               ]
                             }
@@ -10883,7 +11198,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.SQLInjection.btnFind_Click"
                                 }
                               ]
                             }
@@ -10892,7 +11207,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -10901,7 +11216,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -10910,7 +11225,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -10919,7 +11234,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10928,7 +11243,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10937,7 +11252,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -10946,7 +11261,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.content/sqlinjection.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -10955,7 +11270,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -10964,7 +11279,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -10973,7 +11288,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -10982,7 +11297,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -10991,7 +11306,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11000,7 +11315,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -11009,7 +11324,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11018,7 +11333,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11027,7 +11342,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11036,7 +11351,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11045,7 +11360,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11054,7 +11369,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11509,9 +11824,9 @@
             "arguments": [
               "other, ctl00$BodyContentPlaceholder$txtEmail: parameter",
               "/webgoat/WebGoatCoins/ForgotPassword.aspx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.Concat(System.String,System.String,System.String)"
+              "System.Web.HttpRequest.get_Form",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.Concat"
             ]
           },
           "locations": [
@@ -11530,13 +11845,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_Form()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Form"
                                 }
                               ]
                             }
@@ -11545,7 +11867,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_HasForm"
                                 }
                               ]
                             }
@@ -11554,7 +11876,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.GetCollectionBasedOnMethod"
                                 }
                               ]
                             }
@@ -11563,7 +11885,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.DeterminePostBackMode"
                                 }
                               ]
                             }
@@ -11572,7 +11894,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -11581,7 +11903,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11590,7 +11912,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11599,7 +11921,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11608,7 +11930,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -11617,7 +11939,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -11626,7 +11948,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -11635,7 +11957,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -11644,7 +11966,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -11653,7 +11975,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11662,7 +11984,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -11671,7 +11993,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11680,7 +12002,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11689,7 +12011,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11698,7 +12020,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11707,7 +12029,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11716,7 +12038,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11725,13 +12047,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -11740,7 +12069,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.TextBox.LoadPostData"
                                 }
                               ]
                             }
@@ -11749,7 +12078,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessPostData"
                                 }
                               ]
                             }
@@ -11758,7 +12087,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -11767,7 +12096,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11776,7 +12105,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11785,7 +12114,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11794,7 +12123,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -11803,7 +12132,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -11812,7 +12141,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -11821,7 +12150,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -11830,7 +12159,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -11839,7 +12168,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11848,7 +12177,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -11857,7 +12186,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11866,7 +12195,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11875,7 +12204,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11884,7 +12213,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -11893,7 +12222,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -11902,7 +12231,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -11911,13 +12240,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -11926,7 +12262,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -11935,7 +12271,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -11944,7 +12280,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -11953,7 +12289,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -11962,7 +12298,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -11971,7 +12307,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11980,7 +12316,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11989,7 +12325,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -11998,7 +12334,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -12007,7 +12343,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12016,7 +12352,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12025,7 +12361,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12034,7 +12370,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12043,7 +12379,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12052,7 +12388,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12061,7 +12397,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12070,7 +12406,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12079,7 +12415,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12088,7 +12424,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12097,7 +12433,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12106,7 +12442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12115,13 +12451,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -12130,7 +12473,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -12139,7 +12482,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -12148,7 +12491,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -12157,7 +12500,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -12166,7 +12509,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -12175,7 +12518,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -12184,7 +12527,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -12193,7 +12536,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12202,7 +12545,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12211,7 +12554,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12220,7 +12563,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -12229,7 +12572,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12238,7 +12581,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12247,7 +12590,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12256,7 +12599,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12265,7 +12608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12274,7 +12617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12283,7 +12626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12292,7 +12635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12301,7 +12644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12310,7 +12653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12319,7 +12662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12328,7 +12671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12337,13 +12680,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -12352,7 +12702,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -12361,7 +12711,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -12370,7 +12720,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetSecurityQuestionAndAnswer"
                                 }
                               ]
                             }
@@ -12379,7 +12729,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.ForgotPassword.ButtonCheckEmail_Click"
                                 }
                               ]
                             }
@@ -12388,7 +12738,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.OnClick"
                                 }
                               ]
                             }
@@ -12397,7 +12747,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent()"
+                                  "fullyQualifiedName": "System.Web.UI.WebControls.Button.RaisePostBackEvent"
                                 }
                               ]
                             }
@@ -12406,7 +12756,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequestMain"
                                 }
                               ]
                             }
@@ -12415,7 +12765,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12424,7 +12774,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12433,7 +12783,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest()"
+                                  "fullyQualifiedName": "System.Web.UI.Page.ProcessRequest"
                                 }
                               ]
                             }
@@ -12442,7 +12792,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest()"
+                                  "fullyQualifiedName": "ASP.webgoatcoins/forgotpassword.aspx.ProcessRequest"
                                 }
                               ]
                             }
@@ -12451,7 +12801,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12460,7 +12810,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12469,7 +12819,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12478,7 +12828,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12487,7 +12837,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12496,7 +12846,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12505,7 +12855,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12514,7 +12864,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12523,7 +12873,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12532,7 +12882,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12541,7 +12891,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12550,7 +12900,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12605,9 +12955,9 @@
             "arguments": [
               "other, query: parameter",
               "/webgoat/WebGoatCoins/Autocomplete.ashx",
-              "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()",
-              "void System.Data.Common.DbCommand.set_CommandText(System.String)",
-              "System.String System.String.Concat(System.String,System.String,System.String)"
+              "System.Web.HttpRequest.get_QueryString",
+              "System.Data.Common.DbCommand.set_CommandText",
+              "System.String.Concat"
             ]
           },
           "locations": [
@@ -12626,13 +12976,20 @@
                 {
                   "locations": [
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection System.Web.HttpRequest.get_QueryString()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_QueryString"
                                 }
                               ]
                             }
@@ -12641,7 +12998,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
                                 }
                               ]
                             }
@@ -12650,7 +13007,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
                                 }
                               ]
                             }
@@ -12659,7 +13016,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12668,7 +13025,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12677,7 +13034,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12686,7 +13043,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12695,7 +13052,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12704,7 +13061,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12713,7 +13070,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12722,7 +13079,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12731,7 +13088,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12740,7 +13097,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12749,7 +13106,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12758,7 +13115,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12767,13 +13124,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.Collections.Specialized.NameValueCollection.Get(System.String)"
+                                  "fullyQualifiedName": "System.Collections.Specialized.NameValueCollection.Get"
                                 }
                               ]
                             }
@@ -12782,7 +13146,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item()"
+                                  "fullyQualifiedName": "System.Web.HttpRequest.get_Item"
                                 }
                               ]
                             }
@@ -12791,7 +13155,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
                                 }
                               ]
                             }
@@ -12800,7 +13164,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12809,7 +13173,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12818,7 +13182,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12827,7 +13191,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12836,7 +13200,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12845,7 +13209,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12854,7 +13218,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12863,7 +13227,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12872,7 +13236,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12881,7 +13245,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -12890,7 +13254,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -12899,7 +13263,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12908,13 +13272,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.String.Concat"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.String System.String.Concat(System.String,System.String,System.String)"
+                                  "fullyQualifiedName": "System.String.Concat"
                                 }
                               ]
                             }
@@ -12923,7 +13294,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
                                 }
                               ]
                             }
@@ -12932,7 +13303,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
                                 }
                               ]
                             }
@@ -12941,7 +13312,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -12950,7 +13321,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -12959,7 +13330,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -12968,7 +13339,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -12977,7 +13348,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -12986,7 +13357,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -12995,7 +13366,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13004,7 +13375,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13013,7 +13384,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13022,7 +13393,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13031,7 +13402,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13040,7 +13411,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13049,13 +13420,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -13064,7 +13442,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -13073,7 +13451,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -13082,7 +13460,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
                                 }
                               ]
                             }
@@ -13091,7 +13469,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
                                 }
                               ]
                             }
@@ -13100,7 +13478,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -13109,7 +13487,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -13118,7 +13496,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -13127,7 +13505,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -13136,7 +13514,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13145,7 +13523,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -13154,7 +13532,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13163,7 +13541,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13172,7 +13550,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13181,7 +13559,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13190,7 +13568,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13199,7 +13577,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13208,13 +13586,20 @@
                       }
                     },
                     {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
+                          }
+                        ]
+                      },
                       "stack": {
                         "frames": [
                           {
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "void System.Data.Common.DbCommand.set_CommandText(System.String)"
+                                  "fullyQualifiedName": "System.Data.Common.DbCommand.set_CommandText"
                                 }
                               ]
                             }
@@ -13223,7 +13608,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlCommand..ctor"
                                 }
                               ]
                             }
@@ -13232,7 +13617,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor()"
+                                  "fullyQualifiedName": "MySql.Data.MySqlClient.MySqlDataAdapter..ctor"
                                 }
                               ]
                             }
@@ -13241,7 +13626,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.App_Code.DB.MySqlDbProvider.GetCustomerEmails"
                                 }
                               ]
                             }
@@ -13250,7 +13635,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest()"
+                                  "fullyQualifiedName": "OWASP.WebGoat.NET.WebGoatCoins.Autocomplete.ProcessRequest"
                                 }
                               ]
                             }
@@ -13259,7 +13644,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute"
                                 }
                               ]
                             }
@@ -13268,7 +13653,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStepImpl"
                                 }
                               ]
                             }
@@ -13277,7 +13662,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.ExecuteStep"
                                 }
                               ]
                             }
@@ -13286,7 +13671,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.PipelineStepManager.ResumeSteps"
                                 }
                               ]
                             }
@@ -13295,7 +13680,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.HttpApplication.BeginProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13304,7 +13689,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate()"
+                                  "fullyQualifiedName": "System.Web.HttpRuntime.ProcessRequestNotificationPrivate"
                                 }
                               ]
                             }
@@ -13313,7 +13698,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13322,7 +13707,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13331,7 +13716,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13340,7 +13725,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion()"
+                                  "fullyQualifiedName": "System.Web.Hosting.UnsafeIISMethods.MgdIndicateCompletion"
                                 }
                               ]
                             }
@@ -13349,7 +13734,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotificationHelper"
                                 }
                               ]
                             }
@@ -13358,7 +13743,7 @@
                             "location": {
                               "logicalLocations": [
                                 {
-                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification()"
+                                  "fullyQualifiedName": "System.Web.Hosting.PipelineRuntime.ProcessRequestNotification"
                                 }
                               ]
                             }
@@ -13994,7 +14379,6 @@
           ]
         }
       },
-      "language": "en-US",
       "originalUriBaseIds": {
         "SITE_ROOT": {
           "description": {


### PR DESCRIPTION
When the CS converter translates a sequence of `propagation-event` elements into a `threadFlow`, it populates each `threadFlowLocation.stack` from the `propagation-event`'s `stack` sub-element. The converter also takes the `propagation-event`'s `signature` sub-element and places it at the top of the stack.

But the converter does not populate `threadFlowLocation.location`, which confuses the VS Code Viewer, which expects `location` to be present. Sure, we could "fix" the viewer, but really, `signature` _does_ specify the location, and we _should_ populate it.

While looking at the code I found a couple more issues:
- The WebGoat.xml.sarif test file included `run.language` = `"en-US"`, which is wrong because it's the default. I removed it. I have a fix in another branch for the test infrastructure bug that failed to detect this.
- "Fully qualified logical names" were not being handled consistently. Now, they _never_ include the return type of the method, and the _never_ include the argument signature.  As a result, there are hundreds of line changes in WebGoat.xml.sarif test file. The important changes, for purposes of fixing the bug, is that every `threadFlowLocation` object now has `location` property in addition to the `stack` property. 