### PR TITLE
Fix #1592: Merge command returns invalid SARIF if there are 0 input files.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -448,6 +448,7 @@
 * BUGFIX: Validation rule `SARIF1015` incorrectly required `originalUriBaseIds` to be contain URIs. https://github.com/microsoft/sarif-sdk/issues/1485
 * BUGFIX: Multitool transform mishandled dottedQuadFileVersion. https://github.com/microsoft/sarif-sdk/issues/1532
 * BUGFIX: Restore missing FxCop converter unit test. https://github.com/microsoft/sarif-sdk/issues/1575
+* BUGFIX: Multitool merge command produced invalid SARIF if there were 0 input files. https://github.com/microsoft/sarif-sdk/issues/1592
 * BUGFIX: FortifyFpr converter produced invalid SARIF. https://github.com/microsoft/sarif-sdk/issues/1593
 * BUGFIX: FxCop converter produced empty `result.message` objects. https://github.com/microsoft/sarif-sdk/issues/1594
 * FEATURE: Add validation rule to ensure correctness of `originalUriBaseIds` entries.

--- a/src/Sarif.Multitool/MergeCommand.cs
+++ b/src/Sarif.Multitool/MergeCommand.cs
@@ -38,6 +38,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
 
                 // Build one SarifLog with all the Runs.
                 SarifLog combinedLog = allRuns.Merge();
+
+                // If there were no input files, the Merge operation set combinedLog.Runs to null. Although
+                // null is valid in certain error cases, it is not valid here. Here, the correct value is
+                // an empty list. See the SARIF spec, §3.13.4, "runs property".
+                combinedLog.Runs = combinedLog.Runs ?? new List<Run>();
+
                 combinedLog.Version = SarifVersion.Current;
                 combinedLog.SchemaUri = combinedLog.Version.ConvertToSchemaUri();
 

--- a/src/Test.UnitTests.Sarif.Multitool/MergeCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool/MergeCommandTests.cs
@@ -45,11 +45,16 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Multitool
             string outputFilePath = Path.Combine(OutputFolderPath, outputFileName);
 
             var mockFileSystem = new Mock<IFileSystem>();
+
+            // We mock the file system to fake out the read operations.
             mockFileSystem.Setup(x => x.FileExists(outputFilePath)).Returns(false);
             mockFileSystem.Setup(x => x.DirectoryExists(InputFolderPath)).Returns(true);
             mockFileSystem.Setup(x => x.GetFilesInDirectory(InputFolderPath, inputResourceName)).Returns(new string[0]); // <= The hard-coded return value in question.
-            mockFileSystem.Setup(x => x.CreateDirectory(OutputFolderPath)).Returns(new DirectoryInfo(OutputFolderPath));
+
+            // But we really do want to create the output file, so tell the mock to execute the actual write operations.
+            mockFileSystem.Setup(x => x.CreateDirectory(OutputFolderPath)).Returns((string path) => { return Directory.CreateDirectory(path); });
             mockFileSystem.Setup(x => x.Create(outputFilePath)).Returns((string path) => { return File.Create(path); });
+
             IFileSystem fileSystem = mockFileSystem.Object;
 
             var options = new MergeOptions

--- a/src/Test.UnitTests.Sarif.Multitool/MergeCommandTests.cs
+++ b/src/Test.UnitTests.Sarif.Multitool/MergeCommandTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Multitool;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Multitool
+{
+    // WARNING: Because the merge command can accept zero, one, or many input files, it isn't well
+    // suited to the FileDiffingUnitTests base class, which assumes you have exactly one input
+    // file. We are using this base class because it has the infrastructure to write the "actual"
+    // and "expected" output files to disk if a test fails, and to provide you with a "diff"
+    // command line that you can use to compare the actual to the expected file contents.
+    //
+    // You will note that the override of ConstructTestOutputFromInputResource hard-codes the mock
+    // file system to return 0 files when GetFilesInDirectory is called. That is fine for the only
+    // existing test, which assumes there are no input files. But on the day we write a test that
+    // requires one or more input files, we'll have to address this. We will probably have to
+    // factor the output file writing and comparison infrastructure out of FileDiffingUnitTests.
+    // We might be able to push it into a lower base class.
+    public class MergeCommandTests : FileDiffingUnitTests
+    {
+        protected override string TestLogResourceNameRoot => "Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Multitool.TestData." + TypeUnderTest;
+
+        public MergeCommandTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+        [Fact]
+        public void MergeCommand_WhenThereAreNoInputFiles_ProducesEmptyRunsArray()
+        {
+            RunTest("NoInputFiles.sarif");
+        }
+
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName)
+        {
+            const string InputFolderPath = @"C:\input";
+            string targetFileSpecifier = Path.Combine(InputFolderPath, inputResourceName);
+
+            string outputFileName = Guid.NewGuid().ToString() + ".sarif";
+            string outputFilePath = Path.Combine(OutputFolderPath, outputFileName);
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(outputFilePath)).Returns(false);
+            mockFileSystem.Setup(x => x.DirectoryExists(InputFolderPath)).Returns(true);
+            mockFileSystem.Setup(x => x.GetFilesInDirectory(InputFolderPath, inputResourceName)).Returns(new string[0]); // <= The hard-coded return value in question.
+            mockFileSystem.Setup(x => x.CreateDirectory(OutputFolderPath)).Returns(new DirectoryInfo(OutputFolderPath));
+            mockFileSystem.Setup(x => x.Create(outputFilePath)).Returns((string path) => { return File.Create(path); });
+            IFileSystem fileSystem = mockFileSystem.Object;
+
+            var options = new MergeOptions
+            {
+                PrettyPrint = true,
+                OutputFolderPath = OutputFolderPath,
+                TargetFileSpecifiers = new[] { targetFileSpecifier },
+                OutputFileName = outputFileName
+            };
+
+            var mergeCommand = new MergeCommand(fileSystem);
+
+            int returnCode = mergeCommand.Run(options);
+            returnCode.Should().Be(0);
+
+            return File.ReadAllText(outputFilePath);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
+++ b/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
@@ -14,7 +14,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
-    <None Remove="TestData\MergeCommand\NoInputFiles.sarif" />
+    <None Remove="TestData\MergeCommand\ExpectedOutputs\NoInputFiles.sarif" />
     <None Remove="TestData\PageCommand\elfie-arriba - Copy.sarif" />
     <None Remove="TestData\PageCommand\elfie-arriba.sarif" />
     <None Remove="TestData\RebaseUriCommand\ExpectedOutputs\RunWithArtifacts.sarif" />

--- a/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
+++ b/src/Test.UnitTests.Sarif.Multitool/Test.UnitTests.Sarif.Multitool.csproj
@@ -14,6 +14,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
+    <None Remove="TestData\MergeCommand\NoInputFiles.sarif" />
     <None Remove="TestData\PageCommand\elfie-arriba - Copy.sarif" />
     <None Remove="TestData\PageCommand\elfie-arriba.sarif" />
     <None Remove="TestData\RebaseUriCommand\ExpectedOutputs\RunWithArtifacts.sarif" />
@@ -21,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestData\MergeCommand\ExpectedOutputs\NoInputFiles.sarif" />
     <EmbeddedResource Include="TestData\QueryCommand\elfie-arriba.CSCAN0020.sarif" />
     <EmbeddedResource Include="TestData\PageCommand\elfie-arriba.sarif" />
     <EmbeddedResource Include="TestData\RebaseUriCommand\ExpectedOutputs\RunWithArtifacts.sarif" />

--- a/src/Test.UnitTests.Sarif.Multitool/TestData/MergeCommand/ExpectedOutputs/NoInputFiles.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool/TestData/MergeCommand/ExpectedOutputs/NoInputFiles.sarif
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "version": "2.1.0",
+  "runs": []
+}


### PR DESCRIPTION
The product code fix is straightforward. To understand the _reason_ for the change, see the comment thread in #1592.

The test code looks similar to code you've seen before, but there is a subtlety, explained in a big WARNING comment. I don't think it's necessary to address this issue now, and possibly ever.