### PR TITLE
Fix bugs in SarifCurrentToVersionOneVisitor

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -413,3 +413,6 @@
 * BUGFIX: Fortify FPR converter does not populate originalUriBaseIds if the source is a drive letter (e.g. C:)
 * BUGFIX: Multitool rebaseUri command throws null reference exception if results reference run.artifacts using the index property.
 * BUGFIX: Pre-release transformer does not upgrade schema uri if input version is higher than rtm.1.
+
+## **v2.1.7** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.7) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.7) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.7) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.7)
+* BUGFIX: The `SarifCurrentToVersionOneVisitor` was not translating v2 `result.partialFingerprints` to v1 `result.toolFingerprintContribution`. https://github.com/microsoft/sarif-sdk/issues/1556

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -416,3 +416,4 @@
 
 ## **v2.1.7** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.7) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.7) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.7) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.7)
 * BUGFIX: The `SarifCurrentToVersionOneVisitor` was not translating v2 `result.partialFingerprints` to v1 `result.toolFingerprintContribution`. https://github.com/microsoft/sarif-sdk/issues/1556
+* BUGFIX: The `SarifCurrentToVersionOneVisitor` was dropping `run.id` and emitting an empty `run.stableId`. https://github.com/microsoft/sarif-sdk/issues/1557

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (!instanceId.Contains("/"))
             {
-                return String.Empty;
+                return null;
             }
 
             return instanceId.Substring(0, instanceId.LastIndexOf('/'));

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -45,9 +45,8 @@
     <Content Include="Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
     <Content Include="Schemata\sarif-external-property-file-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
 
-    <!-- Link=false: Don't display this item in Solution Explorer. -->
     <!-- This item will be added to the NuGet package, however. -->
-    <Content Include="..\ReleaseHistory.md" Link="false" />
+    <Content Include="..\ReleaseHistory.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
+++ b/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                     run.BaselineId = v2Run.BaselineGuid;
                     run.Files = CreateFileDataVersionOneDictionary();
-                    run.Id = v2Run.AutomationDetails?.Guid;
+                    run.Id = v2Run.AutomationDetails?.Id;
                     run.AutomationId = v2Run.RunAggregates?.FirstOrDefault()?.Id;
 
                     run.StableId = v2Run.AutomationDetails?.InstanceIdLogicalComponent();

--- a/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
+++ b/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security;
@@ -504,6 +503,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             return region;
         }
 
+        internal string CreateToolFingerprintContributionVersionOne(IDictionary<string, string> v2PartialFingerprints)
+        {
+            string toolFingerprintContribution = null;
+
+            if (v2PartialFingerprints?.Keys.Count > 0)
+            {
+                // V1 only supports one of what v2 refers to as "partial fingerprints". We arbitrarily take the
+                // one with the "smallest" key.
+                string smallestKey = v2PartialFingerprints.Keys.OrderBy(k => k).First();
+                toolFingerprintContribution = v2PartialFingerprints[smallestKey];
+            }
+
+            return toolFingerprintContribution;
+        }
+
         private int ConvertCharOffsetToByteOffset(int charOffset, Uri uri)
         {
             int byteOffset = 0;
@@ -772,7 +786,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                     RelatedLocations = v2Result.RelatedLocations?.Select(CreateAnnotatedCodeLocationVersionOne).ToList(),
                     Snippet = v2Result.Locations?[0]?.PhysicalLocation?.Region?.Snippet?.Text,
                     Stacks = v2Result.Stacks?.Select(CreateStackVersionOne).ToList(),
-                    SuppressionStates = Utilities.CreateSuppressionStatesVersionOne(v2Result.Suppressions)
+                    SuppressionStates = Utilities.CreateSuppressionStatesVersionOne(v2Result.Suppressions),
+                    ToolFingerprintContribution = CreateToolFingerprintContributionVersionOne(v2Result.PartialFingerprints)
                 };
 
                 if (result.Fixes != null)

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -157,6 +157,8 @@
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\Regions.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\RestoreFromPropertyBag.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\ResultLocations.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\ResultWithOnePartialFingerprint.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\ResultWithTwoPartialFingerprints.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\TwoResultsWithFixes.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\MinimumWithLanguage.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\NestedInnerExceptionsInNotifications.sarif" />
@@ -194,6 +196,8 @@
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\OneRunWithNotificationsButNoInvocations.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\OneRunWithRules.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\RestoreFromPropertyBag.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\ResultWithOnePartialFingerprint.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\ResultWithTwoPartialFingerprints.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\TwoResultsWithFixes.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\UriBaseId.sarif" />
   </ItemGroup>

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -135,6 +135,7 @@
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\Minimum.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\MinimumWithTwoRuns.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\NotificationExceptionWithStack.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithAutomationDetails.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithBasicInvocation.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithFiles.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithNotificationTime.sarif" />
@@ -148,6 +149,7 @@
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\Minimum.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\MinimumWithTwoRuns.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\NotificationExceptionWithStack.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\OneRunWithAutomationDetails.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\OneRunWithBasicInvocation.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\OneRunWithFiles.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\Inputs\OneRunWithNotificationTime.sarif" />

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/OneRunWithAutomationDetails.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/OneRunWithAutomationDetails.sarif
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-1.0.0.json",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0",
+        "language": "en-US"
+      },
+      "results": [],
+      "id": "Nightly security tools run/master/x86/debug/2018-10-05",
+      "stableId": "Nightly security tools run/master/x86/debug"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/ResultWithOnePartialFingerprint.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/ResultWithOnePartialFingerprint.sarif
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-1.0.0.json",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0",
+        "language": "en-US"
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": "Something happened.",
+          "locations": [
+            {
+              "resultFile": {
+                "uri": "io/kb.c",
+                "uriBaseId": "SRCROOT"
+              }
+            }
+          ],
+          "toolFingerprintContribution": "12345"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/ResultWithTwoPartialFingerprints.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/ExpectedOutputs/ResultWithTwoPartialFingerprints.sarif
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-1.0.0.json",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "CodeScanner",
+        "semanticVersion": "2.1.0",
+        "language": "en-US"
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": "Something happened.",
+          "locations": [
+            {
+              "resultFile": {
+                "uri": "io/kb.c",
+                "uriBaseId": "SRCROOT"
+              }
+            }
+          ],
+          "toolFingerprintContribution": "12345"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/OneRunWithAutomationDetails.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/OneRunWithAutomationDetails.sarif
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.3",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "semanticVersion": "2.1.0"
+        }
+      },
+      "results": [],
+      "automationDetails": {
+        "id": "Nightly security tools run/master/x86/debug/2018-10-05"
+      }
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithOnePartialFingerprint.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithOnePartialFingerprint.sarif
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.3",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "semanticVersion": "2.1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Something happened."
+          },
+          "partialFingerprints": {
+            "a": "12345"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "io/kb.c",
+                  "uriBaseId": "SRCROOT"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithTwoPartialFingerprints.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithTwoPartialFingerprints.sarif
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.3",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "semanticVersion": "2.1.0"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Something happened."
+          },
+          "partialFingerprints": {
+            "a": "12345",
+            "b": "67980"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "io/kb.c",
+                  "uriBaseId": "SRCROOT"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
@@ -76,5 +76,8 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Visitors
 
         [Fact]
         public void SarifTransformerTests_ToVersionOne_TwoPartialPartialFingerprints() => RunTest("ResultWithTwoPartialFingerprints.sarif");
+
+        [Fact]
+        public void SarifTransformerTests_ToVersionOne_PopulatesRunIdAndStableId() => RunTest("OneRunWithAutomationDetails.sarif");
     }
 }

--- a/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/SarifCurrentToVersionOneVisitorTests.cs
@@ -70,5 +70,11 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests.Visitors
 
         [Fact]
         public void SarifTransformerTests_ToVersionOne_OneRunWithNotificationTime() => RunTest("OneRunWithNotificationTime.sarif");
+
+        [Fact]
+        public void SarifTransformerTests_ToVersionOne_OnePartialPartialFingerprint() => RunTest("ResultWithOnePartialFingerprint.sarif");
+
+        [Fact]
+        public void SarifTransformerTests_ToVersionOne_TwoPartialPartialFingerprints() => RunTest("ResultWithTwoPartialFingerprints.sarif");
     }
 }

--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.6</VersionPrefix>
+    <VersionPrefix>2.1.7</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -29,7 +29,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.5</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.6</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.2</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>


### PR DESCRIPTION
- #1556: `SarifCurrentToVersionOneVisitor` drops partial fingerprints.
- #1557: `SarifCurrentToVersionOneVisitor` drops `run.id` and emits empty `run.stableId`.