### PR TITLE
Fortify converter ignores originalUriBaseId if root (e.g. C:)

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -410,4 +410,4 @@
 * Change schemas back to draft-04 to reenable Intellisense in the Visual Studio JSON editor.
 
 ## **v2.1.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.6)
-* BUGFIX: Fortify converter does not populat originalUriBaseId if the Source is root (e.g. C:)
+* BUGFIX: Fortify FPR converter does not populate originalUriBaseIds if the source is a drive letter (e.g. C:)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -408,3 +408,6 @@
 
 ## **v2.1.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.5)
 * Change schemas back to draft-04 to reenable Intellisense in the Visual Studio JSON editor.
+
+## **v2.1.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.6)
+* BUGFIX: Fortify converter does not populat originalUriBaseId if the Source is root (e.g. C:)

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 if (originalUriBasePath.StartsWith("/") &&
                      platform == "Linux")
                 {
-                    originalUriBasePath = "file:/" + originalUriBasePath;
+                    originalUriBasePath = "file://" + originalUriBasePath;
                 }
 
                 if (!originalUriBasePath.EndsWith("/"))

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -218,6 +218,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     _originalUriBasePath = "file:/" + _originalUriBasePath;
                 }
 
+                if (_originalUriBasePath.EndsWith(":"))
+                {
+                    _originalUriBasePath = _originalUriBasePath + "/";
+                }
+
                 if (Uri.TryCreate(_originalUriBasePath, UriKind.Absolute, out Uri uri))
                 {
                     run.OriginalUriBaseIds = new Dictionary<string, ArtifactLocation>

--- a/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             originalUriBaseIdsDictionary.Count.Should().Be(1);
             originalUriBaseIdsDictionary.ContainsKey(FortifyFprConverter.FileLocationUriBaseId).Should().BeTrue();
-            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].Uri.Should().Be(@"file://root/projects/myproject/src/");
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].Uri.Should().Be(@"file:///root/projects/myproject/src/");
             originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].UriBaseId.Should().BeNull();
         }
 

--- a/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
+++ b/src/Test.UnitTests.Sarif.Converters/FortifyFprConverterTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
             };
 
-            foreach(KeyValuePair<string,FailureLevel> keyValuePair in expectedInputOutputs)
+            foreach (KeyValuePair<string, FailureLevel> keyValuePair in expectedInputOutputs)
             {
                 ReportingDescriptor rule = new ReportingDescriptor();
                 rule.SetProperty<string>("Impact", keyValuePair.Key);
@@ -94,7 +94,58 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
 
                 level.Should().Be(keyValuePair.Value);
             }
-            
         }
+
+        [Fact]
+        public void FortifyFprConverter_GetOriginalUriBaseIdsDictionary_sourceIsDriveLetter()
+        {
+            Dictionary<string, ArtifactLocation> originalUriBaseIdsDictionary = FortifyFprConverter.GetOriginalUriBaseIdsDictionary("C:", "Windows Server 2016");
+
+            originalUriBaseIdsDictionary.Count.Should().Be(1);
+            originalUriBaseIdsDictionary.ContainsKey(FortifyFprConverter.FileLocationUriBaseId).Should().BeTrue();
+
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].Uri.Should().Be(@"file:///C:/");
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].UriBaseId.Should().BeNull();
+
+        }
+
+        [Fact]
+        public void FortifyFprConverter_GetOriginalUriBaseIdsDictionary_sourceIsAbsolutePathWithoutTrailingSlash()
+        {
+            Dictionary<string, ArtifactLocation> originalUriBaseIdsDictionary = FortifyFprConverter.GetOriginalUriBaseIdsDictionary("C:/test/123", "Windows 10");
+
+            originalUriBaseIdsDictionary.Count.Should().Be(1);
+            originalUriBaseIdsDictionary.ContainsKey(FortifyFprConverter.FileLocationUriBaseId).Should().BeTrue();
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].Uri.Should().Be(@"file:///C:/test/123/");
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].UriBaseId.Should().BeNull();
+        }
+
+        [Fact]
+        public void FortifyFprConverter_GetOriginalUriBaseIdsDictionary_sourceIsLinuxStyleAbsolutePath()
+        {
+            Dictionary<string, ArtifactLocation> originalUriBaseIdsDictionary = FortifyFprConverter.GetOriginalUriBaseIdsDictionary("/root/projects/myproject/src/", "Linux");
+
+            originalUriBaseIdsDictionary.Count.Should().Be(1);
+            originalUriBaseIdsDictionary.ContainsKey(FortifyFprConverter.FileLocationUriBaseId).Should().BeTrue();
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].Uri.Should().Be(@"file://root/projects/myproject/src/");
+            originalUriBaseIdsDictionary[FortifyFprConverter.FileLocationUriBaseId].UriBaseId.Should().BeNull();
+        }
+
+        [Fact]
+        public void FortifyFprConverter_GetOriginalUriBaseIdsDictionary_sourceIsRelativeWithTrailingSlash()
+        {
+            Dictionary<string, ArtifactLocation> originalUriBaseIdsDictionary = FortifyFprConverter.GetOriginalUriBaseIdsDictionary("/some/relative/path/", "Windows Server 2016");
+
+            originalUriBaseIdsDictionary.Should().BeNull();
+        }
+
+        [Fact]
+        public void FortifyFprConverter_GetOriginalUriBaseIdsDictionary_sourceIsRelativeWithoutTrailingSlash()
+        {
+            Dictionary<string, ArtifactLocation> originalUriBaseIdsDictionary = FortifyFprConverter.GetOriginalUriBaseIdsDictionary("another/relative/path", "Windows Server 2016");
+
+            originalUriBaseIdsDictionary.Should().BeNull();
+        }
+
     }
 }

--- a/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultBasic.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/OneResultBasic.sarif
@@ -154,7 +154,7 @@
       "language": "en-US",
       "originalUriBaseIds": {
         "SRCROOT": {
-          "uri": "file://root/projects/myproject/src/"
+          "uri": "file:///root/projects/myproject/src/"
         }
       },
       "artifacts": [

--- a/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/ScanWithFailureLevelMatrices.sarif
+++ b/src/Test.UnitTests.Sarif.Converters/TestData/FortifyFprConverter/ExpectedOutputs/ScanWithFailureLevelMatrices.sarif
@@ -49080,7 +49080,11 @@
           }
         }
       ],
-      "language": "en-US",
+      "originalUriBaseIds": {
+        "SRCROOT": {
+          "uri": "file:///C:/"
+        }
+      },
       "artifacts": [
         {
           "location": {

--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.5</VersionPrefix>
+    <VersionPrefix>2.1.6</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -29,7 +29,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.4</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.5</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.2</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>


### PR DESCRIPTION
in fvdl, if <SourceBasePath> is a root (e.g C:), this is ignored by fortify converter.
    <SourceBasePath>C:</SourceBasePath>

This is because Uri.TryCreate method does not treat "C:" as an absolute URI.

Fixing this by manually appending a "/" . We had a test case which covers this scenario already, hence rebaselined it to new expected result.