### PR TITLE
Work item filing extensions support release defs

### DIFF
--- a/src/Sarif.WorkItemFiling/Extensions.cs
+++ b/src/Sarif.WorkItemFiling/Extensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItemFiling
             string organization = artifactLocation.GetProperty("OrganizationName");
             string artifactId = artifactLocation.GetProperty<int>("ArtifactId").ToString();
             string projectName = artifactLocation.GetProperty("ProjectName");
-            string artifactType = artifactLocation.GetProperty("EntityType");
+            string artifactType = artifactLocation.GetProperty("ArtifactType");
 
             // BUG: GetProperty doesn't unencode string values
             string areaPath = $@"{workItemProjectName}" + artifactLocation.GetProperty("AreaPath").Replace(@"\\", @"\");


### PR DESCRIPTION
Updating work item filing extensions to support different artifact types such as release definitions, and not be as hard coded to build definitions.