### PR TITLE
Fix #1680 (regex perf in WebRequest.TryParse) by avoiding backtracking.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -425,3 +425,6 @@
 ## **v2.1.9** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.9) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.9) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.9) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.9)
 * FEATURE: add --remove switch to eliminate certain properties (currently timestamps only) from log file output.
 * BUGFIX: remove verbose 'Analyzing file..' reporting for drivers.
+
+## **v2.1.10** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.10) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.10) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.10) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.10)
+* BUGFIX: Resolve a performance issue in web request parsing code. https://github.com/microsoft/sarif-sdk/issues/1608

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -114,13 +114,13 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         const string QueryPattern =
             @"^
-              \?                              # A literal '?', followed by zero or more
+              \?                                # A literal '?', followed by zero or more
               (?<query>
                 (
-                  (?<name>[^=]+)                # parameter name (everything that's not an = sign),
+                  (?>(?<name>[^=]+))            # parameter name (everything that's not an = sign),
                   =                             # an equal sign, and
                   (
-                    (?<value>[^&]*)             # the value (everything that's not an '&')...
+                    (?>(?<value>[^&]*))         # the value (everything that's not an '&')...
                     &?                          # and an '&' (except after the last one).
                   )
                 )*

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -210,10 +210,10 @@ Cookie: ARRAffinity=somecode; .AspNet.Cookies=somecode
 ";
             Action action = () => WebRequest.TryParse(RequestString, out _);
 
-            // On my machine this takes about 7 msec. We leave a 5x safety factor. This is still
+            // On my machine this takes about 7 msec. We leave a 10x safety factor. This is still
             // too long, but it should provide acceptable performance, and we can pursue further
             // optimizations later if necessary.
-            action.ExecutionTime().Should().BeLessOrEqualTo(35.Milliseconds());
+            action.ExecutionTime().Should().BeLessOrEqualTo(70.Milliseconds());
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;
 
@@ -183,6 +184,28 @@ User-Agent: my-agent
 
             succeeded.Should().BeFalse();
             webRequest.Should().BeNull();
+        }
+
+        [Fact]
+        public void WebRequest_TryParse_HasAcceptablePerformance()
+        {
+            const string RequestString = @"GET /getSomethings?FirstName=test&LastName=test&AddressLine1=555%20110th%20Ave%20NE&City=Bellevue&Country=USA&PostalCode=98004&EmailAddress=test@somedomain.com&BusinessPhone=12345678901&MobilePhone=1234567890&AddressLine2=&AddressLine3 HTTP/1.1
+Host: kdkdkdkd.azurewebsites.net
+Connection: keep-alive
+Cache-Control: max-age=0
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3
+Referer: https://login.somedomain.com/77777777777777777777/oauth2/authorize?client_id=7777&response_mode=form_post&response_type=code+id_token&scope=openid+profile&state=somestate
+Accept-Encoding: gzip, deflate, br
+Accept-Language: en-US,en;q=0.9
+Cookie: ARRAffinity=somecode; .AspNet.Cookies=somecode
+
+";
+            Action action = () => WebRequest.TryParse(RequestString, out _);
+
+            // On my machine this takes about 7 msec. Leaving a 5x safety factor.
+            action.ExecutionTime().Should().BeLessOrEqualTo(35.Milliseconds());
         }
     }
 }

--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.9</VersionPrefix>
+    <VersionPrefix>2.1.10</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -30,7 +30,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.8</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.9</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>


### PR DESCRIPTION
The bug was exposed by an actual web request which left the `=` sign off of the last in a long list of query parameters:
```
/getSomething?firstName=John&lastName=Smith&...&Address2=&Address3
```
Because our regex for query parameters expects an `=` after each query parameter name, the lack of the final `=` caused the engine to backtrack all the way to the beginning. By turning off backtracking within the individual parameter names and values, and by eliminating an unnecessary alternation, we minimize the number of states the engine has to save.