### PR TITLE
Fix schema cross-references in external property files schema.

### DIFF
--- a/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.2.json
+++ b/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.2.json
@@ -30,7 +30,7 @@
 
     "conversion": {
       "description": "A conversion object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.1.json#/definitions/conversion"
+      "$ref": "sarif-2.1.0-rtm.2.json#/definitions/conversion"
     },
 
     "graphs": {
@@ -40,13 +40,13 @@
       "default": [],
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/graph"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/graph"
       }
     },
 
     "externalizedProperties": {
       "description": "Key/value pairs that provide additional information that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.1.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.2.json#/definitions/propertyBag"
     },
 
     "artifacts": {
@@ -55,7 +55,7 @@
       "minItems": 0,
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/artifact"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/artifact"
       }
     },
 
@@ -66,7 +66,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/invocation"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/invocation"
       }
     },
 
@@ -77,7 +77,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/logicalLocation"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/logicalLocation"
       }
     },
 
@@ -88,7 +88,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/threadFlowLocation"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/threadFlowLocation"
       }
     },
 
@@ -99,7 +99,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/result"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/result"
       }
     },
 
@@ -110,13 +110,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/toolComponent"
       }
     },
 
     "driver": {
       "description": "The analysis tool object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.1.json#/definitions/toolComponent"
+      "$ref": "sarif-2.1.0-rtm.2.json#/definitions/toolComponent"
     },
 
     "extensions": {
@@ -126,7 +126,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/toolComponent"
       }
     },
 
@@ -137,7 +137,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/toolComponent"
       }
     },
 
@@ -148,7 +148,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/toolComponent"
       }
     },
 
@@ -159,7 +159,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/address"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/address"
       }
     },
 
@@ -170,7 +170,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/webRequest"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/webRequest"
       }
     },
 
@@ -181,13 +181,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.1.json#/definitions/webResponse"
+        "$ref": "sarif-2.1.0-rtm.2.json#/definitions/webResponse"
       }
     },
 
     "properties": {
       "description": "Key/value pairs that provide additional information about the external properties.",
-      "$ref": "sarif-2.1.0-rtm.1.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.2.json#/definitions/propertyBag"
     }
   },
   "required": [ "version" ],


### PR DESCRIPTION
When we updated our SDK schema version numbers from `rtm.1` to `rtm.2`, we missed the cross-references from the external properties file schema back to the log file schema.

There's no need to update the release history: this is not a fix from a previous SDK version; it's the correction of incomplete work we did within the current version.