### PR TITLE
Introduce web message parsers

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -398,3 +398,4 @@
 * BUGFIX: Contrast Security converter no longer emits incomplete `artifact` objects. https://github.com/microsoft/sarif-sdk/issues/1529
 * BUGFIX: Fix crashing bugs and logic flaws in ArtifactLocation.TryReconstructAbsoluteUri.
 * API NON-BREAKING: Provide a SARIF converter for Visual Studio log files.
+* API NON-BREAKING: Introduce WebRequest.Parse and WebResponse.Parse to parse web traffic strings into SARIF WebRequest and WebResponse objects.

--- a/src/Sarif.Converters/VisualStudioBuildLogConverter.cs
+++ b/src/Sarif.Converters/VisualStudioBuildLogConverter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
             \s*:\s*
             (?<message>.*)
             $";
-        private static readonly Regex s_errorLineRegex = RegexFromPattern(ErrorLinePattern);
+        private static readonly Regex s_errorLineRegex = SarifUtilities.RegexFromPattern(ErrorLinePattern);
 
         private Result GetResultFrom(string fullMessage)
         {
@@ -170,23 +170,23 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
         // (startLine)
         private const string StartLineStartOnlyPattern = @"^(?<startLine>\d+)$";
-        private static readonly Regex s_startLineOnlyRegex = RegexFromPattern(StartLineStartOnlyPattern);
+        private static readonly Regex s_startLineOnlyRegex = SarifUtilities.RegexFromPattern(StartLineStartOnlyPattern);
 
         // (startLine-endLine)
         private const string StartLineEndLinePattern = @"^(?<startLine>\d+)-(?<endLine>\d+)$";
-        private static readonly Regex s_startLineEndLineRegex = RegexFromPattern(StartLineEndLinePattern);
+        private static readonly Regex s_startLineEndLineRegex = SarifUtilities.RegexFromPattern(StartLineEndLinePattern);
 
         // (startLine,startColumn)
         private const string StartLineStartColumnPattern = @"^(?<startLine>\d+),(?<startColumn>\d+)$";
-        private static readonly Regex s_startLineStartColumnRegex = RegexFromPattern(StartLineStartColumnPattern);
+        private static readonly Regex s_startLineStartColumnRegex = SarifUtilities.RegexFromPattern(StartLineStartColumnPattern);
 
         // (startLine,startColumn-endColumn)
         private const string StartLineStartColumEndColumnPattern = @"^(?<startLine>\d+),(?<startColumn>\d+)-(?<endColumn>\d+)$";
-        private static readonly Regex s_startLineStartColumnEndColumnRegex = RegexFromPattern(StartLineStartColumEndColumnPattern);
+        private static readonly Regex s_startLineStartColumnEndColumnRegex = SarifUtilities.RegexFromPattern(StartLineStartColumEndColumnPattern);
 
         // (startLine,startColumn,endLine,endColumn)
         private const string StartLineStartColumEndLineEndColumnPattern = @"^(?<startLine>\d+),(?<startColumn>\d+),(?<endLine>\d+),(?<endColumn>\d+)$";
-        private static readonly Regex s_startLineStartColumnEndLineEndColumnRegex = RegexFromPattern(StartLineStartColumEndLineEndColumnPattern);
+        private static readonly Regex s_startLineStartColumnEndLineEndColumnRegex = SarifUtilities.RegexFromPattern(StartLineStartColumEndLineEndColumnPattern);
 
         private static Region GetRegionFrom(string regionString)
         {
@@ -278,10 +278,5 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             return region;
         }
-
-        private static Regex RegexFromPattern(string pattern) =>
-            new Regex(
-                pattern,
-                RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
     }
 }

--- a/src/Sarif/Autogenerated/WebRequest.cs
+++ b/src/Sarif/Autogenerated/WebRequest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The request parameters.
         /// </summary>
         [DataMember(Name = "parameters", IsRequired = false, EmitDefaultValue = false)]
-        public object Parameters { get; set; }
+        public IDictionary<string, string> Parameters { get; set; }
 
         /// <summary>
         /// The body of the request.
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public WebRequest(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        public WebRequest(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, IDictionary<string, string> parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Init(index, protocol, version, target, method, headers, parameters, body, properties);
         }
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new WebRequest(this);
         }
 
-        protected virtual void Init(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        protected virtual void Init(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, IDictionary<string, string> parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Index = index;
             Protocol = protocol;
@@ -182,7 +182,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 Headers = new Dictionary<string, string>(headers);
             }
 
-            Parameters = parameters;
+            if (parameters != null)
+            {
+                Parameters = new Dictionary<string, string>(parameters);
+            }
+
             if (body != null)
             {
                 Body = new ArtifactContent(body);

--- a/src/Sarif/Autogenerated/WebRequest.cs
+++ b/src/Sarif/Autogenerated/WebRequest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The request headers.
         /// </summary>
         [DataMember(Name = "headers", IsRequired = false, EmitDefaultValue = false)]
-        public object Headers { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// The request parameters.
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public WebRequest(int index, string protocol, string version, string target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        public WebRequest(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Init(index, protocol, version, target, method, headers, parameters, body, properties);
         }
@@ -170,14 +170,18 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new WebRequest(this);
         }
 
-        protected virtual void Init(int index, string protocol, string version, string target, string method, object headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
+        protected virtual void Init(int index, string protocol, string version, string target, string method, IDictionary<string, string> headers, object parameters, ArtifactContent body, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Index = index;
             Protocol = protocol;
             Version = version;
             Target = target;
             Method = method;
-            Headers = headers;
+            if (headers != null)
+            {
+                Headers = new Dictionary<string, string>(headers);
+            }
+
             Parameters = parameters;
             if (body != null)
             {

--- a/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
@@ -53,9 +53,26 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (!object.Equals(left.Headers, right.Headers))
+            if (!object.ReferenceEquals(left.Headers, right.Headers))
             {
-                return false;
+                if (left.Headers == null || right.Headers == null || left.Headers.Count != right.Headers.Count)
+                {
+                    return false;
+                }
+
+                foreach (var value_0 in left.Headers)
+                {
+                    string value_1;
+                    if (!right.Headers.TryGetValue(value_0.Key, out value_1))
+                    {
+                        return false;
+                    }
+
+                    if (value_0.Value != value_1)
+                    {
+                        return false;
+                    }
+                }
             }
 
             if (!object.Equals(left.Parameters, right.Parameters))
@@ -75,15 +92,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                foreach (var value_0 in left.Properties)
+                foreach (var value_2 in left.Properties)
                 {
-                    SerializedPropertyInfo value_1;
-                    if (!right.Properties.TryGetValue(value_0.Key, out value_1))
+                    SerializedPropertyInfo value_3;
+                    if (!right.Properties.TryGetValue(value_2.Key, out value_3))
                     {
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!object.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }
@@ -126,7 +143,18 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 if (obj.Headers != null)
                 {
-                    result = (result * 31) + obj.Headers.GetHashCode();
+                    // Use xor for dictionaries to be order-independent.
+                    int xor_0 = 0;
+                    foreach (var value_4 in obj.Headers)
+                    {
+                        xor_0 ^= value_4.Key.GetHashCode();
+                        if (value_4.Value != null)
+                        {
+                            xor_0 ^= value_4.Value.GetHashCode();
+                        }
+                    }
+
+                    result = (result * 31) + xor_0;
                 }
 
                 if (obj.Parameters != null)
@@ -142,17 +170,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Properties != null)
                 {
                     // Use xor for dictionaries to be order-independent.
-                    int xor_0 = 0;
-                    foreach (var value_2 in obj.Properties)
+                    int xor_1 = 0;
+                    foreach (var value_5 in obj.Properties)
                     {
-                        xor_0 ^= value_2.Key.GetHashCode();
-                        if (value_2.Value != null)
+                        xor_1 ^= value_5.Key.GetHashCode();
+                        if (value_5.Value != null)
                         {
-                            xor_0 ^= value_2.Value.GetHashCode();
+                            xor_1 ^= value_5.Value.GetHashCode();
                         }
                     }
 
-                    result = (result * 31) + xor_0;
+                    result = (result * 31) + xor_1;
                 }
             }
 

--- a/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebRequestEqualityComparer.cs
@@ -75,9 +75,26 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
             }
 
-            if (!object.Equals(left.Parameters, right.Parameters))
+            if (!object.ReferenceEquals(left.Parameters, right.Parameters))
             {
-                return false;
+                if (left.Parameters == null || right.Parameters == null || left.Parameters.Count != right.Parameters.Count)
+                {
+                    return false;
+                }
+
+                foreach (var value_2 in left.Parameters)
+                {
+                    string value_3;
+                    if (!right.Parameters.TryGetValue(value_2.Key, out value_3))
+                    {
+                        return false;
+                    }
+
+                    if (value_2.Value != value_3)
+                    {
+                        return false;
+                    }
+                }
             }
 
             if (!ArtifactContent.ValueComparer.Equals(left.Body, right.Body))
@@ -92,15 +109,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                foreach (var value_2 in left.Properties)
+                foreach (var value_4 in left.Properties)
                 {
-                    SerializedPropertyInfo value_3;
-                    if (!right.Properties.TryGetValue(value_2.Key, out value_3))
+                    SerializedPropertyInfo value_5;
+                    if (!right.Properties.TryGetValue(value_4.Key, out value_5))
                     {
                         return false;
                     }
 
-                    if (!object.Equals(value_2.Value, value_3))
+                    if (!object.Equals(value_4.Value, value_5))
                     {
                         return false;
                     }
@@ -145,12 +162,12 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     // Use xor for dictionaries to be order-independent.
                     int xor_0 = 0;
-                    foreach (var value_4 in obj.Headers)
+                    foreach (var value_6 in obj.Headers)
                     {
-                        xor_0 ^= value_4.Key.GetHashCode();
-                        if (value_4.Value != null)
+                        xor_0 ^= value_6.Key.GetHashCode();
+                        if (value_6.Value != null)
                         {
-                            xor_0 ^= value_4.Value.GetHashCode();
+                            xor_0 ^= value_6.Value.GetHashCode();
                         }
                     }
 
@@ -159,7 +176,18 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 if (obj.Parameters != null)
                 {
-                    result = (result * 31) + obj.Parameters.GetHashCode();
+                    // Use xor for dictionaries to be order-independent.
+                    int xor_1 = 0;
+                    foreach (var value_7 in obj.Parameters)
+                    {
+                        xor_1 ^= value_7.Key.GetHashCode();
+                        if (value_7.Value != null)
+                        {
+                            xor_1 ^= value_7.Value.GetHashCode();
+                        }
+                    }
+
+                    result = (result * 31) + xor_1;
                 }
 
                 if (obj.Body != null)
@@ -170,17 +198,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Properties != null)
                 {
                     // Use xor for dictionaries to be order-independent.
-                    int xor_1 = 0;
-                    foreach (var value_5 in obj.Properties)
+                    int xor_2 = 0;
+                    foreach (var value_8 in obj.Properties)
                     {
-                        xor_1 ^= value_5.Key.GetHashCode();
-                        if (value_5.Value != null)
+                        xor_2 ^= value_8.Key.GetHashCode();
+                        if (value_8.Value != null)
                         {
-                            xor_1 ^= value_5.Value.GetHashCode();
+                            xor_2 ^= value_8.Value.GetHashCode();
                         }
                     }
 
-                    result = (result * 31) + xor_1;
+                    result = (result * 31) + xor_2;
                 }
             }
 

--- a/src/Sarif/Autogenerated/WebResponse.cs
+++ b/src/Sarif/Autogenerated/WebResponse.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The response headers.
         /// </summary>
         [DataMember(Name = "headers", IsRequired = false, EmitDefaultValue = false)]
-        public object Headers { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// The body of the response.
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public WebResponse(int index, string protocol, string version, int statusCode, string reasonPhrase, object headers, ArtifactContent body, bool noResponseReceived, IDictionary<string, SerializedPropertyInfo> properties)
+        public WebResponse(int index, string protocol, string version, int statusCode, string reasonPhrase, IDictionary<string, string> headers, ArtifactContent body, bool noResponseReceived, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Init(index, protocol, version, statusCode, reasonPhrase, headers, body, noResponseReceived, properties);
         }
@@ -173,14 +173,18 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new WebResponse(this);
         }
 
-        protected virtual void Init(int index, string protocol, string version, int statusCode, string reasonPhrase, object headers, ArtifactContent body, bool noResponseReceived, IDictionary<string, SerializedPropertyInfo> properties)
+        protected virtual void Init(int index, string protocol, string version, int statusCode, string reasonPhrase, IDictionary<string, string> headers, ArtifactContent body, bool noResponseReceived, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Index = index;
             Protocol = protocol;
             Version = version;
             StatusCode = statusCode;
             ReasonPhrase = reasonPhrase;
-            Headers = headers;
+            if (headers != null)
+            {
+                Headers = new Dictionary<string, string>(headers);
+            }
+
             if (body != null)
             {
                 Body = new ArtifactContent(body);

--- a/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/WebResponseEqualityComparer.cs
@@ -53,9 +53,26 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (!object.Equals(left.Headers, right.Headers))
+            if (!object.ReferenceEquals(left.Headers, right.Headers))
             {
-                return false;
+                if (left.Headers == null || right.Headers == null || left.Headers.Count != right.Headers.Count)
+                {
+                    return false;
+                }
+
+                foreach (var value_0 in left.Headers)
+                {
+                    string value_1;
+                    if (!right.Headers.TryGetValue(value_0.Key, out value_1))
+                    {
+                        return false;
+                    }
+
+                    if (value_0.Value != value_1)
+                    {
+                        return false;
+                    }
+                }
             }
 
             if (!ArtifactContent.ValueComparer.Equals(left.Body, right.Body))
@@ -75,15 +92,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return false;
                 }
 
-                foreach (var value_0 in left.Properties)
+                foreach (var value_2 in left.Properties)
                 {
-                    SerializedPropertyInfo value_1;
-                    if (!right.Properties.TryGetValue(value_0.Key, out value_1))
+                    SerializedPropertyInfo value_3;
+                    if (!right.Properties.TryGetValue(value_2.Key, out value_3))
                     {
                         return false;
                     }
 
-                    if (!object.Equals(value_0.Value, value_1))
+                    if (!object.Equals(value_2.Value, value_3))
                     {
                         return false;
                     }
@@ -122,7 +139,18 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 if (obj.Headers != null)
                 {
-                    result = (result * 31) + obj.Headers.GetHashCode();
+                    // Use xor for dictionaries to be order-independent.
+                    int xor_0 = 0;
+                    foreach (var value_4 in obj.Headers)
+                    {
+                        xor_0 ^= value_4.Key.GetHashCode();
+                        if (value_4.Value != null)
+                        {
+                            xor_0 ^= value_4.Value.GetHashCode();
+                        }
+                    }
+
+                    result = (result * 31) + xor_0;
                 }
 
                 if (obj.Body != null)
@@ -134,17 +162,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (obj.Properties != null)
                 {
                     // Use xor for dictionaries to be order-independent.
-                    int xor_0 = 0;
-                    foreach (var value_2 in obj.Properties)
+                    int xor_1 = 0;
+                    foreach (var value_5 in obj.Properties)
                     {
-                        xor_0 ^= value_2.Key.GetHashCode();
-                        if (value_2.Value != null)
+                        xor_1 ^= value_5.Key.GetHashCode();
+                        if (value_5.Value != null)
                         {
-                            xor_0 ^= value_2.Value.GetHashCode();
+                            xor_1 ^= value_5.Value.GetHashCode();
                         }
                     }
 
-                    result = (result * 31) + xor_0;
+                    result = (result * 31) + xor_1;
                 }
             }
 

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -1114,6 +1114,11 @@
       "kind": "DictionaryHint"
     }
   ],
+  "WebRequest.Parameters": [
+    {
+      "kind": "DictionaryHint"
+    }
+  ],
   "webResponse": [
     {
       "kind": "BaseTypeHint",

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -1109,6 +1109,11 @@
       }
     }
   ],
+  "WebRequest.Headers": [
+    {
+      "kind": "DictionaryHint"
+    }
+  ],
   "webResponse": [
     {
       "kind": "BaseTypeHint",
@@ -1117,6 +1122,11 @@
           "PropertyBagHolder"
         ]
       }
+    }
+  ],
+  "WebResponse.Headers": [
+    {
+      "kind": "DictionaryHint"
     }
   ]
 }

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -36,5 +36,18 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             return match.Success;
         }
+
+        internal static bool ValidateMethod(string method)
+        {
+            return ValidateToken(method);
+        }
+
+        private const string TokenPattern = "^[!#$%&'*+._`|~0-9a-zA-Z^-]+$";
+        private static readonly Regex s_tokenRegex = SarifUtilities.RegexFromPattern(TokenPattern);
+
+        private static bool ValidateToken(string token)
+        {
+            return s_tokenRegex.IsMatch(token);
+        }
     }
 }

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -23,6 +23,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         // it to this length:
         private const int MaxExceptionMessageStringLength = 200;
 
+        // These patterns are taken from the grammar defined in RFC 7230, "Hypertext Transfer Protocol (HTTP/1.1):
+        // Message Syntax and Routing". Yes, tokens (such as message header field names) really can have all those
+        // weird characters.
+        //
+        // We are a little looser than the RFC in a couple of places. In the request, we don't verify that the
+        // "target" field on the request line is a valid URI. Nor do we verify that the request body or response
+        // body contains only "VCHAR"s (visible characters as opposed to control characters), as required by
+        // the RFC.
         internal const string CRLF = "\r\n";
         internal const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
         internal const string HttpVersionPattern = @"(?<protocol>HTTP)/(?<version>[0-9]\.[0-9])";
@@ -41,9 +49,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly Regex s_headerRegex = SarifUtilities.RegexFromPattern(HeaderPattern);
 
-        internal static void ParseHeaderLines(string requestString, out Dictionary<string, string> headers, out int totalLength)
+        internal static IDictionary<string, string> ParseHeaderLines(string requestString, out int totalLength)
         {
-            headers = new Dictionary<string, string>();
+            var headers = new Dictionary<string, string>();
             totalLength = 0;
              
             do
@@ -60,6 +68,8 @@ namespace Microsoft.CodeAnalysis.Sarif
             } while (!requestString.StartsWith(CRLF));  // An empty line signals the end of the headers.
 
             totalLength += CRLF.Length;                 // Skip past the empty line;
+
+            return headers;
         }
 
         internal static void ParseHeaderLine(string headerLine, out string fieldName, out string fieldValue, out int length)

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </remarks>
     internal static class WebMessageUtilities
     {
+        private const string CRLF = "\r\n";
         private const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
         private const string HttpVersionPattern = @"(?<protocol>HTTP)/(?<version>[0-9]\.[0-9])";
 
@@ -133,7 +134,13 @@ namespace Microsoft.CodeAnalysis.Sarif
                     requestString = requestString.Substring(length);
                     totalLength += length;
                 }
-            } while (!string.IsNullOrWhiteSpace(requestString));
+                else
+                {
+                    return false;
+                }
+            } while (!requestString.StartsWith(CRLF));  // An empty line signals the end of the headers.
+
+            totalLength += CRLF.Length;                 // Skip past the empty line;
 
             return true;
         }

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -37,19 +38,47 @@ namespace Microsoft.CodeAnalysis.Sarif
             return match.Success;
         }
 
-        internal static bool ValidateMethod(string method)
+        private const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
+
+        private const string RequestLinePattern =
+            @"^
+            (?<method>" + TokenPattern + @")            # The method, which is a token,
+            \x20                                        # followed by a single space (which we must write this way
+                                                        # because we're using RegexOptions.IgnorePatternWhitespace),
+            (?<target>[^\s]+)                           # the target URI, which we don't validate further,
+            \x20                                        # another space,
+            (?<httpVersion>" + HttpVersionPattern + @") # and the HTTP version, e.g., 'HTTP/1.1'.
+            \r\n";
+
+        private static readonly Regex s_requestLineRegex = SarifUtilities.RegexFromPattern(RequestLinePattern);
+
+        internal static bool ParseRequestLine(string requestString, out string method, out string target, out string httpVersion, out string protocol, out string version, out int length)
         {
-            return ValidateToken(method);
+            method = target = httpVersion = protocol = version = null;
+            length = -1;
+
+            Match match = s_requestLineRegex.Match(requestString);
+            if (match.Success)
+            {
+                method = match.Groups["method"].Value;
+                target = match.Groups["target"].Value;
+                httpVersion = match.Groups["httpVersion"].Value;
+                protocol = match.Groups["protocol"].Value;
+                version = match.Groups["version"].Value;
+
+                length = match.Length;
+            }
+
+            return match.Success;
         }
 
-        private const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
         private const string HeaderPattern =
             @"^
-              (?<fieldName>" + TokenPattern + @")   # The field name, which must be a token,
-              :                                     # immediately followed by a colon,
-              \s*                                   # optional white space,
-              (?<fieldValue>.*?)                    # and the field value, which is a non-greedy match (.*?)
-              \s*                                   # so that it doesn't include the optional trailing white space.
+              (?<fieldName>" + TokenPattern + @")       # The field name, which must be a token,
+              :                                         # immediately followed by a colon,
+              \s*                                       # optional white space,
+              (?<fieldValue>.*?)                        # and the field value, which is a non-greedy match (.*?)
+              \s*                                       # so that it doesn't include the optional trailing white space.
               $";
 
         private static readonly Regex s_headerRegex = SarifUtilities.RegexFromPattern(HeaderPattern);
@@ -68,6 +97,10 @@ namespace Microsoft.CodeAnalysis.Sarif
             return match.Success;
         }
 
+        internal static bool ValidateMethod(string method)
+        {
+            return ValidateToken(method);
+        }
 
         private const string TokenOnlyPattern = "^" + TokenPattern + "$";
         private static readonly Regex s_tokenOnlyRegex = SarifUtilities.RegexFromPattern(TokenOnlyPattern);

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -105,20 +107,48 @@ namespace Microsoft.CodeAnalysis.Sarif
               :                                         # immediately followed by a colon,
               \s*                                       # optional white space,
               (?<fieldValue>.*?)                        # and the field value, which is a non-greedy match (.*?)
-              \s*                                       # so that it doesn't include the optional trailing white space.
-              $";
+              \s*?                                      # so that it doesn't include the optional trailing white space...
+              \r\n                                      # ... or the CRLF.
+                                                        # The pattern does _not_ include '$' because there might
+                                                        # be more headers, or a body, to follow"
+              ;
 
         private static readonly Regex s_headerRegex = SarifUtilities.RegexFromPattern(HeaderPattern);
 
-        internal static bool ParseHeaderLine(string headerLine, out string fieldName, out string fieldValue)
+        internal static bool ParseHeaderLines(string requestString, out Dictionary<string, string> headers, out int totalLength)
+        {
+            headers = new Dictionary<string, string>();
+            totalLength = 0;
+             
+            do
+            {
+                if (ParseHeaderLine(requestString, out string fieldName, out string fieldValue, out int length))
+                {
+                    if (headers.ContainsKey(fieldName))
+                    {
+                        return false;
+                    }
+
+                    headers.Add(fieldName, fieldValue);
+                    requestString = requestString.Substring(length);
+                    totalLength += length;
+                }
+            } while (!string.IsNullOrWhiteSpace(requestString));
+
+            return true;
+        }
+
+        internal static bool ParseHeaderLine(string headerLine, out string fieldName, out string fieldValue, out int length)
         {
             fieldName = fieldValue = null;
+            length = -1;
 
             Match match = s_headerRegex.Match(headerLine);
             if (match.Success)
             {
                 fieldName = match.Groups["fieldName"].Value;
                 fieldValue = match.Groups["fieldValue"].Value;
+                length = match.Length;
             }
 
             return match.Success;

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             Match match = s_headerRegex.Match(headerLine);
             if (!match.Success)
             {
-                throw new ArgumentException($"Invalid header line: '{Truncate(headerLine)}'.");
+                throw new ArgumentException($"Invalid header line: '{Truncate(headerLine)}'.", nameof(headerLine));
             }
 
             fieldName = match.Groups["fieldName"].Value;

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -32,7 +32,14 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly Regex s_requestLineRegex = SarifUtilities.RegexFromPattern(RequestLinePattern);
 
-        internal static bool ParseRequestLine(string requestString, out string method, out string target, out string httpVersion, out string protocol, out string version, out int length)
+        internal static bool ParseRequestLine(
+            string requestString,
+            out string method,
+            out string target,
+            out string httpVersion,
+            out string protocol,
+            out string version,
+            out int length)
         {
             method = target = httpVersion = protocol = version = null;
             length = -1;
@@ -65,7 +72,14 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly Regex s_statusLineRegex = SarifUtilities.RegexFromPattern(StatusLinePattern);
 
-        internal static bool ParseStatusLine(string responseString, out string httpVersion, out string protocol, out string version, out int statusCode, out string reasonPhrase, out int length)
+        internal static bool ParseStatusLine(
+            string responseString,
+            out string httpVersion,
+            out string protocol,
+            out string version,
+            out int statusCode,
+            out string reasonPhrase,
+            out int length)
         {
             httpVersion = protocol = version = reasonPhrase = null;
             statusCode = length = -1;

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         private const string HttpVersionPattern = @"(?<protocol>[^/]+)/(?<version>.+)";
         private static readonly Regex s_httpVersionRegex = SarifUtilities.RegexFromPattern(HttpVersionPattern);
 
+        internal static string MakeProtocolVersion(string protocol, string version)
+            => (protocol ?? string.Empty) + "/" + (version ?? string.Empty);
+
         internal static bool ParseProtocolAndVersion(string httpVersion, out string protocol, out string version)
         {
             protocol = version = null;

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </remarks>
     internal static class WebMessageUtilities
     {
-        private const string HttpVersionPattern = @"(?<protocol>[^/]+)/(?<version>.+)";
+        private const string HttpVersionPattern = @"(?<protocol>HTTP)/(?<version>[0-9]\.[0-9])";
         private static readonly Regex s_httpVersionRegex = SarifUtilities.RegexFromPattern(HttpVersionPattern);
 
         internal static string MakeProtocolVersion(string protocol, string version)

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    /// <summary>
+    /// This class provides utilities common to the parsing of <see cref="WebRequest"/>
+    /// and <see cref="WebResponse"/> objects from the raw request and response strings.
+    /// </summary>
+    /// <remarks>
+    /// Ideally, this would have been a base class for both WebRequest and WebResponse.
+    /// Unfortunately, every class in the SARIF SDK's object model derives from
+    /// <see cref="PropertyBagHolder"/>, so the .NET class inheritance point is already
+    /// spent.
+    /// </remarks>
+    internal static class WebMessageUtilities
+    {
+        private const string HttpVersionPattern = @"(?<protocol>[^/]+)/(?<version>.+)";
+        private static readonly Regex s_httpVersionRegex = SarifUtilities.RegexFromPattern(HttpVersionPattern);
+
+        internal static bool ParseProtocolAndVersion(string httpVersion, out string protocol, out string version)
+        {
+            protocol = version = null;
+
+            Match match = s_httpVersionRegex.Match(httpVersion);
+            if (match.Success)
+            {
+                protocol = match.Groups["protocol"].Value;
+                version = match.Groups["version"].Value;
+            }
+
+            return match.Success;
+        }
+    }
+}

--- a/src/Sarif/Core/WebMessageUtilities.cs
+++ b/src/Sarif/Core/WebMessageUtilities.cs
@@ -23,82 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         // it to this length:
         private const int MaxExceptionMessageStringLength = 200;
 
-        private const string CRLF = "\r\n";
-        private const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
-        private const string HttpVersionPattern = @"(?<protocol>HTTP)/(?<version>[0-9]\.[0-9])";
-
-        private const string RequestLinePattern =
-            @"^
-            (?<method>" + TokenPattern + @")            # The method, which is a token,
-            \x20                                        # followed by a single space (which we must write this way
-                                                        # because we're using RegexOptions.IgnorePatternWhitespace),
-            (?<target>[^\s]+)                           # the target URI, which we don't validate further,
-            \x20                                        # another space,
-            (?<httpVersion>" + HttpVersionPattern + @") # and the HTTP version, e.g., 'HTTP/1.1'.
-            \r\n";
-
-        private static readonly Regex s_requestLineRegex = SarifUtilities.RegexFromPattern(RequestLinePattern);
-
-        internal static void ParseRequestLine(
-            string requestString,
-            out string method,
-            out string target,
-            out string httpVersion,
-            out string protocol,
-            out string version,
-            out int length)
-        {
-            Match match = s_requestLineRegex.Match(requestString);
-            if (!match.Success)
-            {
-                throw new ArgumentException($"Invalid request line: '{Truncate(requestString)}'", nameof(requestString));
-            }
-
-            method = match.Groups["method"].Value;
-            target = match.Groups["target"].Value;
-            httpVersion = match.Groups["httpVersion"].Value;
-            protocol = match.Groups["protocol"].Value;
-            version = match.Groups["version"].Value;
-
-            length = match.Length;
-        }
-
-        private const string StatusLinePattern =
-            @"^
-            (?<httpVersion>" + HttpVersionPattern + @") # The HTTP version, e.g., 'HTTP/1.1',
-            \x20                                        # followed by a single space (which we must write this way
-                                                        # because we're using RegexOptions.IgnorePatternWhitespace),
-            (?<statusCode>\d\d\d)                       # a 3-digit status code,
-            \x20                                        # another space,
-            (?<reasonPhrase>.*?)                        # and the 'reason phrase', which we match non-greedy (.*?)
-            \r\n                                        # so that it doesn't include the trailing CRLF.
-            ";
-
-        private static readonly Regex s_statusLineRegex = SarifUtilities.RegexFromPattern(StatusLinePattern);
-
-        internal static void ParseStatusLine(
-            string responseString,
-            out string httpVersion,
-            out string protocol,
-            out string version,
-            out int statusCode,
-            out string reasonPhrase,
-            out int length)
-        {
-            Match match = s_statusLineRegex.Match(responseString);
-            if (!match.Success)
-            {
-                throw new ArgumentException($"Invalid status line: '{Truncate(responseString)}'", nameof(responseString));
-            }
-
-            httpVersion = match.Groups["httpVersion"].Value;
-            protocol = match.Groups["protocol"].Value;
-            version = match.Groups["version"].Value;
-            statusCode = int.Parse(match.Groups["statusCode"].Value);
-            reasonPhrase = match.Groups["reasonPhrase"].Value;
-
-            length = match.Length;
-        }
+        internal const string CRLF = "\r\n";
+        internal const string TokenPattern = "[!#$%&'*+._`|~0-9a-zA-Z^-]+";
+        internal const string HttpVersionPattern = @"(?<protocol>HTTP)/(?<version>[0-9]\.[0-9])";
 
         private const string HeaderPattern =
             @"^
@@ -109,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif
               \s*?                                      # so that it doesn't include the optional trailing white space...
               \r\n                                      # ... or the CRLF.
                                                         # The pattern does _not_ include '$' because there might
-                                                        # be more headers, or a body, to follow"
+                                                        # be more headers, or a body, to follow."
               ;
 
         private static readonly Regex s_headerRegex = SarifUtilities.RegexFromPattern(HeaderPattern);
@@ -148,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             length = match.Length;
         }
 
-        private static string Truncate(string s)
+        internal static string Truncate(string s)
         {
             return s.Length <= MaxExceptionMessageStringLength
                 ? s

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -34,7 +34,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             WebMessageUtilities.ParseHeaderLines(requestString, out Dictionary<string, string> headers, out int totalHeadersLength);
             webRequest.Headers = headers;
 
-            requestString = requestString.Substring(totalHeadersLength);
+            if (requestString.Length > totalHeadersLength)
+            {
+                webRequest.Body = new ArtifactContent
+                {
+                    Text = requestString.Substring(totalHeadersLength)
+                };
+            }
 
             return webRequest;
         }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -35,7 +34,16 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 if (fields.Length > 2)
                 {
-                    webRequest.ParseProtocolAndVersion(fields[2]);
+                    bool success = WebMessageUtilities.ParseProtocolAndVersion(fields[0], out string protocol, out string version);
+                    if (success)
+                    {
+                        webRequest.Protocol = protocol;
+                        webRequest.Version = version;
+                    }
+                    else
+                    {
+                        webRequest.IsInvalid = true;
+                    }
                 }
 
                 if (fields.Length < 3)
@@ -51,24 +59,6 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             return webRequest;
-        }
-
-        private const string HttpVersionPattern = @"(?<protocol>[^/]+)/(?<version>.+)";
-        private static readonly Regex s_httpVersionRegex = SarifUtilities.RegexFromPattern(HttpVersionPattern);
-
-        private void ParseProtocolAndVersion(string httpVersion)
-        {
-            Match match = s_httpVersionRegex.Match(httpVersion);
-            if (match.Success)
-            {
-                Protocol = match.Groups["protocol"].Value;
-                Version = match.Groups["version"].Value;
-            }
-            else
-            {
-                Protocol = httpVersion;
-                IsInvalid = true;
-            }
         }
     }
 }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -42,7 +46,75 @@ namespace Microsoft.CodeAnalysis.Sarif
                 };
             }
 
+            if (Uri.TryCreate(webRequest.Target, UriKind.RelativeOrAbsolute, out Uri uri))
+            {
+                webRequest.Parameters = ParseQueryParametersFromUri(uri);
+            }
+
             return webRequest;
+        }
+
+        private static IDictionary<string, string> ParseQueryParametersFromUri(Uri uri)
+        {
+            // uri.Query throws an exception if uri is not absolute, so first make it absolute.
+            uri = SynthesizeAbsoluteUriFrom(uri);
+
+            return ParseParametersFromQueryString(uri.Query);
+        }
+
+        private static Uri SynthesizeAbsoluteUriFrom(Uri uri)
+        {
+            if (!uri.IsAbsoluteUri)
+            {
+                var sb = new StringBuilder("http://www.example.com");
+                if (!uri.OriginalString.StartsWith("/"))
+                {
+                    sb.Append("/");
+                }
+
+                sb.Append(uri.OriginalString);
+                uri = new Uri(sb.ToString(), UriKind.Absolute);
+            }
+
+            return uri;
+        }
+
+        const string QueryPattern =
+            @"^
+              \?                              # A literal '?', followed by zero or more
+              (
+                (?<name>[^=])                 # parameter name (everything that's not an = sign),
+                =                             # an equal sign, and
+                (
+                  (?<value>[^&]*)             # the value (everything that's not an '&')...
+                  &?                          # and an '&' (except after the last one).
+                )
+              )*";
+        private static readonly Regex s_queryRegex = SarifUtilities.RegexFromPattern(QueryPattern);
+
+        private static IDictionary<string, string> ParseParametersFromQueryString(string query)
+        {
+            Dictionary<string, string> parameterDictionary = null;
+            if (query != null)
+            {
+                Match match = s_queryRegex.Match(query);
+                if (match.Success)
+                {
+                    List<string> names = match.Groups["name"].Captures.Cast<Capture>().Select(c => c.Value).ToList();
+                    List<string> values = match.Groups["value"].Captures.Cast<Capture>().Select(c => c.Value).ToList();
+
+                    if (names.Count == values.Count)
+                    {
+                        parameterDictionary = new Dictionary<string, string>();
+                        for (int i = 0; i < names.Count; ++i)
+                        {
+                            parameterDictionary.Add(names[i], values[i]);
+                        }
+                    }
+                }
+            }
+
+            return parameterDictionary;
         }
     }
 }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -11,6 +11,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         [JsonIgnore]
         public bool IsInvalid { get; private set; }
 
+        [JsonIgnore]
+        public string ProtocolVersion => WebMessageUtilities.MakeProtocolVersion(Protocol, Version);
+
         public static WebRequest Parse(string requestString)
         {
             var webRequest = new WebRequest();
@@ -34,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                 if (fields.Length > 2)
                 {
-                    bool success = WebMessageUtilities.ParseProtocolAndVersion(fields[0], out string protocol, out string version);
+                    bool success = WebMessageUtilities.ParseProtocolAndVersion(fields[2], out string protocol, out string version);
                     if (success)
                     {
                         webRequest.Protocol = protocol;

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (fields.Length > 0)
                 {
                     webRequest.Method = fields[0];
+                    if (!WebMessageUtilities.ValidateMethod(webRequest.Method)) { webRequest.IsInvalid = true; }
                 }
 
                 if (fields.Length > 1)

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -17,13 +18,28 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var webRequest = new WebRequest();
 
-            if (WebMessageUtilities.ParseRequestLine(requestString, out string method, out string target, out string httpVersion, out string protocol, out string version, out int length))
+            if (WebMessageUtilities.ParseRequestLine(
+                requestString,
+                out string method,
+                out string target,
+                out string httpVersion,
+                out string protocol,
+                out string version,
+                out int requestLineLength))
             {
                 webRequest.Method = method;
                 webRequest.Target = target;
                 webRequest.HttpVersion = httpVersion;
                 webRequest.Protocol = protocol;
                 webRequest.Version = version;
+
+                requestString = requestString.Substring(requestLineLength);
+                if (WebMessageUtilities.ParseHeaderLines(requestString, out Dictionary<string, string> headers, out int totalHeadersLength))
+                {
+                    webRequest.Headers = headers;
+                }
+
+                requestString = requestString.Substring(totalHeadersLength);
             }
             else
             {

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public partial class WebRequest
+    {
+        public static WebRequest Parse(string requestString)
+        {
+            return new WebRequest();
+        }
+    }
+}

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -1,13 +1,32 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public partial class WebRequest
     {
         public static WebRequest Parse(string requestString)
         {
-            return new WebRequest();
+            var webRequest = new WebRequest();
+
+            string[] lines = requestString.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            int lineIndex = 0;
+            if (lines.Length > 0)
+            {
+                string requestLine = lines[0];
+                string[] fields = requestLine.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                if (fields.Length > 0)
+                {
+                    webRequest.Method = fields[0];
+                }
+
+                ++lineIndex;
+            }
+
+            return webRequest;
         }
     }
 }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -19,24 +19,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var webRequest = new WebRequest();
 
-            ParseRequestLine(
-                requestString,
-                out string method,
-                out string target,
-                out string httpVersion,
-                out string protocol,
-                out string version,
-                out int requestLineLength);
-
-            webRequest.Method = method;
-            webRequest.Target = target;
-            webRequest.HttpVersion = httpVersion;
-            webRequest.Protocol = protocol;
-            webRequest.Version = version;
+            webRequest.ParseRequestLine(requestString, out int requestLineLength);
 
             requestString = requestString.Substring(requestLineLength);
-            WebMessageUtilities.ParseHeaderLines(requestString, out Dictionary<string, string> headers, out int totalHeadersLength);
-            webRequest.Headers = headers;
+            webRequest.Headers = WebMessageUtilities.ParseHeaderLines(requestString, out int totalHeadersLength);
 
             if (requestString.Length > totalHeadersLength)
             {
@@ -66,13 +52,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly Regex s_requestLineRegex = SarifUtilities.RegexFromPattern(RequestLinePattern);
 
-        internal static void ParseRequestLine(
+        internal void ParseRequestLine(
             string requestString,
-            out string method,
-            out string target,
-            out string httpVersion,
-            out string protocol,
-            out string version,
             out int length)
         {
             Match match = s_requestLineRegex.Match(requestString);
@@ -81,11 +62,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentException($"Invalid request line: '{WebMessageUtilities.Truncate(requestString)}'", nameof(requestString));
             }
 
-            method = match.Groups["method"].Value;
-            target = match.Groups["target"].Value;
-            httpVersion = match.Groups["httpVersion"].Value;
-            protocol = match.Groups["protocol"].Value;
-            version = match.Groups["version"].Value;
+            this.Method = match.Groups["method"].Value;
+            this.Target = match.Groups["target"].Value;
+            this.HttpVersion = match.Groups["httpVersion"].Value;
+            this.Protocol = match.Groups["protocol"].Value;
+            this.Version = match.Groups["version"].Value;
 
             length = match.Length;
         }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -38,6 +38,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     webRequest.Headers = headers;
                 }
+                else
+                {
+                    webRequest.IsInvalid = true;
+                    return webRequest;
+                }
 
                 requestString = requestString.Substring(totalHeadersLength);
             }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public bool IsInvalid { get; private set; }
 
         [JsonIgnore]
-        public string ProtocolVersion { get; private set; }
+        public string HttpVersion { get; private set; }
 
         public static WebRequest Parse(string requestString)
         {
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             {
                 webRequest.Method = method;
                 webRequest.Target = target;
-                webRequest.ProtocolVersion = httpVersion;
+                webRequest.HttpVersion = httpVersion;
                 webRequest.Protocol = protocol;
                 webRequest.Version = version;
             }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -9,48 +9,32 @@ namespace Microsoft.CodeAnalysis.Sarif
     public partial class WebRequest
     {
         [JsonIgnore]
-        public bool IsInvalid { get; private set; }
-
-        [JsonIgnore]
         public string HttpVersion { get; private set; }
 
         public static WebRequest Parse(string requestString)
         {
             var webRequest = new WebRequest();
 
-            if (WebMessageUtilities.ParseRequestLine(
+            WebMessageUtilities.ParseRequestLine(
                 requestString,
                 out string method,
                 out string target,
                 out string httpVersion,
                 out string protocol,
                 out string version,
-                out int requestLineLength))
-            {
-                webRequest.Method = method;
-                webRequest.Target = target;
-                webRequest.HttpVersion = httpVersion;
-                webRequest.Protocol = protocol;
-                webRequest.Version = version;
+                out int requestLineLength);
 
-                requestString = requestString.Substring(requestLineLength);
-                if (WebMessageUtilities.ParseHeaderLines(requestString, out Dictionary<string, string> headers, out int totalHeadersLength))
-                {
-                    webRequest.Headers = headers;
-                }
-                else
-                {
-                    webRequest.IsInvalid = true;
-                    return webRequest;
-                }
+            webRequest.Method = method;
+            webRequest.Target = target;
+            webRequest.HttpVersion = httpVersion;
+            webRequest.Protocol = protocol;
+            webRequest.Version = version;
 
-                requestString = requestString.Substring(totalHeadersLength);
-            }
-            else
-            {
-                webRequest.IsInvalid = true;
-                return webRequest;
-            }
+            requestString = requestString.Substring(requestLineLength);
+            WebMessageUtilities.ParseHeaderLines(requestString, out Dictionary<string, string> headers, out int totalHeadersLength);
+            webRequest.Headers = headers;
+
+            requestString = requestString.Substring(totalHeadersLength);
 
             return webRequest;
         }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -2,20 +2,25 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public partial class WebRequest
     {
+        [JsonIgnore]
+        public bool IsInvalid { get; private set; }
+
         public static WebRequest Parse(string requestString)
         {
             var webRequest = new WebRequest();
 
-            string[] lines = requestString.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
-
-            int lineIndex = 0;
-            if (lines.Length > 0)
+            if (!string.IsNullOrEmpty(requestString))
             {
+                string[] lines = requestString.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+                int lineIndex = 0;
                 string requestLine = lines[0];
                 string[] fields = requestLine.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
                 if (fields.Length > 0)
@@ -23,10 +28,47 @@ namespace Microsoft.CodeAnalysis.Sarif
                     webRequest.Method = fields[0];
                 }
 
+                if (fields.Length > 1)
+                {
+                    webRequest.Target = fields[1];
+                }
+
+                if (fields.Length > 2)
+                {
+                    webRequest.ParseProtocolAndVersion(fields[2]);
+                }
+
+                if (fields.Length < 3)
+                {
+                    webRequest.IsInvalid = true;
+                }
+
                 ++lineIndex;
+            }
+            else
+            {
+                webRequest.IsInvalid = true;
             }
 
             return webRequest;
+        }
+
+        private const string HttpVersionPattern = @"(?<protocol>[^/]+)/(?<version>.+)";
+        private static readonly Regex s_httpVersionRegex = SarifUtilities.RegexFromPattern(HttpVersionPattern);
+
+        private void ParseProtocolAndVersion(string httpVersion)
+        {
+            Match match = s_httpVersionRegex.Match(httpVersion);
+            if (match.Success)
+            {
+                Protocol = match.Groups["protocol"].Value;
+                Version = match.Groups["version"].Value;
+            }
+            else
+            {
+                Protocol = httpVersion;
+                IsInvalid = true;
+            }
         }
     }
 }

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 
@@ -17,24 +16,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var webResponse = new WebResponse();
 
-            ParseStatusLine(
-                responseString,
-                out string httpVersion,
-                out string protocol,
-                out string version,
-                out int statusCode,
-                out string reasonPhrase,
-                out int statusLineLength);
-
-            webResponse.HttpVersion = httpVersion;
-            webResponse.Protocol = protocol;
-            webResponse.Version = version;
-            webResponse.StatusCode = statusCode;
-            webResponse.ReasonPhrase = reasonPhrase;
+            webResponse.ParseStatusLine(responseString, out int statusLineLength);
 
             responseString = responseString.Substring(statusLineLength);
-            WebMessageUtilities.ParseHeaderLines(responseString, out Dictionary<string, string> headers, out int totalHeadersLength);
-            webResponse.Headers = headers;
+            webResponse.Headers = WebMessageUtilities.ParseHeaderLines(responseString, out int totalHeadersLength);
 
             if (responseString.Length > totalHeadersLength)
             {
@@ -60,13 +45,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         private static readonly Regex s_statusLineRegex = SarifUtilities.RegexFromPattern(StatusLinePattern);
 
-        internal static void ParseStatusLine(
+        internal void ParseStatusLine(
             string responseString,
-            out string httpVersion,
-            out string protocol,
-            out string version,
-            out int statusCode,
-            out string reasonPhrase,
             out int length)
         {
             Match match = s_statusLineRegex.Match(responseString);
@@ -75,11 +55,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentException($"Invalid status line: '{WebMessageUtilities.Truncate(responseString)}'", nameof(responseString));
             }
 
-            httpVersion = match.Groups["httpVersion"].Value;
-            protocol = match.Groups["protocol"].Value;
-            version = match.Groups["version"].Value;
-            statusCode = int.Parse(match.Groups["statusCode"].Value);
-            reasonPhrase = match.Groups["reasonPhrase"].Value;
+            this.HttpVersion = match.Groups["httpVersion"].Value;
+            this.Protocol = match.Groups["protocol"].Value;
+            this.Version = match.Groups["version"].Value;
+            this.StatusCode = int.Parse(match.Groups["statusCode"].Value);
+            this.ReasonPhrase = match.Groups["reasonPhrase"].Value;
 
             length = match.Length;
         }

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public bool IsInvalid { get; private set; }
 
         [JsonIgnore]
-        public string ProtocolVersion => (Protocol ?? string.Empty) + "/" + (Version ?? string.Empty);
+        public string ProtocolVersion => WebMessageUtilities.MakeProtocolVersion(Protocol, Version);
 
         public static WebResponse Parse(string responseString)
         {

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
@@ -21,6 +22,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                 if (fields.Length > 0)
                 {
                     webResponse.Protocol = fields[0];
+                }
+
+                if (fields.Length > 1 && int.TryParse(fields[1], NumberStyles.None, CultureInfo.InvariantCulture, out int statusCode))
+                {
+                    webResponse.StatusCode = statusCode;
                 }
 
                 ++lineIndex;

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -1,13 +1,32 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public partial class WebResponse
     {
         public static WebResponse Parse(string responseString)
         {
-            return new WebResponse();
+            var webResponse = new WebResponse();
+
+            string[] lines = responseString.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            int lineIndex = 0;
+            if (lines.Length > 0)
+            {
+                string requestLine = lines[0];
+                string[] fields = requestLine.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                if (fields.Length > 0)
+                {
+                    webResponse.Protocol = fields[0];
+                }
+
+                ++lineIndex;
+            }
+
+            return webResponse;
         }
     }
 }

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public partial class WebResponse
+    {
+        public static WebResponse Parse(string responseString)
+        {
+            return new WebResponse();
+        }
+    }
+}

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
     public partial class WebResponse
     {
+        [JsonIgnore]
         public bool IsInvalid { get; private set; }
 
         public static WebResponse Parse(string responseString)
@@ -37,7 +39,16 @@ namespace Microsoft.CodeAnalysis.Sarif
                     webResponse.ReasonPhrase = fields[2];
                 }
 
+                if (fields.Length < 3)
+                {
+                    webResponse.IsInvalid = true;
+                }
+
                 ++lineIndex;
+            }
+            else
+            {
+                webResponse.IsInvalid = true;
             }
 
             return webResponse;

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                     webResponse.StatusCode = statusCode;
                 }
 
+                if (fields.Length > 2)
+                {
+                    webResponse.ReasonPhrase = fields[2];
+                }
+
                 ++lineIndex;
             }
 

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -17,7 +17,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             var webResponse = new WebResponse();
 
-            if (WebMessageUtilities.ParseStatusLine(responseString, out string httpVersion, out string protocol, out string version, out int statusCode, out string reasonPhrase, out int length))
+            if (WebMessageUtilities.ParseStatusLine(
+                responseString,
+                out string httpVersion,
+                out string protocol,
+                out string version,
+                out int statusCode,
+                out string reasonPhrase,
+                out int statusLineLength))
             {
                 webResponse.HttpVersion = httpVersion;
                 webResponse.Protocol = protocol;

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -13,53 +11,24 @@ namespace Microsoft.CodeAnalysis.Sarif
         public bool IsInvalid { get; private set; }
 
         [JsonIgnore]
-        public string HttpVersion => WebMessageUtilities.MakeProtocolVersion(Protocol, Version);
+        public string HttpVersion { get; private set; }
 
         public static WebResponse Parse(string responseString)
         {
             var webResponse = new WebResponse();
 
-            string[] lines = responseString.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
-
-            int lineIndex = 0;
-            if (lines.Length > 0)
+            if (WebMessageUtilities.ParseStatusLine(responseString, out string httpVersion, out string protocol, out string version, out int statusCode, out string reasonPhrase, out int length))
             {
-                string requestLine = lines[0];
-                string[] fields = requestLine.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
-                if (fields.Length > 0)
-                {
-                    bool success = WebMessageUtilities.ParseProtocolAndVersion(fields[0], out string protocol, out string version);
-                    if (success)
-                    {
-                        webResponse.Protocol = protocol;
-                        webResponse.Version = version;
-                    }
-                    else
-                    {
-                        webResponse.IsInvalid = true;
-                    }
-                }
-
-                if (fields.Length > 1 && int.TryParse(fields[1], NumberStyles.None, CultureInfo.InvariantCulture, out int statusCode))
-                {
-                    webResponse.StatusCode = statusCode;
-                }
-
-                if (fields.Length > 2)
-                {
-                    webResponse.ReasonPhrase = fields[2];
-                }
-
-                if (fields.Length < 3)
-                {
-                    webResponse.IsInvalid = true;
-                }
-
-                ++lineIndex;
+                webResponse.HttpVersion = httpVersion;
+                webResponse.Protocol = protocol;
+                webResponse.Version = version;
+                webResponse.StatusCode = statusCode;
+                webResponse.ReasonPhrase = reasonPhrase;
             }
             else
             {
                 webResponse.IsInvalid = true;
+                return webResponse;
             }
 
             return webResponse;

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -34,7 +34,13 @@ namespace Microsoft.CodeAnalysis.Sarif
             WebMessageUtilities.ParseHeaderLines(responseString, out Dictionary<string, string> headers, out int totalHeadersLength);
             webResponse.Headers = headers;
 
-            responseString = responseString.Substring(totalHeadersLength);
+            if (responseString.Length > totalHeadersLength)
+            {
+                webResponse.Body = new ArtifactContent
+                {
+                    Text = responseString.Substring(totalHeadersLength)
+                };
+            }
 
             return webResponse;
         }

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         [JsonIgnore]
         public bool IsInvalid { get; private set; }
 
+        [JsonIgnore]
+        public string ProtocolVersion => (Protocol ?? string.Empty) + "/" + (Version ?? string.Empty);
+
         public static WebResponse Parse(string responseString)
         {
             var webResponse = new WebResponse();

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -9,48 +9,32 @@ namespace Microsoft.CodeAnalysis.Sarif
     public partial class WebResponse
     {
         [JsonIgnore]
-        public bool IsInvalid { get; private set; }
-
-        [JsonIgnore]
         public string HttpVersion { get; private set; }
 
         public static WebResponse Parse(string responseString)
         {
             var webResponse = new WebResponse();
 
-            if (WebMessageUtilities.ParseStatusLine(
+            WebMessageUtilities.ParseStatusLine(
                 responseString,
                 out string httpVersion,
                 out string protocol,
                 out string version,
                 out int statusCode,
                 out string reasonPhrase,
-                out int statusLineLength))
-            {
-                webResponse.HttpVersion = httpVersion;
-                webResponse.Protocol = protocol;
-                webResponse.Version = version;
-                webResponse.StatusCode = statusCode;
-                webResponse.ReasonPhrase = reasonPhrase;
+                out int statusLineLength);
 
-                responseString = responseString.Substring(statusLineLength);
-                if (WebMessageUtilities.ParseHeaderLines(responseString, out Dictionary<string, string> headers, out int totalHeadersLength))
-                {
-                    webResponse.Headers = headers;
-                }
-                else
-                {
-                    webResponse.IsInvalid = true;
-                    return webResponse;
-                }
+            webResponse.HttpVersion = httpVersion;
+            webResponse.Protocol = protocol;
+            webResponse.Version = version;
+            webResponse.StatusCode = statusCode;
+            webResponse.ReasonPhrase = reasonPhrase;
 
-                responseString = responseString.Substring(totalHeadersLength);
-            }
-            else
-            {
-                webResponse.IsInvalid = true;
-                return webResponse;
-            }
+            responseString = responseString.Substring(statusLineLength);
+            WebMessageUtilities.ParseHeaderLines(responseString, out Dictionary<string, string> headers, out int totalHeadersLength);
+            webResponse.Headers = headers;
+
+            responseString = responseString.Substring(totalHeadersLength);
 
             return webResponse;
         }

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif
@@ -31,6 +32,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                 webResponse.Version = version;
                 webResponse.StatusCode = statusCode;
                 webResponse.ReasonPhrase = reasonPhrase;
+
+                responseString = responseString.Substring(statusLineLength);
+                if (WebMessageUtilities.ParseHeaderLines(responseString, out Dictionary<string, string> headers, out int totalHeadersLength))
+                {
+                    webResponse.Headers = headers;
+                }
+                else
+                {
+                    webResponse.IsInvalid = true;
+                    return webResponse;
+                }
+
+                responseString = responseString.Substring(totalHeadersLength);
             }
             else
             {

--- a/src/Sarif/Core/WebResponse.cs
+++ b/src/Sarif/Core/WebResponse.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         public bool IsInvalid { get; private set; }
 
         [JsonIgnore]
-        public string ProtocolVersion => WebMessageUtilities.MakeProtocolVersion(Protocol, Version);
+        public string HttpVersion => WebMessageUtilities.MakeProtocolVersion(Protocol, Version);
 
         public static WebResponse Parse(string responseString)
         {

--- a/src/Sarif/SarifUtilities.cs
+++ b/src/Sarif/SarifUtilities.cs
@@ -181,6 +181,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return bytes.Length;
         }
 
+        public static Regex RegexFromPattern(string pattern) =>
+            new Regex(
+                pattern,
+                RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
+
         internal static bool UnitTesting = false;
 
         internal static void DebugAssert(bool conditional)

--- a/src/Test.UnitTests.Sarif/Core/ArtifactTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ArtifactTests.cs
@@ -5,12 +5,13 @@ using System;
 using System.IO;
 using System.Text;
 using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Sarif
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class ArtifactTests
     {

--- a/src/Test.UnitTests.Sarif/Core/ResultTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/ResultTests.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Xunit;
-using Newtonsoft.Json;
 using FluentAssertions;
-using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Sarif;
 
-namespace Microsoft.CodeAnalysis.Sarif
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class ResultTests
     {

--- a/src/Test.UnitTests.Sarif/Core/RunTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/RunTests.cs
@@ -6,8 +6,9 @@ using Xunit;
 using Newtonsoft.Json;
 using FluentAssertions;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Sarif;
 
-namespace Microsoft.CodeAnalysis.Sarif
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class RunTests
     {

--- a/src/Test.UnitTests.Sarif/Core/RunTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/RunTests.cs
@@ -75,8 +75,10 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             // Now use a file location that has no url and therefore relies strictly on
             // the index in run.artifacts (i.e., _fileToIndexMap will not be used).
-            fileLocation = new ArtifactLocation();
-            fileLocation.Index = 0;
+            fileLocation = new ArtifactLocation
+            {
+                Index = 0
+            };
             RetrieveFileIndexAndValidate(run, fileLocation, expectedFileIndex: 0);
         }
 

--- a/src/Test.UnitTests.Sarif/Core/StackTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/StackTests.cs
@@ -10,7 +10,7 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Sarif
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class StackTests
     {

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
+{
+    public class WebMessageUtilitiesTests
+    {
+        [Theory]
+        [InlineData(null, null, "/")]
+        [InlineData("HTTP", "", "HTTP/")]
+        [InlineData("", "1.1", "/1.1")]
+        [InlineData("HTTP", "1.1", "HTTP/1.1")]
+        public void WebResponse_SynthesizesProtocolVersionFromProtocolAndVersion(string protocol, string version, string expectedProtocolVersion)
+        {
+            WebMessageUtilities.MakeProtocolVersion(protocol, version).Should().Be(expectedProtocolVersion);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [InlineData("GET /hello.txt HTTP/1.1\r\n", true, "GET", "/hello.txt", "HTTP/1.1", "HTTP", "1.1", 25, "request line is valid")]
         public void WebMessageUtilities_ParseRequestLine(
             string requestLine,
-            bool expectedResult,
+            bool shouldSucceed,
             string expectedMethod,
             string expectedTarget,
             string expectedHttpVersion,
@@ -28,7 +29,9 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             int expectedLength,
             string because)
         {
-            bool result = WebMessageUtilities.ParseRequestLine(
+            Action action = () =>
+            {
+                WebMessageUtilities.ParseRequestLine(
                 requestLine,
                 out string method,
                 out string target,
@@ -37,13 +40,16 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 out string version,
                 out int length);
 
-            result.Should().Be(expectedResult, because);
-            method.Should().Be(expectedMethod, because);
-            target.Should().Be(expectedTarget, because);
-            httpVersion.Should().Be(expectedHttpVersion, because);
-            protocol.Should().Be(expectedProtocol, because);
-            version.Should().Be(expectedVersion, because);
-            length.Should().Be(expectedLength, because);
+                method.Should().Be(expectedMethod, because);
+                target.Should().Be(expectedTarget, because);
+                httpVersion.Should().Be(expectedHttpVersion, because);
+                protocol.Should().Be(expectedProtocol, because);
+                version.Should().Be(expectedVersion, because);
+                length.Should().Be(expectedLength, because);
+            };
+
+            if (shouldSucceed) { action.Should().NotThrow(); }
+            else { action.Should().Throw<Exception>(); }
         }
 
         [Theory]
@@ -59,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [InlineData("HTTP/1.1 200 OK\r\n", true, "HTTP/1.1", "HTTP", "1.1", 200, "OK", 17, "status line is valid")]
         public void WebMessageUtilities_ParseStatusLine(
             string statusLine,
-            bool expectedResult,
+            bool shouldSucceed,
             string expectedHttpVersion,
             string expectedProtocol,
             string expectedVersion,
@@ -68,22 +74,27 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             int expectedLength,
             string because)
         {
-            bool result = WebMessageUtilities.ParseStatusLine(
-                statusLine,
-                out string httpVersion,
-                out string protocol,
-                out string version,
-                out int statusCode,
-                out string reasonPhrase,
-                out int length);
+            Action action = () =>
+            {
+                WebMessageUtilities.ParseStatusLine(
+                    statusLine,
+                    out string httpVersion,
+                    out string protocol,
+                    out string version,
+                    out int statusCode,
+                    out string reasonPhrase,
+                    out int length);
 
-            result.Should().Be(expectedResult, because);
-            httpVersion.Should().Be(expectedHttpVersion, because);
-            protocol.Should().Be(expectedProtocol, because);
-            version.Should().Be(expectedVersion, because);
-            statusCode.Should().Be(expectedStatusCode, because);
-            reasonPhrase.Should().Be(expectedReasonPhrase, because);
-            length.Should().Be(expectedLength, because);
+                httpVersion.Should().Be(expectedHttpVersion, because);
+                protocol.Should().Be(expectedProtocol, because);
+                version.Should().Be(expectedVersion, because);
+                statusCode.Should().Be(expectedStatusCode, because);
+                reasonPhrase.Should().Be(expectedReasonPhrase, because);
+                length.Should().Be(expectedLength, because);
+            };
+
+            if (shouldSucceed) { action.Should().NotThrow(); }
+            else { action.Should().Throw<Exception>(); }
         }
 
         [Theory]
@@ -92,11 +103,26 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [InlineData("Host:www.example.com\r\n", true, "Host", "www.example.com")]          // No leading whitespace before field value.
         [InlineData("Host: www.example.com  \t  \r\n", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
         [InlineData("H@st: www.example.com\r\n", false, null, null)]                       // Invalid field name token.
-        public void WebMessageUtilities_ParseHeader(string header, bool expectedResult, string expectedName, string expectedValue)
+        public void WebMessageUtilities_ParseHeader(
+            string header,
+            bool shouldSucceed,
+            string expectedName,
+            string expectedValue)
         {
-            WebMessageUtilities.ParseHeaderLine(header, out string name, out string value, out int totalHeaderLinesLength).Should().Be(expectedResult);
-            name.Should().Be(expectedName);
-            value.Should().Be(expectedValue);
+            Action action = () =>
+            {
+                WebMessageUtilities.ParseHeaderLine(
+                    header,
+                    out string name,
+                    out string value,
+                    out int totalHeaderLinesLength);
+
+                name.Should().Be(expectedName);
+                value.Should().Be(expectedValue);
+            };
+
+            if (shouldSucceed) { action.Should().NotThrow(); }
+            else { action.Should().Throw<Exception>(); }
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -14,9 +14,21 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [InlineData("HTTP", "", "HTTP/")]
         [InlineData("", "1.1", "/1.1")]
         [InlineData("HTTP", "1.1", "HTTP/1.1")]
-        public void WebResponse_SynthesizesProtocolVersionFromProtocolAndVersion(string protocol, string version, string expectedProtocolVersion)
+        public void WebMessageUtilties_MakeProtocolVersion_SynthesizesProtocolVersionFromProtocolAndVersion(string protocol, string version, string expectedProtocolVersion)
         {
             WebMessageUtilities.MakeProtocolVersion(protocol, version).Should().Be(expectedProtocolVersion);
+        }
+
+        [Theory]
+        [InlineData("", null, null)]
+        [InlineData("1.1", null, null)]
+        [InlineData("HTTP/1.1", "HTTP", "1.1")]
+        public void WebMessageUtilities_ParseProtocolAndVersion_ParsesProtocolAndVersionFromProtocolVersion(string protocolVersion, string expectedProtocol, string expectedVersion)
+        {
+            WebMessageUtilities.ParseProtocolAndVersion(protocolVersion, out string protocol, out string version);
+
+            protocol.Should().Be(expectedProtocol);
+            version.Should().Be(expectedVersion);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -10,39 +10,6 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
     public class WebMessageUtilitiesTests
     {
         [Theory]
-        [InlineData(null, null, "/")]
-        [InlineData("HTTP", "", "HTTP/")]
-        [InlineData("", "1.1", "/1.1")]
-        [InlineData("HTTP", "1.1", "HTTP/1.1")]
-        public void WebMessageUtilties_MakeProtocolVersion_SynthesizesProtocolVersionFromProtocolAndVersion(string protocol, string version, string expectedProtocolVersion)
-        {
-            WebMessageUtilities.MakeProtocolVersion(protocol, version).Should().Be(expectedProtocolVersion);
-        }
-
-        [Theory]
-        [InlineData("", null, null)]
-        [InlineData("1.1", null, null)]
-        [InlineData("HTTP/1.1", "HTTP", "1.1")]
-        public void WebMessageUtilities_ParseProtocolAndVersion_ParsesProtocolAndVersionFromProtocolVersion(string protocolVersion, string expectedProtocol, string expectedVersion)
-        {
-            WebMessageUtilities.ParseProtocolAndVersion(protocolVersion, out string protocol, out string version);
-
-            protocol.Should().Be(expectedProtocol);
-            version.Should().Be(expectedVersion);
-        }
-
-        [Theory]
-        [InlineData("GET", true)]
-        [InlineData("!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true)]
-        [InlineData("GET!", true)]
-        [InlineData("GET/", false)]
-        [InlineData("@GET", false)]
-        public void WebMessageUtilties_ValidateMethod_SucceedsAndFailsAsExpected(string method, bool expectedResult)
-        {
-            WebMessageUtilities.ValidateMethod(method).Should().Be(expectedResult);
-        }
-
-        [Theory]
         [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
         [InlineData("Host: www.example.com", true, "Host", "www.example.com")]
         [InlineData("Host:www.example.com", true, "Host", "www.example.com")]          // No leading whitespace before field value.

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -9,9 +9,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class WebMessageUtilitiesTests
     {
-
         [Theory]
-        [InlineData("", false, null, null, null, null, null, -1, "request is empty")]
+        [InlineData("", false, null, null, null, null, null, -1, "request line is empty")]
         [InlineData("GET", false, null, null, null, null, null, -1, "target is absent")]
         [InlineData("GET /hello.txt", false, null, null, null, null, null, -1, "HTTP version is absent")]
         [InlineData("GET /hello.txt HTTP/1.1", false, null, null, null, null, null, -1, "request line does not end in CRLF")]
@@ -27,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             string expectedProtocol,
             string expectedVersion,
             int expectedLength,
-            string reason)
+            string because)
         {
             bool result = WebMessageUtilities.ParseRequestLine(
                 requestLine,
@@ -38,13 +37,53 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
                 out string version,
                 out int length);
 
-            result.Should().Be(expectedResult, reason);
-            method.Should().Be(expectedMethod, reason);
-            target.Should().Be(expectedTarget, reason);
-            httpVersion.Should().Be(expectedHttpVersion, reason);
-            protocol.Should().Be(expectedProtocol, reason);
-            version.Should().Be(expectedVersion, reason);
-            length.Should().Be(expectedLength, reason);
+            result.Should().Be(expectedResult, because);
+            method.Should().Be(expectedMethod, because);
+            target.Should().Be(expectedTarget, because);
+            httpVersion.Should().Be(expectedHttpVersion, because);
+            protocol.Should().Be(expectedProtocol, because);
+            version.Should().Be(expectedVersion, because);
+            length.Should().Be(expectedLength, because);
+        }
+
+        [Theory]
+        [InlineData("", false, null, null, null, -1, null, -1, "status line is empty")]
+        [InlineData("HTTP/1.1", false, null, null, null, -1, null, -1, "status code is absent")]
+        [InlineData("HTTP/1.1 200", false, null, null, null, -1, null, -1, "reason phrase is absent")]
+        [InlineData("HTTP/1.1 200 OK", false, null, null, null, -1, null, -1, "status line does not end in CRLF")]
+        [InlineData("HTTP2/1.1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid name")]
+        [InlineData("HTTP/1..1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid version number")]
+        [InlineData("HTTP/1.1 200a OK\r\n", false, null, null, null, -1, null, -1, "status code is not an integer")]
+        [InlineData("HTTP/1.1 20 OK\r\n", false, null, null, null, -1, null, -1, "status code has fewer than three digits")]
+        [InlineData("HTTP/1.1 2000 OK\r\n", false, null, null, null, -1, null, -1, "status code has more than three digits")]
+        [InlineData("HTTP/1.1 200 OK\r\n", true, "HTTP/1.1", "HTTP", "1.1", 200, "OK", 17, "status line is valid")]
+        public void WebMessageUtilities_ParseStatusLine(
+            string statusLine,
+            bool expectedResult,
+            string expectedHttpVersion,
+            string expectedProtocol,
+            string expectedVersion,
+            int expectedStatusCode,
+            string expectedReasonPhrase,
+            int expectedLength,
+            string because)
+        {
+            bool result = WebMessageUtilities.ParseStatusLine(
+                statusLine,
+                out string httpVersion,
+                out string protocol,
+                out string version,
+                out int statusCode,
+                out string reasonPhrase,
+                out int length);
+
+            result.Should().Be(expectedResult, because);
+            httpVersion.Should().Be(expectedHttpVersion, because);
+            protocol.Should().Be(expectedProtocol, because);
+            version.Should().Be(expectedVersion, because);
+            statusCode.Should().Be(expectedStatusCode, because);
+            reasonPhrase.Should().Be(expectedReasonPhrase, because);
+            length.Should().Be(expectedLength, because);
         }
 
         [Theory]

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -87,14 +87,14 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         }
 
         [Theory]
-        [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
-        [InlineData("Host: www.example.com", true, "Host", "www.example.com")]
-        [InlineData("Host:www.example.com", true, "Host", "www.example.com")]          // No leading whitespace before field value.
-        [InlineData("Host: www.example.com  \t  ", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
-        [InlineData("H@st: www.example.com", false, null, null)]                       // Invalid field name token.
+        [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3\r\n", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
+        [InlineData("Host: www.example.com\r\n", true, "Host", "www.example.com")]
+        [InlineData("Host:www.example.com\r\n", true, "Host", "www.example.com")]          // No leading whitespace before field value.
+        [InlineData("Host: www.example.com  \t  \r\n", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
+        [InlineData("H@st: www.example.com\r\n", false, null, null)]                       // Invalid field name token.
         public void WebMessageUtilities_ParseHeader(string header, bool expectedResult, string expectedName, string expectedValue)
         {
-            WebMessageUtilities.ParseHeaderLine(header, out string name, out string value).Should().Be(expectedResult);
+            WebMessageUtilities.ParseHeaderLine(header, out string name, out string value, out int totalHeaderLinesLength).Should().Be(expectedResult);
             name.Should().Be(expectedName);
             value.Should().Be(expectedValue);
         }

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -41,5 +41,18 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         {
             WebMessageUtilities.ValidateMethod(method).Should().Be(expectedResult);
         }
+
+        [Theory]
+        [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
+        [InlineData("Host: www.example.com", true, "Host", "www.example.com")]
+        [InlineData("Host:www.example.com", true, "Host", "www.example.com")]          // No leading whitespace before field value.
+        [InlineData("Host: www.example.com  \t  ", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
+        [InlineData("H@st: www.example.com", false, null, null)]                       // Invalid field name token.
+        public void WebMessageUtilities_ParseHeader_SucceedsAndFailsAsExpected(string header, bool expectedResult, string expectedName, string expectedValue)
+        {
+            WebMessageUtilities.ParseHeaderLine(header, out string name, out string value).Should().Be(expectedResult);
+            name.Should().Be(expectedName);
+            value.Should().Be(expectedValue);
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -11,99 +11,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
     public class WebMessageUtilitiesTests
     {
         [Theory]
-        [InlineData("", false, null, null, null, null, null, -1, "request line is empty")]
-        [InlineData("GET", false, null, null, null, null, null, -1, "target is absent")]
-        [InlineData("GET /hello.txt", false, null, null, null, null, null, -1, "HTTP version is absent")]
-        [InlineData("GET /hello.txt HTTP/1.1", false, null, null, null, null, null, -1, "request line does not end in CRLF")]
-        [InlineData("GET /hello.txt HTTP2/1.1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid name")]
-        [InlineData("GET /hello.txt HTTP/1..1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid version number")]
-        [InlineData("GET /hello.txt HTTP/1.1\r\n", true, "GET", "/hello.txt", "HTTP/1.1", "HTTP", "1.1", 25, "request line is valid")]
-        public void WebMessageUtilities_ParseRequestLine(
-            string requestLine,
-            bool shouldSucceed,
-            string expectedMethod,
-            string expectedTarget,
-            string expectedHttpVersion,
-            string expectedProtocol,
-            string expectedVersion,
-            int expectedLength,
-            string because)
-        {
-            Action action = () =>
-            {
-                WebMessageUtilities.ParseRequestLine(
-                requestLine,
-                out string method,
-                out string target,
-                out string httpVersion,
-                out string protocol,
-                out string version,
-                out int length);
-
-                method.Should().Be(expectedMethod, because);
-                target.Should().Be(expectedTarget, because);
-                httpVersion.Should().Be(expectedHttpVersion, because);
-                protocol.Should().Be(expectedProtocol, because);
-                version.Should().Be(expectedVersion, because);
-                length.Should().Be(expectedLength, because);
-            };
-
-            if (shouldSucceed) { action.Should().NotThrow(); }
-            else { action.Should().Throw<Exception>(); }
-        }
-
-        [Theory]
-        [InlineData("", false, null, null, null, -1, null, -1, "status line is empty")]
-        [InlineData("HTTP/1.1", false, null, null, null, -1, null, -1, "status code is absent")]
-        [InlineData("HTTP/1.1 200", false, null, null, null, -1, null, -1, "reason phrase is absent")]
-        [InlineData("HTTP/1.1 200 OK", false, null, null, null, -1, null, -1, "status line does not end in CRLF")]
-        [InlineData("HTTP2/1.1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid name")]
-        [InlineData("HTTP/1..1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid version number")]
-        [InlineData("HTTP/1.1 200a OK\r\n", false, null, null, null, -1, null, -1, "status code is not an integer")]
-        [InlineData("HTTP/1.1 20 OK\r\n", false, null, null, null, -1, null, -1, "status code has fewer than three digits")]
-        [InlineData("HTTP/1.1 2000 OK\r\n", false, null, null, null, -1, null, -1, "status code has more than three digits")]
-        [InlineData("HTTP/1.1 200 OK\r\n", true, "HTTP/1.1", "HTTP", "1.1", 200, "OK", 17, "status line is valid")]
-        public void WebMessageUtilities_ParseStatusLine(
-            string statusLine,
-            bool shouldSucceed,
-            string expectedHttpVersion,
-            string expectedProtocol,
-            string expectedVersion,
-            int expectedStatusCode,
-            string expectedReasonPhrase,
-            int expectedLength,
-            string because)
-        {
-            Action action = () =>
-            {
-                WebMessageUtilities.ParseStatusLine(
-                    statusLine,
-                    out string httpVersion,
-                    out string protocol,
-                    out string version,
-                    out int statusCode,
-                    out string reasonPhrase,
-                    out int length);
-
-                httpVersion.Should().Be(expectedHttpVersion, because);
-                protocol.Should().Be(expectedProtocol, because);
-                version.Should().Be(expectedVersion, because);
-                statusCode.Should().Be(expectedStatusCode, because);
-                reasonPhrase.Should().Be(expectedReasonPhrase, because);
-                length.Should().Be(expectedLength, because);
-            };
-
-            if (shouldSucceed) { action.Should().NotThrow(); }
-            else { action.Should().Throw<Exception>(); }
-        }
-
-        [Theory]
         [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3\r\n", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
         [InlineData("Host: www.example.com\r\n", true, "Host", "www.example.com")]
         [InlineData("Host:www.example.com\r\n", true, "Host", "www.example.com")]          // No leading whitespace before field value.
         [InlineData("Host: www.example.com  \t  \r\n", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
         [InlineData("H@st: www.example.com\r\n", false, null, null)]                       // Invalid field name token.
-        public void WebMessageUtilities_ParseHeader(
+        public void WebMessageUtilities_ParseHeaderLine_HandlesErrorConditions(
             string header,
             bool shouldSucceed,
             string expectedName,

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -9,13 +9,51 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class WebMessageUtilitiesTests
     {
+
+        [Theory]
+        [InlineData("", false, null, null, null, null, null, -1, "request is empty")]
+        [InlineData("GET", false, null, null, null, null, null, -1, "target is absent")]
+        [InlineData("GET /hello.txt", false, null, null, null, null, null, -1, "HTTP version is absent")]
+        [InlineData("GET /hello.txt HTTP/1.1", false, null, null, null, null, null, -1, "request line does not end in CRLF")]
+        [InlineData("GET /hello.txt HTTP2/1.1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid name")]
+        [InlineData("GET /hello.txt HTTP/1..1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid version number")]
+        [InlineData("GET /hello.txt HTTP/1.1\r\n", true, "GET", "/hello.txt", "HTTP/1.1", "HTTP", "1.1", 25, "request line is valid")]
+        public void WebMessageUtilities_ParseRequestLine(
+            string requestLine,
+            bool expectedResult,
+            string expectedMethod,
+            string expectedTarget,
+            string expectedHttpVersion,
+            string expectedProtocol,
+            string expectedVersion,
+            int expectedLength,
+            string reason)
+        {
+            bool result = WebMessageUtilities.ParseRequestLine(
+                requestLine,
+                out string method,
+                out string target,
+                out string httpVersion,
+                out string protocol,
+                out string version,
+                out int length);
+
+            result.Should().Be(expectedResult, reason);
+            method.Should().Be(expectedMethod, reason);
+            target.Should().Be(expectedTarget, reason);
+            httpVersion.Should().Be(expectedHttpVersion, reason);
+            protocol.Should().Be(expectedProtocol, reason);
+            version.Should().Be(expectedVersion, reason);
+            length.Should().Be(expectedLength, reason);
+        }
+
         [Theory]
         [InlineData("User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3", true, "User-Agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3")]
         [InlineData("Host: www.example.com", true, "Host", "www.example.com")]
         [InlineData("Host:www.example.com", true, "Host", "www.example.com")]          // No leading whitespace before field value.
         [InlineData("Host: www.example.com  \t  ", true, "Host", "www.example.com")]   // Trailing whitespace after field value.
         [InlineData("H@st: www.example.com", false, null, null)]                       // Invalid field name token.
-        public void WebMessageUtilities_ParseHeader_SucceedsAndFailsAsExpected(string header, bool expectedResult, string expectedName, string expectedValue)
+        public void WebMessageUtilities_ParseHeader(string header, bool expectedResult, string expectedName, string expectedValue)
         {
             WebMessageUtilities.ParseHeaderLine(header, out string name, out string value).Should().Be(expectedResult);
             name.Should().Be(expectedName);

--- a/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebMessageUtilitiesTests.cs
@@ -30,5 +30,16 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
             protocol.Should().Be(expectedProtocol);
             version.Should().Be(expectedVersion);
         }
+
+        [Theory]
+        [InlineData("GET", true)]
+        [InlineData("!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true)]
+        [InlineData("GET!", true)]
+        [InlineData("GET/", false)]
+        [InlineData("@GET", false)]
+        public void WebMessageUtilties_ValidateMethod_SucceedsAndFailsAsExpected(string method, bool expectedResult)
+        {
+            WebMessageUtilities.ValidateMethod(method).Should().Be(expectedResult);
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -28,18 +28,5 @@ Accept-Language: en, mi";
             webRequest.HttpVersion.Should().Be("HTTP/1.1");
             webRequest.IsInvalid.Should().BeFalse();
         }
-
-        [Theory]
-        [InlineData("", "request is empty")]
-        [InlineData("GET", "request target absent")]
-        [InlineData("GET /hello.txt", "protocol version is absent")]
-        [InlineData("GET /hello.txt HTTP", "protocol version is invalid")]
-        [InlineData("G@T /hello.txt HTTP/1.1", "method token is invalid")]
-        public void WebRequest_Parse_DetectsInvalidRequestStrings(string requestString, string reason)
-        {
-            WebRequest webRequest = WebRequest.Parse(requestString);
-
-            webRequest.IsInvalid.Should().BeTrue(because: reason);
-        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
@@ -88,6 +89,48 @@ User-Agent: my-agent
             webRequest.Headers.Count.Should().Be(1);
             webRequest.Headers["User-Agent"].Should().Be("my-agent");
             webRequest.Body.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("", false, null, null, null, null, null, -1, "request line is empty")]
+        [InlineData("GET", false, null, null, null, null, null, -1, "target is absent")]
+        [InlineData("GET /hello.txt", false, null, null, null, null, null, -1, "HTTP version is absent")]
+        [InlineData("GET /hello.txt HTTP/1.1", false, null, null, null, null, null, -1, "request line does not end in CRLF")]
+        [InlineData("GET /hello.txt HTTP2/1.1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid name")]
+        [InlineData("GET /hello.txt HTTP/1..1\r\n", false, null, null, null, null, null, -1, "HTTP version has invalid version number")]
+        [InlineData("GET /hello.txt HTTP/1.1\r\n", true, "GET", "/hello.txt", "HTTP/1.1", "HTTP", "1.1", 25, "request line is valid")]
+        public void WebRequest_ParseRequestLine_HandlesErrorConditions(
+            string requestLine,
+            bool shouldSucceed,
+            string expectedMethod,
+            string expectedTarget,
+            string expectedHttpVersion,
+            string expectedProtocol,
+            string expectedVersion,
+            int expectedLength,
+            string because)
+        {
+            Action action = () =>
+            {
+                WebRequest.ParseRequestLine(
+                    requestLine,
+                    out string method,
+                    out string target,
+                    out string httpVersion,
+                    out string protocol,
+                    out string version,
+                    out int length);
+
+                method.Should().Be(expectedMethod, because);
+                target.Should().Be(expectedTarget, because);
+                httpVersion.Should().Be(expectedHttpVersion, because);
+                protocol.Should().Be(expectedProtocol, because);
+                version.Should().Be(expectedVersion, because);
+                length.Should().Be(expectedLength, because);
+            };
+
+            if (shouldSucceed) { action.Should().NotThrow(); }
+            else { action.Should().Throw<Exception>(); }
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -17,16 +17,21 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 @"GET /hello.txt HTTP/1.1
 User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
 Host: www.example.com
-Accept-Language: en, mi";
+Accept-Language: en, mi
+";
 
             WebRequest webRequest = WebRequest.Parse(RequestString);
 
+            webRequest.IsInvalid.Should().BeFalse();
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
             webRequest.Protocol.Should().Be("HTTP");
             webRequest.Version.Should().Be("1.1");
             webRequest.HttpVersion.Should().Be("HTTP/1.1");
-            webRequest.IsInvalid.Should().BeFalse();
+            webRequest.Headers.Count.Should().Be(3);
+            webRequest.Headers["User-Agent"].Should().Be("curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3");
+            webRequest.Headers["Host"].Should().Be("www.example.com");
+            webRequest.Headers["Accept-Language"].Should().Be("en, mi");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -22,6 +22,11 @@ Accept-Language: en, mi";
             WebRequest webRequest = WebRequest.Parse(RequestString);
 
             webRequest.Method.Should().Be("GET");
+            webRequest.Target.Should().Be("/hello.txt");
+            webRequest.Protocol.Should().Be("HTTP");
+            webRequest.Version.Should().Be("1.1");
+            webRequest.ProtocolVersion.Should().Be("HTTP/1.1");
+            webRequest.IsInvalid.Should().BeFalse();
         }
 
         [Theory]

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -23,5 +23,17 @@ Accept-Language: en, mi";
 
             webRequest.Method.Should().Be("GET");
         }
+
+        [Theory]
+        [InlineData("", "request is empty")]
+        [InlineData("GET", "request target absent")]
+        [InlineData("GET /hello.txt", "protocol version is absent")]
+        [InlineData("GET /hello.txt HTTP", "protocol version is invalid")]
+        public void WebRequest_Parse_DetectsInvalidRequestStrings(string requestString, string reason)
+        {
+            WebRequest webRequest = WebRequest.Parse(requestString);
+
+            webRequest.IsInvalid.Should().BeTrue(because: reason);
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -32,6 +32,7 @@ Accept-Language: en, mi
             webRequest.Headers["User-Agent"].Should().Be("curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3");
             webRequest.Headers["Host"].Should().Be("www.example.com");
             webRequest.Headers["Accept-Language"].Should().Be("en, mi");
+            webRequest.Body.Should().BeNull();
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
 Host: www.example.com
 Accept-Language: en, mi
+
 ";
 
             WebRequest webRequest = WebRequest.Parse(RequestString);

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -2,16 +2,32 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
     public class WebRequestTests
     {
-        [Fact(Skip = "NYI")]
+        [Fact]
         public void WebRequest_Parse_CreatesExpectedWebRequestObject()
         {
-            false.Should().BeTrue();
+            const string RequestString =
+@"GET /app/search/search.html?searchTerm=water HTTP/1.1
+Accept: text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8
+Accept-Charset: *
+Accept-Encoding: gzip, deflate
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)
+Host: webscout-ppe
+Content-Type: application/x-www-form-urlencoded
+Cookie: ai_user=12345|2019-06-13T15:24:19.508Z; ai_session=abcde|12345.67|122233334444.65
+
+Some body text.
+Just for testing.";
+
+            WebRequest webRequest = WebRequest.Parse(RequestString);
+
+            webRequest.Method.Should().Be("GET");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -12,18 +12,12 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void WebRequest_Parse_CreatesExpectedWebRequestObject()
         {
+            // Example from RFC 7230.
             const string RequestString =
-@"GET /app/search/search.html?searchTerm=water HTTP/1.1
-Accept: text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8
-Accept-Charset: *
-Accept-Encoding: gzip, deflate
-User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)
-Host: webscout-ppe
-Content-Type: application/x-www-form-urlencoded
-Cookie: ai_user=12345|2019-06-13T15:24:19.508Z; ai_session=abcde|12345.67|122233334444.65
-
-Some body text.
-Just for testing.";
+@"GET /hello.txt HTTP/1.1
+User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
+Host: www.example.com
+Accept-Language: en, mi";
 
             WebRequest webRequest = WebRequest.Parse(RequestString);
 

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -112,20 +112,16 @@ User-Agent: my-agent
         {
             Action action = () =>
             {
-                WebRequest.ParseRequestLine(
-                    requestLine,
-                    out string method,
-                    out string target,
-                    out string httpVersion,
-                    out string protocol,
-                    out string version,
-                    out int length);
+                var webRequest = new WebRequest();
 
-                method.Should().Be(expectedMethod, because);
-                target.Should().Be(expectedTarget, because);
-                httpVersion.Should().Be(expectedHttpVersion, because);
-                protocol.Should().Be(expectedProtocol, because);
-                version.Should().Be(expectedVersion, because);
+                webRequest.ParseRequestLine(requestLine, out int length);
+
+                webRequest.Method.Should().Be(expectedMethod, because);
+                webRequest.Target.Should().Be(expectedTarget, because);
+                webRequest.HttpVersion.Should().Be(expectedHttpVersion, because);
+                webRequest.Protocol.Should().Be(expectedProtocol, because);
+                webRequest.Version.Should().Be(expectedVersion, because);
+
                 length.Should().Be(expectedLength, because);
             };
 

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -25,7 +25,7 @@ Accept-Language: en, mi";
             webRequest.Target.Should().Be("/hello.txt");
             webRequest.Protocol.Should().Be("HTTP");
             webRequest.Version.Should().Be("1.1");
-            webRequest.ProtocolVersion.Should().Be("HTTP/1.1");
+            webRequest.HttpVersion.Should().Be("HTTP/1.1");
             webRequest.IsInvalid.Should().BeFalse();
         }
 

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
+{
+    public class WebRequestTests
+    {
+        [Fact(Skip = "NYI")]
+        public void WebRequest_Parse_CreatesExpectedWebRequestObject()
+        {
+            false.Should().BeTrue();
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -23,7 +23,6 @@ Accept-Language: en, mi
 
             WebRequest webRequest = WebRequest.Parse(RequestString);
 
-            webRequest.IsInvalid.Should().BeFalse();
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
             webRequest.Protocol.Should().Be("HTTP");

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -34,5 +34,33 @@ Accept-Language: en, mi
             webRequest.Headers["Accept-Language"].Should().Be("en, mi");
             webRequest.Body.Should().BeNull();
         }
+
+        [Fact]
+        public void WebRequest_Parse_CreatesExpectedWebRequestObjectWithBody()
+        {
+            // Example from RFC 7230.
+            const string RequestString =
+@"GET /hello.txt HTTP/1.1
+User-Agent: curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3
+Host: www.example.com
+Accept-Language: en, mi
+
+This is the body.
+Line 2.
+";
+
+            WebRequest webRequest = WebRequest.Parse(RequestString);
+
+            webRequest.Method.Should().Be("GET");
+            webRequest.Target.Should().Be("/hello.txt");
+            webRequest.Protocol.Should().Be("HTTP");
+            webRequest.Version.Should().Be("1.1");
+            webRequest.HttpVersion.Should().Be("HTTP/1.1");
+            webRequest.Headers.Count.Should().Be(3);
+            webRequest.Headers["User-Agent"].Should().Be("curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3");
+            webRequest.Headers["Host"].Should().Be("www.example.com");
+            webRequest.Headers["Accept-Language"].Should().Be("en, mi");
+            webRequest.Body.Text.Should().Be("This is the body.\r\nLine 2.\r\n");
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -25,6 +25,7 @@ Accept-Language: en, mi
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
+            webRequest.Parameters.Should().BeNull();
             webRequest.Protocol.Should().Be("HTTP");
             webRequest.Version.Should().Be("1.1");
             webRequest.HttpVersion.Should().Be("HTTP/1.1");
@@ -36,7 +37,7 @@ Accept-Language: en, mi
         }
 
         [Fact]
-        public void WebRequest_Parse_CreatesExpectedWebRequestObjectWithBody()
+        public void WebRequest_Parse_ExtractsBody()
         {
             // Example from RFC 7230.
             const string RequestString =
@@ -53,6 +54,7 @@ Line 2.
 
             webRequest.Method.Should().Be("GET");
             webRequest.Target.Should().Be("/hello.txt");
+            webRequest.Parameters.Should().BeNull();
             webRequest.Protocol.Should().Be("HTTP");
             webRequest.Version.Should().Be("1.1");
             webRequest.HttpVersion.Should().Be("HTTP/1.1");
@@ -61,6 +63,31 @@ Line 2.
             webRequest.Headers["Host"].Should().Be("www.example.com");
             webRequest.Headers["Accept-Language"].Should().Be("en, mi");
             webRequest.Body.Text.Should().Be("This is the body.\r\nLine 2.\r\n");
+        }
+
+        [Fact]
+        public void WebRequest_Parse_ExtractsParameters()
+        {
+            // Example from RFC 7230.
+            const string RequestString =
+@"GET /hello.txt?a=b&c=2 HTTP/1.1
+User-Agent: my-agent
+
+";
+
+            WebRequest webRequest = WebRequest.Parse(RequestString);
+
+            webRequest.Method.Should().Be("GET");
+            webRequest.Target.Should().Be("/hello.txt?a=b&c=2");
+            webRequest.Parameters.Count.Should().Be(2);
+            webRequest.Parameters["a"].Should().Be("b");
+            webRequest.Parameters["c"].Should().Be("2");
+            webRequest.Protocol.Should().Be("HTTP");
+            webRequest.Version.Should().Be("1.1");
+            webRequest.HttpVersion.Should().Be("HTTP/1.1");
+            webRequest.Headers.Count.Should().Be(1);
+            webRequest.Headers["User-Agent"].Should().Be("my-agent");
+            webRequest.Body.Should().BeNull();
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -34,6 +34,7 @@ Accept-Language: en, mi";
         [InlineData("GET", "request target absent")]
         [InlineData("GET /hello.txt", "protocol version is absent")]
         [InlineData("GET /hello.txt HTTP", "protocol version is invalid")]
+        [InlineData("G@T /hello.txt HTTP/1.1", "method token is invalid")]
         public void WebRequest_Parse_DetectsInvalidRequestStrings(string requestString, string reason)
         {
             WebRequest webRequest = WebRequest.Parse(requestString);

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -40,6 +40,7 @@ Content-Security-Policy: frame-ancestors 'self'
 
             webResponse.Protocol.Should().Be("HTTP/1.1");
             webResponse.StatusCode.Should().Be(200);
+            webResponse.ReasonPhrase.Should().Be("OK");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -2,16 +2,43 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
 {
-    public class WebRsponseTests
+    public class WebResponseTests
     {
-        [Fact(Skip = "NYI")]
+        [Fact]
         public void WebResponse_Parse_CreatesExpectedWebRequestObject()
         {
-            false.Should().BeTrue();
+            const string ResponseString =
+@"HTTP/1.1 200 OK
+Date: Thu, 13 Jun 2019 15:31:38 GMT
+Content-Length: 1225
+Content-Type: text/html
+Content-Encoding: gzip
+Last-Modified: Fri, 07 Jun 2019 05:15:32 GMT
+Accept-Ranges: bytes
+Server: Microsoft-IIS/10.0
+Vary: Accept-Encoding
+Persistent-Auth: true
+X-Powered-By: ASP.NET
+Strict-Transport-Security: max-age=31536000
+X-Content-Type-Options: nosniff
+X-UA-Compatible: IE=edge
+X-FRAME-OPTIONS: SAMEORIGIN
+Content-Security-Policy: frame-ancestors 'self'
+
+<div error-message error=""error"">
+</di >
+<div class=""form-horizontal"">
+    <div class=""col-sm-12"">
+    </div>
+</div>";
+            WebResponse webResponse = WebResponse.Parse(ResponseString);
+
+            webResponse.Protocol.Should().Be("HTTP/1.1");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -118,5 +118,50 @@ Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
 
             action.Should().Throw<ArgumentException>();
         }
+
+        [Theory]
+        [InlineData("", false, null, null, null, -1, null, -1, "status line is empty")]
+        [InlineData("HTTP/1.1", false, null, null, null, -1, null, -1, "status code is absent")]
+        [InlineData("HTTP/1.1 200", false, null, null, null, -1, null, -1, "reason phrase is absent")]
+        [InlineData("HTTP/1.1 200 OK", false, null, null, null, -1, null, -1, "status line does not end in CRLF")]
+        [InlineData("HTTP2/1.1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid name")]
+        [InlineData("HTTP/1..1 200 OK\r\n", false, null, null, null, -1, null, -1, "HTTP version has invalid version number")]
+        [InlineData("HTTP/1.1 200a OK\r\n", false, null, null, null, -1, null, -1, "status code is not an integer")]
+        [InlineData("HTTP/1.1 20 OK\r\n", false, null, null, null, -1, null, -1, "status code has fewer than three digits")]
+        [InlineData("HTTP/1.1 2000 OK\r\n", false, null, null, null, -1, null, -1, "status code has more than three digits")]
+        [InlineData("HTTP/1.1 200 OK\r\n", true, "HTTP/1.1", "HTTP", "1.1", 200, "OK", 17, "status line is valid")]
+        public void WebResponse_ParseStatusLine_HandlesErrorConditions(
+            string statusLine,
+            bool shouldSucceed,
+            string expectedHttpVersion,
+            string expectedProtocol,
+            string expectedVersion,
+            int expectedStatusCode,
+            string expectedReasonPhrase,
+            int expectedLength,
+            string because)
+        {
+            Action action = () =>
+            {
+                WebResponse.ParseStatusLine(
+                    statusLine,
+                    out string httpVersion,
+                    out string protocol,
+                    out string version,
+                    out int statusCode,
+                    out string reasonPhrase,
+                    out int length);
+
+                httpVersion.Should().Be(expectedHttpVersion, because);
+                protocol.Should().Be(expectedProtocol, because);
+                version.Should().Be(expectedVersion, because);
+                statusCode.Should().Be(expectedStatusCode, because);
+                reasonPhrase.Should().Be(expectedReasonPhrase, because);
+                length.Should().Be(expectedLength, because);
+            };
+
+            if (shouldSucceed) { action.Should().NotThrow(); }
+            else { action.Should().Throw<Exception>(); }
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -43,6 +43,7 @@ Hello World!My payload includes a trailing CRLF.
             webResponse.Headers["Content-Length"].Should().Be("51");
             webResponse.Headers["Vary"].Should().Be("Accept-Encoding");
             webResponse.Headers["Content-Type"].Should().Be("text/plain");
+            webResponse.Body.Text.Should().Be("Hello World!My payload includes a trailing CRLF.\r\n");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -29,12 +29,21 @@ Hello World!My payload includes a trailing CRLF.
 
             WebResponse webResponse = WebResponse.Parse(ResponseString);
 
+            webResponse.IsInvalid.Should().BeFalse();
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");
             webResponse.HttpVersion.Should().Be("HTTP/1.1");
             webResponse.StatusCode.Should().Be(200);
             webResponse.ReasonPhrase.Should().Be("OK");
-            webResponse.IsInvalid.Should().BeFalse();
+            webResponse.Headers.Count.Should().Be(8);
+            webResponse.Headers["Date"].Should().Be("Mon, 27 Jul 2009 12:28:53 GMT");
+            webResponse.Headers["Server"].Should().Be("Apache");
+            webResponse.Headers["Last-Modified"].Should().Be("Wed, 22 Jul 2009 19:15:56 GMT");
+            webResponse.Headers["ETag"].Should().Be("\"34aa387-d-1568eb00\"");
+            webResponse.Headers["Accept-Ranges"].Should().Be("bytes");
+            webResponse.Headers["Content-Length"].Should().Be("51");
+            webResponse.Headers["Vary"].Should().Be("Accept-Encoding");
+            webResponse.Headers["Content-Type"].Should().Be("text/plain");
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
+{
+    public class WebRsponseTests
+    {
+        [Fact(Skip = "NYI")]
+        public void WebResponse_Parse_CreatesExpectedWebRequestObject()
+        {
+            false.Should().BeTrue();
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
@@ -42,6 +43,7 @@ Content-Security-Policy: frame-ancestors 'self'
 
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");
+            webResponse.ProtocolVersion.Should().Be("HTTP/1.1");
             webResponse.StatusCode.Should().Be(200);
             webResponse.ReasonPhrase.Should().Be("OK");
             webResponse.IsInvalid.Should().BeFalse();
@@ -58,7 +60,21 @@ Content-Security-Policy: frame-ancestors 'self'
             WebResponse webResponse = WebResponse.Parse(responseString);
 
             webResponse.IsInvalid.Should().BeTrue(because: reason);
+        }
 
+        public static readonly IEnumerable<object[]> s_protocolVersionTestCases = new List<object[]>
+        {
+            new object[] { new WebResponse(), "/" },
+            new object[] { new WebResponse { Protocol = "HTTP" }, "HTTP/" },
+            new object[] { new WebResponse { Version = "1.1" }, "/1.1" },
+            new object[] { new WebResponse { Protocol = "HTTP", Version = "1.1" }, "HTTP/1.1" }
+        };
+
+        [Theory]
+        [MemberData(nameof(s_protocolVersionTestCases))]
+        public void WebResponse_SynthesizesProtocolVersionFromProtocolAndVersion(WebResponse webResponse, string expectedProtocolVersion)
+        {
+            webResponse.ProtocolVersion.Should().Be(expectedProtocolVersion);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -29,7 +29,6 @@ Hello World!My payload includes a trailing CRLF.
 
             WebResponse webResponse = WebResponse.Parse(ResponseString);
 
-            webResponse.IsInvalid.Should().BeFalse();
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");
             webResponse.HttpVersion.Should().Be("HTTP/1.1");

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -39,6 +39,7 @@ Content-Security-Policy: frame-ancestors 'self'
             WebResponse webResponse = WebResponse.Parse(ResponseString);
 
             webResponse.Protocol.Should().Be("HTTP/1.1");
+            webResponse.StatusCode.Should().Be(200);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
@@ -10,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
     public class WebResponseTests
     {
         [Fact]
-        public void WebResponse_Parse_CreatesExpectedWebRequestObject()
+        public void WebResponse_Parse_CreatesExpectedWebResponseObject()
         {
             const string ResponseString =
 @"HTTP/1.1 200 OK
@@ -43,6 +45,20 @@ Content-Security-Policy: frame-ancestors 'self'
             webResponse.StatusCode.Should().Be(200);
             webResponse.ReasonPhrase.Should().Be("OK");
             webResponse.IsInvalid.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("", "response is empty")]
+        [InlineData("HTTP/1.1", "status code is absent")]
+        [InlineData("HTTP/1.1 200a", "status code is not an integer")]
+        [InlineData("HTTP/1.1 200", "reason phrase is absent")]
+        [InlineData("HTTP 200 OK", "HTTP version is absent")]
+        public void WebResponse_Parse_DetectsInvalidResponseStrings(string responseString, string reason)
+        {
+            WebResponse webResponse = WebResponse.Parse(responseString);
+
+            webResponse.IsInvalid.Should().BeTrue(because: reason);
+
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -43,6 +43,8 @@ Hello World!My payload includes a trailing CRLF.
         [InlineData("HTTP/1.1 200a", "status code is not an integer")]
         [InlineData("HTTP/1.1 200", "reason phrase is absent")]
         [InlineData("HTTP 200 OK", "HTTP version is absent")]
+        [InlineData("HTTP/1..1 200 OK", "HTTP version number is invalid")]
+        [InlineData("HTTP2/1.1 200 OK", "HTTP version protocol name is invalid")]
         public void WebResponse_Parse_DetectsInvalidResponseStrings(string responseString, string reason)
         {
             WebResponse webResponse = WebResponse.Parse(responseString);

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -38,9 +38,11 @@ Content-Security-Policy: frame-ancestors 'self'
 </div>";
             WebResponse webResponse = WebResponse.Parse(ResponseString);
 
-            webResponse.Protocol.Should().Be("HTTP/1.1");
+            webResponse.Protocol.Should().Be("HTTP");
+            webResponse.Version.Should().Be("1.1");
             webResponse.StatusCode.Should().Be(200);
             webResponse.ReasonPhrase.Should().Be("OK");
+            webResponse.IsInvalid.Should().BeFalse();
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -15,30 +15,21 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Core
         [Fact]
         public void WebResponse_Parse_CreatesExpectedWebResponseObject()
         {
+            // Example from RFC 7230.
             const string ResponseString =
 @"HTTP/1.1 200 OK
-Date: Thu, 13 Jun 2019 15:31:38 GMT
-Content-Length: 1225
-Content-Type: text/html
-Content-Encoding: gzip
-Last-Modified: Fri, 07 Jun 2019 05:15:32 GMT
+Date: Mon, 27 Jul 2009 12:28:53 GMT
+Server: Apache
+Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
+ETag: ""34aa387-d-1568eb00""
 Accept-Ranges: bytes
-Server: Microsoft-IIS/10.0
+Content-Length: 51
 Vary: Accept-Encoding
-Persistent-Auth: true
-X-Powered-By: ASP.NET
-Strict-Transport-Security: max-age=31536000
-X-Content-Type-Options: nosniff
-X-UA-Compatible: IE=edge
-X-FRAME-OPTIONS: SAMEORIGIN
-Content-Security-Policy: frame-ancestors 'self'
+Content-Type: text / plain
 
-<div error-message error=""error"">
-</di >
-<div class=""form-horizontal"">
-    <div class=""col-sm-12"">
-    </div>
-</div>";
+Hello World!My payload includes a trailing CRLF.
+";
+
             WebResponse webResponse = WebResponse.Parse(ResponseString);
 
             webResponse.Protocol.Should().Be("HTTP");

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -31,7 +31,7 @@ Hello World!My payload includes a trailing CRLF.
 
             webResponse.Protocol.Should().Be("HTTP");
             webResponse.Version.Should().Be("1.1");
-            webResponse.ProtocolVersion.Should().Be("HTTP/1.1");
+            webResponse.HttpVersion.Should().Be("HTTP/1.1");
             webResponse.StatusCode.Should().Be(200);
             webResponse.ReasonPhrase.Should().Be("OK");
             webResponse.IsInvalid.Should().BeFalse();

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
@@ -49,21 +48,6 @@ Hello World!My payload includes a trailing CRLF.
             WebResponse webResponse = WebResponse.Parse(responseString);
 
             webResponse.IsInvalid.Should().BeTrue(because: reason);
-        }
-
-        public static readonly IEnumerable<object[]> s_protocolVersionTestCases = new List<object[]>
-        {
-            new object[] { new WebResponse(), "/" },
-            new object[] { new WebResponse { Protocol = "HTTP" }, "HTTP/" },
-            new object[] { new WebResponse { Version = "1.1" }, "/1.1" },
-            new object[] { new WebResponse { Protocol = "HTTP", Version = "1.1" }, "HTTP/1.1" }
-        };
-
-        [Theory]
-        [MemberData(nameof(s_protocolVersionTestCases))]
-        public void WebResponse_SynthesizesProtocolVersionFromProtocolAndVersion(WebResponse webResponse, string expectedProtocolVersion)
-        {
-            webResponse.ProtocolVersion.Should().Be(expectedProtocolVersion);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -143,20 +143,16 @@ Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT
         {
             Action action = () =>
             {
-                WebResponse.ParseStatusLine(
-                    statusLine,
-                    out string httpVersion,
-                    out string protocol,
-                    out string version,
-                    out int statusCode,
-                    out string reasonPhrase,
-                    out int length);
+                var webResponse = new WebResponse();
 
-                httpVersion.Should().Be(expectedHttpVersion, because);
-                protocol.Should().Be(expectedProtocol, because);
-                version.Should().Be(expectedVersion, because);
-                statusCode.Should().Be(expectedStatusCode, because);
-                reasonPhrase.Should().Be(expectedReasonPhrase, because);
+                webResponse.ParseStatusLine(statusLine, out int length);
+
+                webResponse.HttpVersion.Should().Be(expectedHttpVersion, because);
+                webResponse.Protocol.Should().Be(expectedProtocol, because);
+                webResponse.Version.Should().Be(expectedVersion, because);
+                webResponse.StatusCode.Should().Be(expectedStatusCode, because);
+                webResponse.ReasonPhrase.Should().Be(expectedReasonPhrase, because);
+
                 length.Should().Be(expectedLength, because);
             };
 

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
@@ -25,7 +23,7 @@ ETag: ""34aa387-d-1568eb00""
 Accept-Ranges: bytes
 Content-Length: 51
 Vary: Accept-Encoding
-Content-Type: text / plain
+Content-Type: text/plain
 
 Hello World!My payload includes a trailing CRLF.
 ";

--- a/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebResponseTests.cs
@@ -36,20 +36,5 @@ Hello World!My payload includes a trailing CRLF.
             webResponse.ReasonPhrase.Should().Be("OK");
             webResponse.IsInvalid.Should().BeFalse();
         }
-
-        [Theory]
-        [InlineData("", "response is empty")]
-        [InlineData("HTTP/1.1", "status code is absent")]
-        [InlineData("HTTP/1.1 200a", "status code is not an integer")]
-        [InlineData("HTTP/1.1 200", "reason phrase is absent")]
-        [InlineData("HTTP 200 OK", "HTTP version is absent")]
-        [InlineData("HTTP/1..1 200 OK", "HTTP version number is invalid")]
-        [InlineData("HTTP2/1.1 200 OK", "HTTP version protocol name is invalid")]
-        public void WebResponse_Parse_DetectsInvalidResponseStrings(string responseString, string reason)
-        {
-            WebResponse webResponse = WebResponse.Parse(responseString);
-
-            webResponse.IsInvalid.Should().BeTrue(because: reason);
-        }
     }
 }


### PR DESCRIPTION
We introduce methods to parse `WebRequest` and `WebResponse` objects from the raw web message strings.

Also:
- Add codegen hints to fix bugs in generated `WebRequest` and `WebResponse` objects:
    - `WebRequest.Headers` must be a dictionary.
    - `WebRequest.Parameters` must be a dictionary.
    - `WebResponse.Headers` must be a dictionary.