### PR TITLE
Fix minor problems in ESLint formatter

### DIFF
--- a/src/ESLint.Formatter/package-lock.json
+++ b/src/ESLint.Formatter/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/eslint-formatter-sarif",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ESLint.Formatter/package.json
+++ b/src/ESLint.Formatter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/eslint-formatter-sarif",
-  "version": "2.1.1",
-  "description": "ESLint formatter for the SARIF v2.1 static analysis file format",
+  "version": "2.1.2",
+  "description": "ESLint formatter for the SARIF (Static Analysis Results Interchange Format) v2.1.0 file format",
   "main": "sarif.js",
   "directories": {
     "test": "test"

--- a/src/ESLint.Formatter/test/sarif.js
+++ b/src/ESLint.Formatter/test/sarif.js
@@ -51,6 +51,20 @@ const rules = {
 //------------------------------------------------------------------------------
 
 describe("formatter:sarif", () => {
+    describe("when run", () => {
+        const code = [];
+
+        it ("should return a log with correct version and tool metadata", () => {
+            const log = JSON.parse(formatter(code, null));
+
+            assert.strictEqual(log['$schema'], 'http://json.schemastore.org/sarif-2.1.0-rtm.4');
+            assert.strictEqual(log.version, '2.1.0');
+
+            assert.strictEqual(log.runs[0].tool.driver.name, "ESLint");
+            assert.strictEqual(log.runs[0].tool.driver.informationUri, "https://eslint.org");
+        })
+    });
+
     describe("when passed no messages", () => {
         const sourceFilePath = "service.js";
         const code = [{
@@ -59,10 +73,11 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with files, but no results", () => {
-            const result = JSON.parse(formatter(code, null));
+            const log = JSON.parse(formatter(code, null));
 
-            assert.isDefined(result.runs[0].artifacts);
-            assert.isUndefined(result.runs[0].results);
+            assert.isDefined(log.runs[0].artifacts);
+            assert.strictEqual(log.runs[0].artifacts[0].location.uri, "service.js");
+            assert.isUndefined(log.runs[0].results);
         });
     });
 });
@@ -79,15 +94,16 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one file and one result", () => {
-            const result = JSON.parse(formatter(code, { rulesMeta: rules }));
+            const log = JSON.parse(formatter(code, { rulesMeta: rules }));
             
-            assert.strictEqual(result.runs[0].artifacts[0].location.uri, sourceFilePath);
-            assert.isDefined(result.runs[0].results);
-            assert.lengthOf(result.runs[0].results, 1);
-            assert.strictEqual(result.runs[0].results[0].level, "error");
-            assert.isDefined(result.runs[0].results[0].message);
-            assert.strictEqual(result.runs[0].results[0].message.text, code[0].messages[0].message);
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath);
+            assert.strictEqual(log.runs[0].artifacts[0].location.uri, sourceFilePath);
+            assert.isDefined(log.runs[0].results);
+            assert.lengthOf(log.runs[0].results, 1);
+            assert.strictEqual(log.runs[0].results[0].level, "error");
+            assert.isDefined(log.runs[0].results[0].message);
+            assert.strictEqual(log.runs[0].results[0].message.text, code[0].messages[0].message);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.index, 0);
         });
     });
 });
@@ -105,14 +121,14 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one rule", () => {
-            const result = JSON.parse(formatter(code, { rulesMeta: rules }));
+            const log = JSON.parse(formatter(code, { rulesMeta: rules }));
             const rule = rules[ruleid];
 
-            assert.strictEqual(result.runs[0].tool.driver.rules.length, 1);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].id, ruleid);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].shortDescription.text, rule.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].helpUri, rule.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].tags.category, rule.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules.length, 1);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].id, ruleid);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].shortDescription.text, rule.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].helpUri, rule.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].properties.category, rule.docs.category);
         });
     });
 });
@@ -128,11 +144,11 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one result whose location region has only a startLine", () => {
-            const result = JSON.parse(formatter(code));
+            const log = JSON.parse(formatter(code));
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.snippet);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.snippet);
         });
     });
 });
@@ -149,11 +165,11 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one result whose location contains a region with line and column #s", () => {
-            const result = JSON.parse(formatter(code));
+            const log = JSON.parse(formatter(code));
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startColumn, code[0].messages[0].column);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.snippet);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn, code[0].messages[0].column);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.snippet);
         });
     });
 });
@@ -171,11 +187,11 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one result whose location contains a region with line and column #s", () => {
-            const result = JSON.parse(formatter(code));
+            const log = JSON.parse(formatter(code));
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startColumn, code[0].messages[0].column);
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.snippet.text, code[0].messages[0].source);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn, code[0].messages[0].column);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.snippet.text, code[0].messages[0].source);
         });
     });
 });
@@ -193,11 +209,11 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with one result whose location contains a region with line and column #s", () => {
-            const result = JSON.parse(formatter(code, rules));
+            const log = JSON.parse(formatter(code, rules));
 
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.startLine);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.snippet.text, code[0].messages[0].source);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startLine);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.snippet.text, code[0].messages[0].source);
         });
     });
 });
@@ -249,67 +265,77 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with two files, three rules, and four results", () => {
-            const result = JSON.parse(formatter(code, { rulesMeta: rules }));
+            const log = JSON.parse(formatter(code, { rulesMeta: rules }));
             const rule1 = rules[ruleid1];
             const rule2 = rules[ruleid2];
             const rule3 = rules[ruleid3];
 
-            assert.lengthOf(result.runs[0].results, 4);
+            assert.lengthOf(log.runs[0].results, 4);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].id, ruleid1);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].id, ruleid2);
-            assert.strictEqual(result.runs[0].tool.driver.rules[2].id, ruleid3);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].id, ruleid1);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].id, ruleid2);
+            assert.strictEqual(log.runs[0].tool.driver.rules[2].id, ruleid3);
 
-            assert.strictEqual(result.runs[0].artifacts[0].location.uri, sourceFilePath1);
-            assert.strictEqual(result.runs[0].artifacts[1].location.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].artifacts[0].location.uri, sourceFilePath1);
+            assert.strictEqual(log.runs[0].artifacts[1].location.uri, sourceFilePath2);
 
-            assert.strictEqual(result.runs[0].artifacts[0].location.uri, sourceFilePath1);
-            assert.strictEqual(result.runs[0].artifacts[1].location.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].artifacts[0].location.uri, sourceFilePath1);
+            assert.strictEqual(log.runs[0].artifacts[1].location.uri, sourceFilePath2);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].id, ruleid1);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].shortDescription.text, rule1.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].helpUri, rule1.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].tags.category, rule1.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].id, ruleid1);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].shortDescription.text, rule1.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].helpUri, rule1.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].properties.category, rule1.docs.category);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].id, ruleid2);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].shortDescription.text, rule2.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].helpUri, rule2.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].tags.category, rule2.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].id, ruleid2);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].shortDescription.text, rule2.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].helpUri, rule2.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].properties.category, rule2.docs.category);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[2].id, ruleid3);
-            assert.strictEqual(result.runs[0].tool.driver.rules[2].shortDescription.text, rule3.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[2].helpUri, rule3.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[2].tags.category, rule3.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules[2].id, ruleid3);
+            assert.strictEqual(log.runs[0].tool.driver.rules[2].shortDescription.text, rule3.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[2].helpUri, rule3.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[2].properties.category, rule3.docs.category);
 
-            assert.strictEqual(result.runs[0].results[0].ruleId, "the-rule");
-            assert.strictEqual(result.runs[0].results[1].ruleId, ruleid1);
-            assert.strictEqual(result.runs[0].results[2].ruleId, ruleid2);
-            assert.strictEqual(result.runs[0].results[3].ruleId, ruleid3);
+            assert.strictEqual(log.runs[0].results[0].ruleId, "the-rule");
+            assert.strictEqual(log.runs[0].results[1].ruleId, ruleid1);
+            assert.strictEqual(log.runs[0].results[2].ruleId, ruleid2);
+            assert.strictEqual(log.runs[0].results[3].ruleId, ruleid3);
 
-            assert.strictEqual(result.runs[0].results[0].level, "error");
-            assert.strictEqual(result.runs[0].results[1].level, "warning");
-            assert.strictEqual(result.runs[0].results[2].level, "error");
-            assert.strictEqual(result.runs[0].results[3].level, "warning");
+            assert.isUndefined(log.runs[0].results[0].ruleIndex); // Custom rule: no metadata available.
+            assert.strictEqual(log.runs[0].results[1].ruleIndex, 0);
+            assert.strictEqual(log.runs[0].results[2].ruleIndex, 1);
+            assert.strictEqual(log.runs[0].results[3].ruleIndex, 2);
 
-            assert.strictEqual(result.runs[0].results[0].message.text, "Unexpected value.");
-            assert.strictEqual(result.runs[0].results[1].message.text, "Some warning.");
-            assert.strictEqual(result.runs[0].results[2].message.text, "Unexpected something.");
-            assert.strictEqual(result.runs[0].results[3].message.text, "Custom error.");
+            assert.strictEqual(log.runs[0].results[0].level, "error");
+            assert.strictEqual(log.runs[0].results[1].level, "warning");
+            assert.strictEqual(log.runs[0].results[2].level, "error");
+            assert.strictEqual(log.runs[0].results[3].level, "warning");
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath1);
-            assert.strictEqual(result.runs[0].results[1].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath1);
-            assert.strictEqual(result.runs[0].results[2].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
-            assert.strictEqual(result.runs[0].results[3].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].results[0].message.text, "Unexpected value.");
+            assert.strictEqual(log.runs[0].results[1].message.text, "Some warning.");
+            assert.strictEqual(log.runs[0].results[2].message.text, "Unexpected something.");
+            assert.strictEqual(log.runs[0].results[3].message.text, "Custom error.");
 
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath1);
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath1);
+            assert.strictEqual(log.runs[0].results[2].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].results[3].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
 
-            assert.strictEqual(result.runs[0].results[1].locations[0].physicalLocation.region.startLine, 10);
-            assert.strictEqual(result.runs[0].results[1].locations[0].physicalLocation.region.startColumn, 5);
-            assert.strictEqual(result.runs[0].results[1].locations[0].physicalLocation.region.snippet.text, "doSomething(thingId)");
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.index, 0);
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.artifactLocation.index, 0);
+            assert.strictEqual(log.runs[0].results[2].locations[0].physicalLocation.artifactLocation.index, 1);
+            assert.strictEqual(log.runs[0].results[3].locations[0].physicalLocation.artifactLocation.index, 1);
 
-            assert.strictEqual(result.runs[0].results[2].locations[0].physicalLocation.region.startLine, 18);
-            assert.isUndefined(result.runs[0].results[2].locations[0].physicalLocation.region.startColumn);
-            assert.isUndefined(result.runs[0].results[2].locations[0].physicalLocation.region.snippet);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region);
+
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.region.startLine, 10);
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.region.startColumn, 5);
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.region.snippet.text, "doSomething(thingId)");
+
+            assert.strictEqual(log.runs[0].results[2].locations[0].physicalLocation.region.startLine, 18);
+            assert.isUndefined(log.runs[0].results[2].locations[0].physicalLocation.region.startColumn);
+            assert.isUndefined(log.runs[0].results[2].locations[0].physicalLocation.region.snippet);
         });
     });
 });
@@ -349,44 +375,44 @@ describe("formatter:sarif", () => {
         }];
 
         it("should return a log with two files, two rules, and two results", () => {
-            const result = JSON.parse(formatter(code, { rulesMeta: rules }));
+            const log = JSON.parse(formatter(code, { rulesMeta: rules }));
             const rule2 = rules[ruleid2];
             const rule3 = rules[ruleid3];
 
-            assert.lengthOf(result.runs[0].artifacts, 2);
-            assert.lengthOf(result.runs[0].results, 2);
+            assert.lengthOf(log.runs[0].artifacts, 2);
+            assert.lengthOf(log.runs[0].results, 2);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].id, ruleid2);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].id, ruleid3);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].id, ruleid2);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].id, ruleid3);
 
-            assert.strictEqual(result.runs[0].artifacts[0].location.uri, sourceFilePath1);
-            assert.strictEqual(result.runs[0].artifacts[1].location.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].artifacts[0].location.uri, sourceFilePath1);
+            assert.strictEqual(log.runs[0].artifacts[1].location.uri, sourceFilePath2);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].id, ruleid2);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].shortDescription.text, rule2.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].helpUri, rule2.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[0].tags.category, rule2.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].id, ruleid2);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].shortDescription.text, rule2.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].helpUri, rule2.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[0].properties.category, rule2.docs.category);
 
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].id, ruleid3);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].shortDescription.text, rule3.docs.description);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].helpUri, rule3.docs.url);
-            assert.strictEqual(result.runs[0].tool.driver.rules[1].tags.category, rule3.docs.category);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].id, ruleid3);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].shortDescription.text, rule3.docs.description);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].helpUri, rule3.docs.url);
+            assert.strictEqual(log.runs[0].tool.driver.rules[1].properties.category, rule3.docs.category);
 
-            assert.strictEqual(result.runs[0].results[0].ruleId, ruleid2);
-            assert.strictEqual(result.runs[0].results[1].ruleId, ruleid3);
+            assert.strictEqual(log.runs[0].results[0].ruleId, ruleid2);
+            assert.strictEqual(log.runs[0].results[1].ruleId, ruleid3);
 
-            assert.strictEqual(result.runs[0].results[0].level, "error");
-            assert.strictEqual(result.runs[0].results[1].level, "warning");
+            assert.strictEqual(log.runs[0].results[0].level, "error");
+            assert.strictEqual(log.runs[0].results[1].level, "warning");
 
-            assert.strictEqual(result.runs[0].results[0].message.text, "Unexpected something.");
-            assert.strictEqual(result.runs[0].results[1].message.text, "Custom error.");
+            assert.strictEqual(log.runs[0].results[0].message.text, "Unexpected something.");
+            assert.strictEqual(log.runs[0].results[1].message.text, "Custom error.");
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
-            assert.strictEqual(result.runs[0].results[1].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
+            assert.strictEqual(log.runs[0].results[1].locations[0].physicalLocation.artifactLocation.uri, sourceFilePath2);
 
-            assert.strictEqual(result.runs[0].results[0].locations[0].physicalLocation.region.startLine, 18);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
-            assert.isUndefined(result.runs[0].results[0].locations[0].physicalLocation.region.snippet);
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, 18);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.snippet);
         });
     });
 });


### PR DESCRIPTION
- Bring `$schema` up to date.
- Populate `result.ruleIndex` when metadata is available.
- Populate `result.locations[i].physicalLocation.artifactLocation.index`.
- Rule metadata `tags` should be `properties`.
- The appropriate tool component URI here is `informationUri`, not `downloadUri`.