### PR TITLE
Remove SarifContractResolver from examples

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -8,12 +8,9 @@
 
 ## Write a SARIF log file to disk
 
-Whenever you read or write a SARIF log file, use the `SarifContractResolver` class to format elements such as URIs and dates according to the SARIF standard.
-
 ```C#
 JsonSerializerSettings settings = new JsonSerializerSettings()
 {
-    ContractResolver = SarifContractResolver.Instance,
     Formatting = Formatting.Indented
 };
 
@@ -25,17 +22,10 @@ File.WriteAllText(outputFilePath, sarifText);
 
 ## Read a SARIF log file from disk
 
-Whenever you read or write a SARIF log file, use the `SarifContractResolver` class to format elements such as URIs and dates according to the SARIF standard.
-
 ```C#
 string logContents = File.ReadAllText(logFilePath);
 
-var settings = new JsonSerializerSettings()
-{
-    ContractResolver = SarifContractResolver.Instance
-};
-
-SarifLog log = JsonConvert.DeserializeObject<SarifLog>(logContents, settings);
+SarifLog log = JsonConvert.DeserializeObject<SarifLog>(logContents);
 ```
 
 ## Format a result message


### PR DESCRIPTION
#1103 has removed the requirement to use `SarifContractResolver` while reading and writing files. Removes obsolete code from samples.