### PR TITLE
Fix #1581 Handle null property value during deserialization

### DIFF
--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -100,8 +100,25 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             SerializedPropertyInfo propValue = Properties[propertyName];
+            if (propValue == null)
+            {
+                if (typeof(T).IsValueType)
+                {
+                    throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            SdkResources.PropertyOfValueTypeCannotBeNull,
+                            propertyName,
+                            typeof(T).FullName));
+                }
 
-            return propValue == null ? default : JsonConvert.DeserializeObject<T>(propValue.SerializedValue);
+                // This will return null for reference types. Could not set null here b/c T could be a value type as well.
+                return default;
+            }
+            else
+            {
+                return JsonConvert.DeserializeObject<T>(propValue.SerializedValue);
+            }
         }
 
         public bool TryGetSerializedPropertyValue(string propertyName, out string serializedValue)

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -99,7 +99,9 @@ namespace Microsoft.CodeAnalysis.Sarif
                         propertyName));
             }
 
-            return JsonConvert.DeserializeObject<T>(Properties[propertyName].SerializedValue);
+            SerializedPropertyInfo propValue = Properties[propertyName];
+
+            return propValue == null ? default : JsonConvert.DeserializeObject<T>(propValue.SerializedValue);
         }
 
         public bool TryGetSerializedPropertyValue(string propertyName, out string serializedValue)

--- a/src/Sarif/Readers/PropertyBagConverter.cs
+++ b/src/Sarif/Readers/PropertyBagConverter.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 }
                 else
                 {
-                    writer.WriteRawValue(propertyDictionary[key].SerializedValue ?? "null");
+                    writer.WriteRawValue(propertyDictionary[key].SerializedValue);
                 }
             }
 

--- a/src/Sarif/Readers/PropertyBagConverter.cs
+++ b/src/Sarif/Readers/PropertyBagConverter.cs
@@ -35,9 +35,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             foreach (string key in objectDictionary.Keys)
             {
                 object value = objectDictionary[key];
-                Type propertyType = value.GetType();
+                Type propertyType = value?.GetType();
 
-                string serializedValue = value.ToString();
+                string serializedValue = value?.ToString();
                 bool isString = false;
 
                 if (propertyType == typeof(bool))
@@ -50,9 +50,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                     isString = true;
                 }
 
-                propertyDictionary.Add(
-                    key,
-                    new SerializedPropertyInfo(serializedValue, isString));
+                SerializedPropertyInfo propInfo = value == null ? null : new SerializedPropertyInfo(serializedValue, isString);
+
+                propertyDictionary.Add(key, propInfo);
             }
 
             return propertyDictionary;
@@ -70,7 +70,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             foreach (string key in propertyDictionary.Keys)
             {
                 writer.WritePropertyName(key);
-                writer.WriteRawValue(propertyDictionary[key].SerializedValue);
+                string valueToSerialize = propertyDictionary[key]?.SerializedValue;
+
+                if (valueToSerialize == null)
+                {
+                    writer.WriteNull();
+                }
+                else
+                {
+                    writer.WriteRawValue(propertyDictionary[key].SerializedValue ?? "null");
+                }
             }
 
             writer.WriteEndObject();

--- a/src/Sarif/SdkResources.Designer.cs
+++ b/src/Sarif/SdkResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SdkResources {
@@ -345,6 +345,15 @@ namespace Microsoft.CodeAnalysis.Sarif {
         internal static string PropertyDoesNotExist {
             get {
                 return ResourceManager.GetString("PropertyDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The property bag contains a property {0} with the value null. It cannot be converted to the value type {1}..
+        /// </summary>
+        internal static string PropertyOfValueTypeCannotBeNull {
+            get {
+                return ResourceManager.GetString("PropertyOfValueTypeCannotBeNull", resourceCulture);
             }
         }
         

--- a/src/Sarif/SdkResources.resx
+++ b/src/Sarif/SdkResources.resx
@@ -213,6 +213,9 @@
   <data name="PropertyDoesNotExist" xml:space="preserve">
     <value>Property '{0}' does not exist. Consider calling TryGetProperty instead.</value>
   </data>
+  <data name="PropertyOfValueTypeCannotBeNull" xml:space="preserve">
+    <value>The property bag contains a property {0} with the value null. It cannot be converted to the value type {1}.</value>
+  </data>
   <data name="ResultRuleIdDoesNotMatchRule" xml:space="preserve">
     <value>The rule id '{0}' specified by the result does not match the actual id of the rule '{1}'</value>
   </data>

--- a/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
         [Fact]
         [Trait(TestTraits.Bug, "1581")]
-        public void PropertyBagConverter_RoundTripsNullValue()
+        public void PropertyBagConverter_RoundTripsNullValueForReferenceType()
         {
             _input = "{\"properties\":{\"a\":null}}";
 
@@ -121,6 +121,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             _inputObject.GetProperty<string>("a").Should().BeNull();
             _roundTrippedObject.GetProperty<string>("a").Should().BeNull();
+        }
+
+        [Fact]
+        [Trait(TestTraits.Bug, "1581")]
+        public void PropertyBagConverter_RoundTripsNullValueForValueType()
+        {
+            _input = "{\"properties\":{\"a\":null}}";
+
+            PerformRoundTrip();
+
+            Assert.Throws<InvalidOperationException>(() => _inputObject.GetProperty<int>("a"));
+            Assert.Throws<InvalidOperationException>(() => _roundTrippedObject.GetProperty<int>("a"));
         }
 
         public class ObjectClass

--- a/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
@@ -131,8 +131,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
 
             PerformRoundTrip();
 
-            Assert.Throws<InvalidOperationException>(() => _inputObject.GetProperty<int>("a"));
-            Assert.Throws<InvalidOperationException>(() => _roundTrippedObject.GetProperty<int>("a"));
+            Action action = () => _inputObject.GetProperty<int>("a");
+            action.Should().Throw<InvalidOperationException>();
+
+            action = () => _roundTrippedObject.GetProperty<int>("a");
+            action.Should().Throw <InvalidOperationException>();
         }
 
         public class ObjectClass

--- a/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
@@ -111,6 +111,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             _roundTrippedObject.GetProperty<Guid>("g").Should().Be(expectedGuid);
         }
 
+        [Fact]
+        [Trait(TestTraits.Bug, "1487")]
+        public void PropertyBagConverter_RoundTripsNullValue()
+        {
+            _input = "{\"properties\":{\"a\":null}}";
+
+            PerformRoundTrip();
+
+            _inputObject.GetProperty<string>("a").Should().BeNull();
+            _roundTrippedObject.GetProperty<string>("a").Should().BeNull();
+        }
+
         public class ObjectClass
         {
             public int One { get; set; }

--- a/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/PropertyBagConverterTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         }
 
         [Fact]
-        [Trait(TestTraits.Bug, "1487")]
+        [Trait(TestTraits.Bug, "1581")]
         public void PropertyBagConverter_RoundTripsNullValue()
         {
             _input = "{\"properties\":{\"a\":null}}";


### PR DESCRIPTION
Address #1581 by adding GetProperty<T> support for null and handling null values for properties during deserialization using PropertyBagConverter.