### PR TITLE
Remove duplicative 'Analyzing file...' messages.

### DIFF
--- a/src/Sarif.Driver/DriverResources.Designer.cs
+++ b/src/Sarif.Driver/DriverResources.Designer.cs
@@ -97,15 +97,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Analyzing....
-        /// </summary>
-        internal static string MSG_Analyzing {
-            get {
-                return ResourceManager.GetString("MSG_Analyzing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Analysis halted prematurely due to a fatal execution condition..
         /// </summary>
         internal static string MSG_UnexpectedApplicationExit {

--- a/src/Sarif.Driver/DriverResources.resx
+++ b/src/Sarif.Driver/DriverResources.resx
@@ -129,9 +129,6 @@
   <data name="MSG_AnalysisIncomplete" xml:space="preserve">
     <value>Analysis finished but was not complete due to non-fatal runtime errors.</value>
   </data>
-  <data name="MSG_Analyzing" xml:space="preserve">
-    <value>Analyzing...</value>
-  </data>
   <data name="MSG_UnexpectedApplicationExit" xml:space="preserve">
     <value>Analysis halted prematurely due to a fatal execution condition.</value>
   </data>

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -596,13 +596,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             var context = CreateContext(options, rootContext.Logger, rootContext.RuntimeErrors, target);
             context.Policy = rootContext.Policy;
 
-            if (options.Verbose)
-            {
-                Console.WriteLine(string.Format(CultureInfo.CurrentCulture,
-                    @"Analyzing '{0}'...",
-                    context.TargetUri.GetFileName()));
-            }
-
             if (options.ComputeFileHashes)
             {
                 _resultsCachingLogger.HashToResultsMap.TryGetValue(context.Hashes.Sha256, out List<Tuple<ReportingDescriptor, Result>> cachedResultTuples);
@@ -766,16 +759,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
                 switch (applicability)
                 {
                     case AnalysisApplicability.NotApplicableToSpecifiedTarget:
-                        {
-                            Notes.LogNotApplicableToSpecifiedTarget(context, reasonForNotAnalyzing);
-                            break;
-                        }
+                    {
+                        Notes.LogNotApplicableToSpecifiedTarget(context, reasonForNotAnalyzing);
+                        break;
+                    }
 
                     case AnalysisApplicability.ApplicableToSpecifiedTarget:
-                        {
-                            candidateSkimmers.Add(skimmer);
-                            break;
-                        }
+                    {
+                        candidateSkimmers.Add(skimmer);
+                        break;
+                    }
                 }
             }
             return candidateSkimmers;

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void AnalysisStarted()
         {
+            WriteLineToConsole(SdkResources.MSG_Analyzing);
         }
 
         public void AnalysisStopped(RuntimeConditions runtimeConditions)

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void AnalysisStarted()
         {
-            WriteLineToConsole(SdkResources.MSG_Analyzing);
         }
 
         public void AnalysisStopped(RuntimeConditions runtimeConditions)


### PR DESCRIPTION
@lgolding 

Noticed that we've somehow introduced duplicative 'Analyzing blah...' messages (with verbose mode enabled). Now that ConsoleLogger is the only place where this occurs.