### PR TITLE
Fix #1632: UriConverter crashes with NullReferenceException on empty URI

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -437,3 +437,4 @@
 
 ## **v2.1.13** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.13) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.13) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.13) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.13)
 * BUGFIX: Respect the --force option in Sarif.Multitool rather than overwriting the output file. https://github.com/microsoft/sarif-sdk/issues/1304
+* BUGFIX: Accept URI-valued properties whose value is the empty string. https://github.com/microsoft/sarif-sdk/issues/1632

--- a/src/Sarif/UriHelper.cs
+++ b/src/Sarif/UriHelper.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </remarks>
         public static string MakeValidUri(string path)
         {
-            if (string.IsNullOrEmpty(path))
+            if (path == null)
             {
                 throw new ArgumentNullException(nameof(path));
             }

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -17,6 +17,7 @@
     <None Remove="TestData\Baseline\elfie-arriba.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
+    <None Remove="TestData\JsonConverters\UriConverterTests.json" />
     <None Remove="TestData\Map\Sample.json" />
     <None Remove="TestData\Map\TinyArray.json" />
     <None Remove="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\ArtifactsWithRoles.sarif" />
@@ -67,6 +68,7 @@
     <EmbeddedResource Include="TestData\Baseline\SuppressionTestPrevious.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\ExpectedOutputs\TopLevelOriginalUriBaseIdUriMissing_ContextRegionSnippets.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\Inputs\TopLevelOriginalUriBaseIdUriMissing.sarif" />
+    <EmbeddedResource Include="TestData\JsonConverters\UriConverterTests.json" />
     <EmbeddedResource Include="TestData\Map\TinyArray.json">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/src/Test.UnitTests.Sarif/TestData/JsonConverters/UriConverterTests.json
+++ b/src/Test.UnitTests.Sarif/TestData/JsonConverters/UriConverterTests.json
@@ -1,0 +1,9 @@
+﻿{
+  "nonEmptyUri": "https://www.example.com/rules/TST0001.html",
+  "emptyUri": "",
+  "emptyUriList": [],
+  "nonEmptyUriList": [
+    "https://www.example.com/page1",
+    "https://www.example.com/page2"
+  ]
+}

--- a/src/Test.UnitTests.Sarif/UriConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/UriConverterTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         }
 
         [Fact]
+        [Trait(TestTraits.Bug, "1632")]
         public void WriteJson_ConvertsUriObjectsToStrings()
         {
             var testObject = new TestClass

--- a/src/Test.UnitTests.Sarif/UriConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/UriConverterTests.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
         private static readonly ResourceExtractor s_resourceExtractor = new ResourceExtractor(typeof(UriConverterTests));
         private static readonly string s_testFileText = s_resourceExtractor.GetResourceText("JsonConverters.UriConverterTests.json");
 
-
         [DataContract]
         private class TestClass
         {

--- a/src/Test.UnitTests.Sarif/UriConverterTests.cs
+++ b/src/Test.UnitTests.Sarif/UriConverterTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
+{
+    public class UriConverterTests
+    {
+        private static readonly ResourceExtractor s_resourceExtractor = new ResourceExtractor(typeof(UriConverterTests));
+        private static readonly string s_testFileText = s_resourceExtractor.GetResourceText("JsonConverters.UriConverterTests.json");
+
+
+        [DataContract]
+        private class TestClass
+        {
+            [DataMember(Name = "nonEmptyUri", IsRequired = false, EmitDefaultValue = false)]
+            [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.UriConverter))]
+            public Uri NonEmptyUri { get; set; }
+
+            [DataMember(Name = "emptyUri", IsRequired = false, EmitDefaultValue = false)]
+            [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.UriConverter))]
+            public Uri EmptyUri { get; set; }
+
+            [DataMember(Name = "emptyUriList", IsRequired = false, EmitDefaultValue = false)]
+            [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.UriConverter))]
+            public IList<Uri> EmptyUriList { get; set; }
+
+            [DataMember(Name = "nonEmptyUriList", IsRequired = false, EmitDefaultValue = false)]
+            [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.UriConverter))]
+            public IList<Uri> NonEmptyUriList { get; set; }
+        }
+
+        [Fact]
+        [Trait(TestTraits.Bug, "1632")]
+        public void ReadJson_ConvertsStringsToUriObjects()
+        {
+            TestClass testObject = JsonConvert.DeserializeObject<TestClass>(s_testFileText);
+
+            testObject.NonEmptyUri.OriginalString.Should().Be("https://www.example.com/rules/TST0001.html");
+            testObject.EmptyUri.OriginalString.Should().BeEmpty();
+            testObject.EmptyUriList.Should().BeEmpty();
+            testObject.NonEmptyUriList.Count().Should().Be(2);
+            testObject.NonEmptyUriList.Select(uri => uri.OriginalString).Should().ContainInOrder(
+                "https://www.example.com/page1",
+                "https://www.example.com/page2");
+        }
+
+        [Fact]
+        public void WriteJson_ConvertsUriObjectsToStrings()
+        {
+            var testObject = new TestClass
+            {
+                EmptyUri = new Uri(string.Empty, UriKind.RelativeOrAbsolute),
+                NonEmptyUri = new Uri("https://www.example.com/rules/TST0001.html"),
+                EmptyUriList = new List<Uri>(),
+                NonEmptyUriList = new List<Uri>
+                {
+                    new Uri("https://www.example.com/page1"),
+                    new Uri("https://www.example.com/page2")
+                }
+            };
+
+            var settings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+                DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate
+            };
+
+            JsonConvert.SerializeObject(testObject, settings).Should().Be(s_testFileText);
+        }
+    }
+}


### PR DESCRIPTION
The empty string is a valid relative URI although not a valid absolute URI (per RFC 3986).

This bug causes a crash in the Visual Studio Viewer VSIX (Microsoft/sarif-visualstudio-extension#85), to please review promptly so I can publish a NuGet and update the VSIX with it.