### PR TITLE
Emit all core object model members as virtual.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -3,6 +3,7 @@
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * FEATURE: Introduce SarifConsolidator to shrink large log files. https://github.com/microsoft/sarif-sdk/issues/1675
 * BUGFIX: Analysis rule SARIF1017 incorrectly rejected index-valued properties that referred to taxonomies. https://github.com/microsoft/sarif-sdk/issues/1678
+* API NON-BREAKING: emit all core object model members as 'virtual'
 
 ## **v2.1.16** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.16) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.16) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.16) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.16)
 * BUGFIX, BREAKING: In the Multitool `page` command, the default for `--force` was `true` and it could not be changed. https://github.com/microsoft/sarif-sdk/issues/1630

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -3,7 +3,7 @@
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * FEATURE: Introduce SarifConsolidator to shrink large log files. https://github.com/microsoft/sarif-sdk/issues/1675
 * BUGFIX: Analysis rule SARIF1017 incorrectly rejected index-valued properties that referred to taxonomies. https://github.com/microsoft/sarif-sdk/issues/1678
-* API NON-BREAKING: emit all core object model members as 'virtual'
+* API NON-BREAKING: emit all core object model members as 'virtual'.
 
 ## **v2.1.16** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.16) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.16) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.16) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.16)
 * BUGFIX, BREAKING: In the Multitool `page` command, the default for `--force` was `true` and it could not be changed. https://github.com/microsoft/sarif-sdk/issues/1630

--- a/src/Sarif/Autogenerated/Artifact.cs
+++ b/src/Sarif/Autogenerated/Artifact.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,13 +38,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A short description of the artifact.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// The location of the artifact.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactLocation Location { get; set; }
+        public virtual ArtifactLocation Location { get; set; }
 
         /// <summary>
         /// Identifies the index of the immediate parent of the artifact, if this artifact is nested.
@@ -52,13 +52,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "parentIndex", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ParentIndex { get; set; }
+        public virtual int ParentIndex { get; set; }
 
         /// <summary>
         /// The offset in bytes of the artifact within its containing artifact.
         /// </summary>
         [DataMember(Name = "offset", IsRequired = false, EmitDefaultValue = false)]
-        public int Offset { get; set; }
+        public virtual int Offset { get; set; }
 
         /// <summary>
         /// The length of the artifact in bytes.
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "length", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Length { get; set; }
+        public virtual int Length { get; set; }
 
         /// <summary>
         /// The role or roles played by the artifact in the analysis.
@@ -74,44 +74,44 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "roles", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(FlagsEnumConverter))]
-        public ArtifactRoles Roles { get; set; }
+        public virtual ArtifactRoles Roles { get; set; }
 
         /// <summary>
         /// The MIME type (RFC 2045) of the artifact.
         /// </summary>
         [DataMember(Name = "mimeType", IsRequired = false, EmitDefaultValue = false)]
-        public string MimeType { get; set; }
+        public virtual string MimeType { get; set; }
 
         /// <summary>
         /// The contents of the artifact.
         /// </summary>
         [DataMember(Name = "contents", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactContent Contents { get; set; }
+        public virtual ArtifactContent Contents { get; set; }
 
         /// <summary>
         /// Specifies the encoding for an artifact object that refers to a text file.
         /// </summary>
         [DataMember(Name = "encoding", IsRequired = false, EmitDefaultValue = false)]
-        public string Encoding { get; set; }
+        public virtual string Encoding { get; set; }
 
         /// <summary>
         /// Specifies the source language for any artifact object that refers to a text file that contains source code.
         /// </summary>
         [DataMember(Name = "sourceLanguage", IsRequired = false, EmitDefaultValue = false)]
-        public string SourceLanguage { get; set; }
+        public virtual string SourceLanguage { get; set; }
 
         /// <summary>
         /// A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.
         /// </summary>
         [DataMember(Name = "hashes", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, string> Hashes { get; set; }
+        public virtual IDictionary<string, string> Hashes { get; set; }
 
         /// <summary>
         /// The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "lastModifiedTimeUtc", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
-        public DateTime LastModifiedTimeUtc { get; set; }
+        public virtual DateTime LastModifiedTimeUtc { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the artifact.
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Artifact DeepClone()
+        public virtual Artifact DeepClone()
         {
             return (Artifact)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ArtifactChange.cs
+++ b/src/Sarif/Autogenerated/ArtifactChange.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The location of the artifact to change.
         /// </summary>
         [DataMember(Name = "artifactLocation", IsRequired = true)]
-        public ArtifactLocation ArtifactLocation { get; set; }
+        public virtual ArtifactLocation ArtifactLocation { get; set; }
 
         /// <summary>
         /// An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.
         /// </summary>
         [DataMember(Name = "replacements", IsRequired = true)]
-        public IList<Replacement> Replacements { get; set; }
+        public virtual IList<Replacement> Replacements { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the change.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ArtifactChange DeepClone()
+        public virtual ArtifactChange DeepClone()
         {
             return (ArtifactChange)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ArtifactContent.cs
+++ b/src/Sarif/Autogenerated/ArtifactContent.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,19 +36,19 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// UTF-8-encoded content from a text artifact.
         /// </summary>
         [DataMember(Name = "text", IsRequired = false, EmitDefaultValue = false)]
-        public string Text { get; set; }
+        public virtual string Text { get; set; }
 
         /// <summary>
         /// MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.
         /// </summary>
         [DataMember(Name = "binary", IsRequired = false, EmitDefaultValue = false)]
-        public string Binary { get; set; }
+        public virtual string Binary { get; set; }
 
         /// <summary>
         /// An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region).
         /// </summary>
         [DataMember(Name = "rendered", IsRequired = false, EmitDefaultValue = false)]
-        public MultiformatMessageString Rendered { get; set; }
+        public virtual MultiformatMessageString Rendered { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the artifact content.
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ArtifactContent DeepClone()
+        public virtual ArtifactContent DeepClone()
         {
             return (ArtifactContent)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ArtifactLocation.cs
+++ b/src/Sarif/Autogenerated/ArtifactLocation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -39,13 +39,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         [DataMember(Name = "uri", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.UriConverter))]
-        public Uri Uri { get; set; }
+        public virtual Uri Uri { get; set; }
 
         /// <summary>
         /// A string which indirectly specifies the absolute URI with respect to which a relative URI in the "uri" property is interpreted.
         /// </summary>
         [DataMember(Name = "uriBaseId", IsRequired = false, EmitDefaultValue = false)]
-        public string UriBaseId { get; set; }
+        public virtual string UriBaseId { get; set; }
 
         /// <summary>
         /// The index within the run artifacts array of the artifact object associated with the artifact location.
@@ -53,13 +53,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// A short description of the artifact location.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the artifact location.
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ArtifactLocation DeepClone()
+        public virtual ArtifactLocation DeepClone()
         {
             return (ArtifactLocation)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Attachment.cs
+++ b/src/Sarif/Autogenerated/Attachment.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,27 +37,27 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A message describing the role played by the attachment.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// The location of the attachment.
         /// </summary>
         [DataMember(Name = "artifactLocation", IsRequired = true)]
-        public ArtifactLocation ArtifactLocation { get; set; }
+        public virtual ArtifactLocation ArtifactLocation { get; set; }
 
         /// <summary>
         /// An array of regions of interest within the attachment.
         /// </summary>
         [DataMember(Name = "regions", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Region> Regions { get; set; }
+        public virtual IList<Region> Regions { get; set; }
 
         /// <summary>
         /// An array of rectangles specifying areas of interest within the image.
         /// </summary>
         [DataMember(Name = "rectangles", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Rectangle> Rectangles { get; set; }
+        public virtual IList<Rectangle> Rectangles { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the attachment.
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Attachment DeepClone()
+        public virtual Attachment DeepClone()
         {
             return (Attachment)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/CodeFlow.cs
+++ b/src/Sarif/Autogenerated/CodeFlow.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A message relevant to the code flow.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.
         /// </summary>
         [DataMember(Name = "threadFlows", IsRequired = true)]
-        public IList<ThreadFlow> ThreadFlows { get; set; }
+        public virtual IList<ThreadFlow> ThreadFlows { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the code flow.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public CodeFlow DeepClone()
+        public virtual CodeFlow DeepClone()
         {
             return (CodeFlow)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ConfigurationOverride.cs
+++ b/src/Sarif/Autogenerated/ConfigurationOverride.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Specifies how the rule or notification was configured during the scan.
         /// </summary>
         [DataMember(Name = "configuration", IsRequired = true)]
-        public ReportingConfiguration Configuration { get; set; }
+        public virtual ReportingConfiguration Configuration { get; set; }
 
         /// <summary>
         /// A reference used to locate the descriptor whose configuration was overridden.
         /// </summary>
         [DataMember(Name = "descriptor", IsRequired = true)]
-        public ReportingDescriptorReference Descriptor { get; set; }
+        public virtual ReportingDescriptorReference Descriptor { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the configuration override.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ConfigurationOverride DeepClone()
+        public virtual ConfigurationOverride DeepClone()
         {
             return (ConfigurationOverride)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Conversion.cs
+++ b/src/Sarif/Autogenerated/Conversion.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,20 +37,20 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A tool object that describes the converter.
         /// </summary>
         [DataMember(Name = "tool", IsRequired = true)]
-        public Tool Tool { get; set; }
+        public virtual Tool Tool { get; set; }
 
         /// <summary>
         /// An invocation object that describes the invocation of the converter.
         /// </summary>
         [DataMember(Name = "invocation", IsRequired = false, EmitDefaultValue = false)]
-        public Invocation Invocation { get; set; }
+        public virtual Invocation Invocation { get; set; }
 
         /// <summary>
         /// The locations of the analysis tool's per-run log files.
         /// </summary>
         [DataMember(Name = "analysisToolLogFiles", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ArtifactLocation> AnalysisToolLogFiles { get; set; }
+        public virtual IList<ArtifactLocation> AnalysisToolLogFiles { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the conversion.
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Conversion DeepClone()
+        public virtual Conversion DeepClone()
         {
             return (Conversion)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Edge.cs
+++ b/src/Sarif/Autogenerated/Edge.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,25 +36,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A string that uniquely identifies the edge within its graph.
         /// </summary>
         [DataMember(Name = "id", IsRequired = true)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// A short description of the edge.
         /// </summary>
         [DataMember(Name = "label", IsRequired = false, EmitDefaultValue = false)]
-        public Message Label { get; set; }
+        public virtual Message Label { get; set; }
 
         /// <summary>
         /// Identifies the source node (the node at which the edge starts).
         /// </summary>
         [DataMember(Name = "sourceNodeId", IsRequired = true)]
-        public string SourceNodeId { get; set; }
+        public virtual string SourceNodeId { get; set; }
 
         /// <summary>
         /// Identifies the target node (the node at which the edge ends).
         /// </summary>
         [DataMember(Name = "targetNodeId", IsRequired = true)]
-        public string TargetNodeId { get; set; }
+        public virtual string TargetNodeId { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the edge.
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Edge DeepClone()
+        public virtual Edge DeepClone()
         {
             return (Edge)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/EdgeTraversal.cs
+++ b/src/Sarif/Autogenerated/EdgeTraversal.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,25 +36,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Identifies the edge being traversed.
         /// </summary>
         [DataMember(Name = "edgeId", IsRequired = true)]
-        public string EdgeId { get; set; }
+        public virtual string EdgeId { get; set; }
 
         /// <summary>
         /// A message to display to the user as the edge is traversed.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// The values of relevant expressions after the edge has been traversed.
         /// </summary>
         [DataMember(Name = "finalState", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, MultiformatMessageString> FinalState { get; set; }
+        public virtual IDictionary<string, MultiformatMessageString> FinalState { get; set; }
 
         /// <summary>
         /// The number of edge traversals necessary to return from a nested graph.
         /// </summary>
         [DataMember(Name = "stepOverEdgeCount", IsRequired = false, EmitDefaultValue = false)]
-        public int StepOverEdgeCount { get; set; }
+        public virtual int StepOverEdgeCount { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the edge traversal.
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public EdgeTraversal DeepClone()
+        public virtual EdgeTraversal DeepClone()
         {
             return (EdgeTraversal)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ExceptionData.cs
+++ b/src/Sarif/Autogenerated/ExceptionData.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,26 +37,26 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal.
         /// </summary>
         [DataMember(Name = "kind", IsRequired = false, EmitDefaultValue = false)]
-        public string Kind { get; set; }
+        public virtual string Kind { get; set; }
 
         /// <summary>
         /// A message that describes the exception.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public string Message { get; set; }
+        public virtual string Message { get; set; }
 
         /// <summary>
         /// The sequence of function calls leading to the exception.
         /// </summary>
         [DataMember(Name = "stack", IsRequired = false, EmitDefaultValue = false)]
-        public Stack Stack { get; set; }
+        public virtual Stack Stack { get; set; }
 
         /// <summary>
         /// An array of exception objects each of which is considered a cause of this exception.
         /// </summary>
         [DataMember(Name = "innerExceptions", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExceptionData> InnerExceptions { get; set; }
+        public virtual IList<ExceptionData> InnerExceptions { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the exception.
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ExceptionData DeepClone()
+        public virtual ExceptionData DeepClone()
         {
             return (ExceptionData)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ExternalProperties.cs
+++ b/src/Sarif/Autogenerated/ExternalProperties.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,134 +37,134 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The URI of the JSON schema corresponding to the version of the external property file format.
         /// </summary>
         [DataMember(Name = "schema", IsRequired = false, EmitDefaultValue = false)]
-        public Uri Schema { get; set; }
+        public virtual Uri Schema { get; set; }
 
         /// <summary>
         /// The SARIF format version of this external properties object.
         /// </summary>
         [DataMember(Name = "version", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.SarifVersionConverter))]
-        public SarifVersion Version { get; set; }
+        public virtual SarifVersion Version { get; set; }
 
         /// <summary>
         /// A stable, unique identifer for this external properties object, in the form of a GUID.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// A stable, unique identifer for the run associated with this external properties object, in the form of a GUID.
         /// </summary>
         [DataMember(Name = "runGuid", IsRequired = false, EmitDefaultValue = false)]
-        public string RunGuid { get; set; }
+        public virtual string RunGuid { get; set; }
 
         /// <summary>
         /// A conversion object that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "conversion", IsRequired = false, EmitDefaultValue = false)]
-        public Conversion Conversion { get; set; }
+        public virtual Conversion Conversion { get; set; }
 
         /// <summary>
         /// An array of graph objects that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "graphs", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Graph> Graphs { get; set; }
+        public virtual IList<Graph> Graphs { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "externalizedProperties", IsRequired = false, EmitDefaultValue = false)]
-        public PropertyBag ExternalizedProperties { get; set; }
+        public virtual PropertyBag ExternalizedProperties { get; set; }
 
         /// <summary>
         /// An array of artifact objects that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "artifacts", IsRequired = false, EmitDefaultValue = false)]
-        public IList<Artifact> Artifacts { get; set; }
+        public virtual IList<Artifact> Artifacts { get; set; }
 
         /// <summary>
         /// Describes the invocation of the analysis tool that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "invocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Invocation> Invocations { get; set; }
+        public virtual IList<Invocation> Invocations { get; set; }
 
         /// <summary>
         /// An array of logical locations such as namespaces, types or functions that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "logicalLocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<LogicalLocation> LogicalLocations { get; set; }
+        public virtual IList<LogicalLocation> LogicalLocations { get; set; }
 
         /// <summary>
         /// An array of threadFlowLocation objects that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "threadFlowLocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ThreadFlowLocation> ThreadFlowLocations { get; set; }
+        public virtual IList<ThreadFlowLocation> ThreadFlowLocations { get; set; }
 
         /// <summary>
         /// An array of result objects that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "results", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Result> Results { get; set; }
+        public virtual IList<Result> Results { get; set; }
 
         /// <summary>
         /// Tool taxonomies that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "taxonomies", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponent> Taxonomies { get; set; }
+        public virtual IList<ToolComponent> Taxonomies { get; set; }
 
         /// <summary>
         /// The analysis tool object that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "driver", IsRequired = false, EmitDefaultValue = false)]
-        public ToolComponent Driver { get; set; }
+        public virtual ToolComponent Driver { get; set; }
 
         /// <summary>
         /// Tool extensions that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "extensions", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponent> Extensions { get; set; }
+        public virtual IList<ToolComponent> Extensions { get; set; }
 
         /// <summary>
         /// Tool policies that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "policies", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponent> Policies { get; set; }
+        public virtual IList<ToolComponent> Policies { get; set; }
 
         /// <summary>
         /// Tool translations that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "translations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponent> Translations { get; set; }
+        public virtual IList<ToolComponent> Translations { get; set; }
 
         /// <summary>
         /// Addresses that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "addresses", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Address> Addresses { get; set; }
+        public virtual IList<Address> Addresses { get; set; }
 
         /// <summary>
         /// Requests that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "webRequests", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<WebRequest> WebRequests { get; set; }
+        public virtual IList<WebRequest> WebRequests { get; set; }
 
         /// <summary>
         /// Responses that will be merged with a separate run.
         /// </summary>
         [DataMember(Name = "webResponses", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<WebResponse> WebResponses { get; set; }
+        public virtual IList<WebResponse> WebResponses { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the external properties.
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ExternalProperties DeepClone()
+        public virtual ExternalProperties DeepClone()
         {
             return (ExternalProperties)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReference.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReference.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,13 +38,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The location of the external property file.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactLocation Location { get; set; }
+        public virtual ArtifactLocation Location { get; set; }
 
         /// <summary>
         /// A stable, unique identifer for the external property file in the form of a GUID.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// A non-negative integer specifying the number of items contained in the external property file.
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "itemCount", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ItemCount { get; set; }
+        public virtual int ItemCount { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the external property file.
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ExternalPropertyFileReference DeepClone()
+        public virtual ExternalPropertyFileReference DeepClone()
         {
             return (ExternalPropertyFileReference)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ExternalPropertyFileReferences.cs
+++ b/src/Sarif/Autogenerated/ExternalPropertyFileReferences.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,110 +37,110 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// An external property file containing a run.conversion object to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "conversion", IsRequired = false, EmitDefaultValue = false)]
-        public ExternalPropertyFileReference Conversion { get; set; }
+        public virtual ExternalPropertyFileReference Conversion { get; set; }
 
         /// <summary>
         /// An array of external property files containing a run.graphs object to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "graphs", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Graphs { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Graphs { get; set; }
 
         /// <summary>
         /// An external property file containing a run.properties object to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "externalizedProperties", IsRequired = false, EmitDefaultValue = false)]
-        public ExternalPropertyFileReference ExternalizedProperties { get; set; }
+        public virtual ExternalPropertyFileReference ExternalizedProperties { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.artifacts arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "artifacts", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Artifacts { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Artifacts { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.invocations arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "invocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Invocations { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Invocations { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.logicalLocations arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "logicalLocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> LogicalLocations { get; set; }
+        public virtual IList<ExternalPropertyFileReference> LogicalLocations { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "threadFlowLocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> ThreadFlowLocations { get; set; }
+        public virtual IList<ExternalPropertyFileReference> ThreadFlowLocations { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.results arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "results", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Results { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Results { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.taxonomies arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "taxonomies", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Taxonomies { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Taxonomies { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.addresses arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "addresses", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Addresses { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Addresses { get; set; }
 
         /// <summary>
         /// An external property file containing a run.driver object to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "driver", IsRequired = false, EmitDefaultValue = false)]
-        public ExternalPropertyFileReference Driver { get; set; }
+        public virtual ExternalPropertyFileReference Driver { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.extensions arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "extensions", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Extensions { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Extensions { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.policies arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "policies", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Policies { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Policies { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.translations arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "translations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> Translations { get; set; }
+        public virtual IList<ExternalPropertyFileReference> Translations { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.requests arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "webRequests", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> WebRequests { get; set; }
+        public virtual IList<ExternalPropertyFileReference> WebRequests { get; set; }
 
         /// <summary>
         /// An array of external property files containing run.responses arrays to be merged with the root log file.
         /// </summary>
         [DataMember(Name = "webResponses", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ExternalPropertyFileReference> WebResponses { get; set; }
+        public virtual IList<ExternalPropertyFileReference> WebResponses { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the external property files.
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ExternalPropertyFileReferences DeepClone()
+        public virtual ExternalPropertyFileReferences DeepClone()
         {
             return (ExternalPropertyFileReferences)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Fix.cs
+++ b/src/Sarif/Autogenerated/Fix.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A message that describes the proposed fix, enabling viewers to present the proposed change to an end user.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// One or more artifact changes that comprise a fix for a result.
         /// </summary>
         [DataMember(Name = "artifactChanges", IsRequired = true)]
-        public IList<ArtifactChange> ArtifactChanges { get; set; }
+        public virtual IList<ArtifactChange> ArtifactChanges { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the fix.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Fix DeepClone()
+        public virtual Fix DeepClone()
         {
             return (Fix)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Graph.cs
+++ b/src/Sarif/Autogenerated/Graph.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,21 +37,21 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A description of the graph.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// An array of node objects representing the nodes of the graph.
         /// </summary>
         [DataMember(Name = "nodes", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Node> Nodes { get; set; }
+        public virtual IList<Node> Nodes { get; set; }
 
         /// <summary>
         /// An array of edge objects representing the edges of the graph.
         /// </summary>
         [DataMember(Name = "edges", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Edge> Edges { get; set; }
+        public virtual IList<Edge> Edges { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the graph.
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Graph DeepClone()
+        public virtual Graph DeepClone()
         {
             return (Graph)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/GraphTraversal.cs
+++ b/src/Sarif/Autogenerated/GraphTraversal.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "runGraphIndex", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int RunGraphIndex { get; set; }
+        public virtual int RunGraphIndex { get; set; }
 
         /// <summary>
         /// The index within the result.graphs to be associated with the result.
@@ -48,32 +48,32 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "resultGraphIndex", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ResultGraphIndex { get; set; }
+        public virtual int ResultGraphIndex { get; set; }
 
         /// <summary>
         /// A description of this graph traversal.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// Values of relevant expressions at the start of the graph traversal that may change during graph traversal.
         /// </summary>
         [DataMember(Name = "initialState", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, MultiformatMessageString> InitialState { get; set; }
+        public virtual IDictionary<string, MultiformatMessageString> InitialState { get; set; }
 
         /// <summary>
         /// Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.
         /// </summary>
         [DataMember(Name = "immutableState", IsRequired = false, EmitDefaultValue = false)]
-        public object ImmutableState { get; set; }
+        public virtual object ImmutableState { get; set; }
 
         /// <summary>
         /// The sequences of edges traversed by this graph traversal.
         /// </summary>
         [DataMember(Name = "edgeTraversals", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<EdgeTraversal> EdgeTraversals { get; set; }
+        public virtual IList<EdgeTraversal> EdgeTraversals { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the graph traversal.
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public GraphTraversal DeepClone()
+        public virtual GraphTraversal DeepClone()
         {
             return (GraphTraversal)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Location.cs
+++ b/src/Sarif/Autogenerated/Location.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -40,40 +40,40 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Id { get; set; }
+        public virtual int Id { get; set; }
 
         /// <summary>
         /// Identifies the artifact and region.
         /// </summary>
         [DataMember(Name = "physicalLocation", IsRequired = false, EmitDefaultValue = false)]
-        public PhysicalLocation PhysicalLocation { get; set; }
+        public virtual PhysicalLocation PhysicalLocation { get; set; }
 
         /// <summary>
         /// The logical locations associated with the result.
         /// </summary>
         [DataMember(Name = "logicalLocations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<LogicalLocation> LogicalLocations { get; set; }
+        public virtual IList<LogicalLocation> LogicalLocations { get; set; }
 
         /// <summary>
         /// A message relevant to the location.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// A set of regions relevant to the location.
         /// </summary>
         [DataMember(Name = "annotations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Region> Annotations { get; set; }
+        public virtual IList<Region> Annotations { get; set; }
 
         /// <summary>
         /// An array of objects that describe relationships between this location and others.
         /// </summary>
         [DataMember(Name = "relationships", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<LocationRelationship> Relationships { get; set; }
+        public virtual IList<LocationRelationship> Relationships { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the location.
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Location DeepClone()
+        public virtual Location DeepClone()
         {
             return (Location)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/LocationRelationship.cs
+++ b/src/Sarif/Autogenerated/LocationRelationship.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,20 +37,20 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A reference to the related location.
         /// </summary>
         [DataMember(Name = "target", IsRequired = true)]
-        public int Target { get; set; }
+        public virtual int Target { get; set; }
 
         /// <summary>
         /// A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.
         /// </summary>
         [DataMember(Name = "kinds", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Kinds { get; set; }
+        public virtual IList<string> Kinds { get; set; }
 
         /// <summary>
         /// A description of the location relationship.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the location relationship.
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public LocationRelationship DeepClone()
+        public virtual LocationRelationship DeepClone()
         {
             return (LocationRelationship)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/LogicalLocation.cs
+++ b/src/Sarif/Autogenerated/LogicalLocation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.
         /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         /// <summary>
         /// The index within the logical locations array.
@@ -46,19 +46,19 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// The human-readable fully qualified name of the logical location.
         /// </summary>
         [DataMember(Name = "fullyQualifiedName", IsRequired = false, EmitDefaultValue = false)]
-        public string FullyQualifiedName { get; set; }
+        public virtual string FullyQualifiedName { get; set; }
 
         /// <summary>
         /// The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.
         /// </summary>
         [DataMember(Name = "decoratedName", IsRequired = false, EmitDefaultValue = false)]
-        public string DecoratedName { get; set; }
+        public virtual string DecoratedName { get; set; }
 
         /// <summary>
         /// Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.
@@ -66,13 +66,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "parentIndex", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ParentIndex { get; set; }
+        public virtual int ParentIndex { get; set; }
 
         /// <summary>
         /// The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.
         /// </summary>
         [DataMember(Name = "kind", IsRequired = false, EmitDefaultValue = false)]
-        public string Kind { get; set; }
+        public virtual string Kind { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the logical location.
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public LogicalLocation DeepClone()
+        public virtual LogicalLocation DeepClone()
         {
             return (LogicalLocation)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Message.cs
+++ b/src/Sarif/Autogenerated/Message.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,26 +37,26 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A plain text message string.
         /// </summary>
         [DataMember(Name = "text", IsRequired = false, EmitDefaultValue = false)]
-        public string Text { get; set; }
+        public virtual string Text { get; set; }
 
         /// <summary>
         /// A Markdown message string.
         /// </summary>
         [DataMember(Name = "markdown", IsRequired = false, EmitDefaultValue = false)]
-        public string Markdown { get; set; }
+        public virtual string Markdown { get; set; }
 
         /// <summary>
         /// The identifier for this message.
         /// </summary>
         [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// An array of strings to substitute into the message string.
         /// </summary>
         [DataMember(Name = "arguments", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Arguments { get; set; }
+        public virtual IList<string> Arguments { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the message.
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Message DeepClone()
+        public virtual Message DeepClone()
         {
             return (Message)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/MultiformatMessageString.cs
+++ b/src/Sarif/Autogenerated/MultiformatMessageString.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A plain text message string or format string.
         /// </summary>
         [DataMember(Name = "text", IsRequired = true)]
-        public string Text { get; set; }
+        public virtual string Text { get; set; }
 
         /// <summary>
         /// A Markdown message string or format string.
         /// </summary>
         [DataMember(Name = "markdown", IsRequired = false, EmitDefaultValue = false)]
-        public string Markdown { get; set; }
+        public virtual string Markdown { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the message.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public MultiformatMessageString DeepClone()
+        public virtual MultiformatMessageString DeepClone()
         {
             return (MultiformatMessageString)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Node.cs
+++ b/src/Sarif/Autogenerated/Node.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,26 +37,26 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A string that uniquely identifies the node within its graph.
         /// </summary>
         [DataMember(Name = "id", IsRequired = true)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// A short description of the node.
         /// </summary>
         [DataMember(Name = "label", IsRequired = false, EmitDefaultValue = false)]
-        public Message Label { get; set; }
+        public virtual Message Label { get; set; }
 
         /// <summary>
         /// A code location associated with the node.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public Location Location { get; set; }
+        public virtual Location Location { get; set; }
 
         /// <summary>
         /// Array of child nodes.
         /// </summary>
         [DataMember(Name = "children", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Node> Children { get; set; }
+        public virtual IList<Node> Children { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the node.
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Node DeepClone()
+        public virtual Node DeepClone()
         {
             return (Node)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Notification.cs
+++ b/src/Sarif/Autogenerated/Notification.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -39,13 +39,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         [DataMember(Name = "locations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<Location> Locations { get; set; }
+        public virtual IList<Location> Locations { get; set; }
 
         /// <summary>
         /// A message that describes the condition that was encountered.
         /// </summary>
         [DataMember(Name = "message", IsRequired = true)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// A value specifying the severity level of the notification.
@@ -54,38 +54,38 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DefaultValue(FailureLevel.Warning)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public FailureLevel Level { get; set; }
+        public virtual FailureLevel Level { get; set; }
 
         /// <summary>
         /// The thread identifier of the code that generated the notification.
         /// </summary>
         [DataMember(Name = "threadId", IsRequired = false, EmitDefaultValue = false)]
-        public int ThreadId { get; set; }
+        public virtual int ThreadId { get; set; }
 
         /// <summary>
         /// The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.
         /// </summary>
         [DataMember(Name = "timeUtc", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
-        public DateTime TimeUtc { get; set; }
+        public virtual DateTime TimeUtc { get; set; }
 
         /// <summary>
         /// The runtime exception, if any, relevant to this notification.
         /// </summary>
         [DataMember(Name = "exception", IsRequired = false, EmitDefaultValue = false)]
-        public ExceptionData Exception { get; set; }
+        public virtual ExceptionData Exception { get; set; }
 
         /// <summary>
         /// A reference used to locate the descriptor relevant to this notification.
         /// </summary>
         [DataMember(Name = "descriptor", IsRequired = false, EmitDefaultValue = false)]
-        public ReportingDescriptorReference Descriptor { get; set; }
+        public virtual ReportingDescriptorReference Descriptor { get; set; }
 
         /// <summary>
         /// A reference used to locate the rule descriptor associated with this notification.
         /// </summary>
         [DataMember(Name = "associatedRule", IsRequired = false, EmitDefaultValue = false)]
-        public ReportingDescriptorReference AssociatedRule { get; set; }
+        public virtual ReportingDescriptorReference AssociatedRule { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the notification.
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Notification DeepClone()
+        public virtual Notification DeepClone()
         {
             return (Notification)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/PhysicalLocation.cs
+++ b/src/Sarif/Autogenerated/PhysicalLocation.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,25 +36,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The address of the location.
         /// </summary>
         [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
-        public Address Address { get; set; }
+        public virtual Address Address { get; set; }
 
         /// <summary>
         /// The location of the artifact.
         /// </summary>
         [DataMember(Name = "artifactLocation", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactLocation ArtifactLocation { get; set; }
+        public virtual ArtifactLocation ArtifactLocation { get; set; }
 
         /// <summary>
         /// Specifies a portion of the artifact.
         /// </summary>
         [DataMember(Name = "region", IsRequired = false, EmitDefaultValue = false)]
-        public Region Region { get; set; }
+        public virtual Region Region { get; set; }
 
         /// <summary>
         /// Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region.
         /// </summary>
         [DataMember(Name = "contextRegion", IsRequired = false, EmitDefaultValue = false)]
-        public Region ContextRegion { get; set; }
+        public virtual Region ContextRegion { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the physical location.
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public PhysicalLocation DeepClone()
+        public virtual PhysicalLocation DeepClone()
         {
             return (PhysicalLocation)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/PropertyBag.cs
+++ b/src/Sarif/Autogenerated/PropertyBag.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         [DataMember(Name = "tags", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Tags { get; set; }
+        public virtual IList<string> Tags { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyBag" /> class.
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public PropertyBag DeepClone()
+        public virtual PropertyBag DeepClone()
         {
             return (PropertyBag)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Rectangle.cs
+++ b/src/Sarif/Autogenerated/Rectangle.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,31 +36,31 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The Y coordinate of the top edge of the rectangle, measured in the image's natural units.
         /// </summary>
         [DataMember(Name = "top", IsRequired = false, EmitDefaultValue = false)]
-        public double Top { get; set; }
+        public virtual double Top { get; set; }
 
         /// <summary>
         /// The X coordinate of the left edge of the rectangle, measured in the image's natural units.
         /// </summary>
         [DataMember(Name = "left", IsRequired = false, EmitDefaultValue = false)]
-        public double Left { get; set; }
+        public virtual double Left { get; set; }
 
         /// <summary>
         /// The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.
         /// </summary>
         [DataMember(Name = "bottom", IsRequired = false, EmitDefaultValue = false)]
-        public double Bottom { get; set; }
+        public virtual double Bottom { get; set; }
 
         /// <summary>
         /// The X coordinate of the right edge of the rectangle, measured in the image's natural units.
         /// </summary>
         [DataMember(Name = "right", IsRequired = false, EmitDefaultValue = false)]
-        public double Right { get; set; }
+        public virtual double Right { get; set; }
 
         /// <summary>
         /// A message relevant to the rectangle.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the rectangle.
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Rectangle DeepClone()
+        public virtual Rectangle DeepClone()
         {
             return (Rectangle)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Region.cs
+++ b/src/Sarif/Autogenerated/Region.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,25 +38,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The line number of the first character in the region.
         /// </summary>
         [DataMember(Name = "startLine", IsRequired = false, EmitDefaultValue = false)]
-        public int StartLine { get; set; }
+        public virtual int StartLine { get; set; }
 
         /// <summary>
         /// The column number of the first character in the region.
         /// </summary>
         [DataMember(Name = "startColumn", IsRequired = false, EmitDefaultValue = false)]
-        public int StartColumn { get; set; }
+        public virtual int StartColumn { get; set; }
 
         /// <summary>
         /// The line number of the last character in the region.
         /// </summary>
         [DataMember(Name = "endLine", IsRequired = false, EmitDefaultValue = false)]
-        public int EndLine { get; set; }
+        public virtual int EndLine { get; set; }
 
         /// <summary>
         /// The column number of the character following the end of the region.
         /// </summary>
         [DataMember(Name = "endColumn", IsRequired = false, EmitDefaultValue = false)]
-        public int EndColumn { get; set; }
+        public virtual int EndColumn { get; set; }
 
         /// <summary>
         /// The zero-based offset from the beginning of the artifact of the first character in the region.
@@ -64,13 +64,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "charOffset", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int CharOffset { get; set; }
+        public virtual int CharOffset { get; set; }
 
         /// <summary>
         /// The length of the region in characters.
         /// </summary>
         [DataMember(Name = "charLength", IsRequired = false, EmitDefaultValue = false)]
-        public int CharLength { get; set; }
+        public virtual int CharLength { get; set; }
 
         /// <summary>
         /// The zero-based offset from the beginning of the artifact of the first byte in the region.
@@ -78,31 +78,31 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "byteOffset", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ByteOffset { get; set; }
+        public virtual int ByteOffset { get; set; }
 
         /// <summary>
         /// The length of the region in bytes.
         /// </summary>
         [DataMember(Name = "byteLength", IsRequired = false, EmitDefaultValue = false)]
-        public int ByteLength { get; set; }
+        public virtual int ByteLength { get; set; }
 
         /// <summary>
         /// The portion of the artifact contents within the specified region.
         /// </summary>
         [DataMember(Name = "snippet", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactContent Snippet { get; set; }
+        public virtual ArtifactContent Snippet { get; set; }
 
         /// <summary>
         /// A message relevant to the region.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// Specifies the source language, if any, of the portion of the artifact specified by the region object.
         /// </summary>
         [DataMember(Name = "sourceLanguage", IsRequired = false, EmitDefaultValue = false)]
-        public string SourceLanguage { get; set; }
+        public virtual string SourceLanguage { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the region.
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Region DeepClone()
+        public virtual Region DeepClone()
         {
             return (Region)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Replacement.cs
+++ b/src/Sarif/Autogenerated/Replacement.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The region of the artifact to delete.
         /// </summary>
         [DataMember(Name = "deletedRegion", IsRequired = true)]
-        public Region DeletedRegion { get; set; }
+        public virtual Region DeletedRegion { get; set; }
 
         /// <summary>
         /// The content to insert at the location specified by the 'deletedRegion' property.
         /// </summary>
         [DataMember(Name = "insertedContent", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactContent InsertedContent { get; set; }
+        public virtual ArtifactContent InsertedContent { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the replacement.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Replacement DeepClone()
+        public virtual Replacement DeepClone()
         {
             return (Replacement)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ReportingDescriptorReference.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorReference.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The id of the descriptor.
         /// </summary>
         [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.
@@ -46,19 +46,19 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// A guid that uniquely identifies the descriptor.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// A reference used to locate the toolComponent associated with the descriptor.
         /// </summary>
         [DataMember(Name = "toolComponent", IsRequired = false, EmitDefaultValue = false)]
-        public ToolComponentReference ToolComponent { get; set; }
+        public virtual ToolComponentReference ToolComponent { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the reporting descriptor reference.
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ReportingDescriptorReference DeepClone()
+        public virtual ReportingDescriptorReference DeepClone()
         {
             return (ReportingDescriptorReference)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
+++ b/src/Sarif/Autogenerated/ReportingDescriptorRelationship.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,20 +37,20 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A reference to the related reporting descriptor.
         /// </summary>
         [DataMember(Name = "target", IsRequired = true)]
-        public ReportingDescriptorReference Target { get; set; }
+        public virtual ReportingDescriptorReference Target { get; set; }
 
         /// <summary>
         /// A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.
         /// </summary>
         [DataMember(Name = "kinds", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Kinds { get; set; }
+        public virtual IList<string> Kinds { get; set; }
 
         /// <summary>
         /// A description of the reporting descriptor relationship.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the reporting descriptor reference.
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ReportingDescriptorRelationship DeepClone()
+        public virtual ReportingDescriptorRelationship DeepClone()
         {
             return (ReportingDescriptorRelationship)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ResultProvenance.cs
+++ b/src/Sarif/Autogenerated/ResultProvenance.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,25 +38,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The Coordinated Universal Time (UTC) date and time at which the result was first detected. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "firstDetectionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
-        public DateTime FirstDetectionTimeUtc { get; set; }
+        public virtual DateTime FirstDetectionTimeUtc { get; set; }
 
         /// <summary>
         /// The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "lastDetectionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
-        public DateTime LastDetectionTimeUtc { get; set; }
+        public virtual DateTime LastDetectionTimeUtc { get; set; }
 
         /// <summary>
         /// A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.
         /// </summary>
         [DataMember(Name = "firstDetectionRunGuid", IsRequired = false, EmitDefaultValue = false)]
-        public string FirstDetectionRunGuid { get; set; }
+        public virtual string FirstDetectionRunGuid { get; set; }
 
         /// <summary>
         /// A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.
         /// </summary>
         [DataMember(Name = "lastDetectionRunGuid", IsRequired = false, EmitDefaultValue = false)]
-        public string LastDetectionRunGuid { get; set; }
+        public virtual string LastDetectionRunGuid { get; set; }
 
         /// <summary>
         /// The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.
@@ -64,14 +64,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "invocationIndex", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int InvocationIndex { get; set; }
+        public virtual int InvocationIndex { get; set; }
 
         /// <summary>
         /// An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.
         /// </summary>
         [DataMember(Name = "conversionSources", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<PhysicalLocation> ConversionSources { get; set; }
+        public virtual IList<PhysicalLocation> ConversionSources { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the result.
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ResultProvenance DeepClone()
+        public virtual ResultProvenance DeepClone()
         {
             return (ResultProvenance)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/RunAutomationDetails.cs
+++ b/src/Sarif/Autogenerated/RunAutomationDetails.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,25 +36,25 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A description of the identity and role played within the engineering system by this object's containing run object.
         /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
-        public Message Description { get; set; }
+        public virtual Message Description { get; set; }
 
         /// <summary>
         /// A hierarchical string that uniquely identifies this object's containing run object.
         /// </summary>
         [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// A stable, unique identifer for this object's containing run object in the form of a GUID.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.
         /// </summary>
         [DataMember(Name = "correlationGuid", IsRequired = false, EmitDefaultValue = false)]
-        public string CorrelationGuid { get; set; }
+        public virtual string CorrelationGuid { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the run automation details.
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public RunAutomationDetails DeepClone()
+        public virtual RunAutomationDetails DeepClone()
         {
             return (RunAutomationDetails)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/SpecialLocations.cs
+++ b/src/Sarif/Autogenerated/SpecialLocations.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// Provides a suggestion to SARIF consumers to display file paths relative to the specified location.
         /// </summary>
         [DataMember(Name = "displayBase", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactLocation DisplayBase { get; set; }
+        public virtual ArtifactLocation DisplayBase { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the special locations.
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public SpecialLocations DeepClone()
+        public virtual SpecialLocations DeepClone()
         {
             return (SpecialLocations)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Stack.cs
+++ b/src/Sarif/Autogenerated/Stack.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,13 +36,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A message relevant to this call stack.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.
         /// </summary>
         [DataMember(Name = "frames", IsRequired = true)]
-        public IList<StackFrame> Frames { get; set; }
+        public virtual IList<StackFrame> Frames { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the stack.
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Stack DeepClone()
+        public virtual Stack DeepClone()
         {
             return (Stack)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/StackFrame.cs
+++ b/src/Sarif/Autogenerated/StackFrame.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,26 +37,26 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The location to which this stack frame refers.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public Location Location { get; set; }
+        public virtual Location Location { get; set; }
 
         /// <summary>
         /// The name of the module that contains the code of this stack frame.
         /// </summary>
         [DataMember(Name = "module", IsRequired = false, EmitDefaultValue = false)]
-        public string Module { get; set; }
+        public virtual string Module { get; set; }
 
         /// <summary>
         /// The thread identifier of the stack frame.
         /// </summary>
         [DataMember(Name = "threadId", IsRequired = false, EmitDefaultValue = false)]
-        public int ThreadId { get; set; }
+        public virtual int ThreadId { get; set; }
 
         /// <summary>
         /// The parameters of the call that is executing.
         /// </summary>
         [DataMember(Name = "parameters", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Parameters { get; set; }
+        public virtual IList<string> Parameters { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the stack frame.
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public StackFrame DeepClone()
+        public virtual StackFrame DeepClone()
         {
             return (StackFrame)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Suppression.cs
+++ b/src/Sarif/Autogenerated/Suppression.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,33 +37,33 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A stable, unique identifer for the suprression in the form of a GUID.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// A string that indicates where the suppression is persisted.
         /// </summary>
         [DataMember(Name = "kind", IsRequired = true)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public SuppressionKind Kind { get; set; }
+        public virtual SuppressionKind Kind { get; set; }
 
         /// <summary>
         /// A string that indicates the state of the suppression.
         /// </summary>
         [DataMember(Name = "state", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public SuppressionState State { get; set; }
+        public virtual SuppressionState State { get; set; }
 
         /// <summary>
         /// A string representing the justification for the suppression.
         /// </summary>
         [DataMember(Name = "justification", IsRequired = false, EmitDefaultValue = false)]
-        public string Justification { get; set; }
+        public virtual string Justification { get; set; }
 
         /// <summary>
         /// Identifies the location associated with the suppression.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public Location Location { get; set; }
+        public virtual Location Location { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the suppression.
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Suppression DeepClone()
+        public virtual Suppression DeepClone()
         {
             return (Suppression)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ThreadFlow.cs
+++ b/src/Sarif/Autogenerated/ThreadFlow.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,31 +36,31 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.
         /// </summary>
         [DataMember(Name = "id", IsRequired = false, EmitDefaultValue = false)]
-        public string Id { get; set; }
+        public virtual string Id { get; set; }
 
         /// <summary>
         /// A message relevant to the thread flow.
         /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
-        public Message Message { get; set; }
+        public virtual Message Message { get; set; }
 
         /// <summary>
         /// Values of relevant expressions at the start of the thread flow that may change during thread flow execution.
         /// </summary>
         [DataMember(Name = "initialState", IsRequired = false, EmitDefaultValue = false)]
-        public object InitialState { get; set; }
+        public virtual object InitialState { get; set; }
 
         /// <summary>
         /// Values of relevant expressions at the start of the thread flow that remain constant.
         /// </summary>
         [DataMember(Name = "immutableState", IsRequired = false, EmitDefaultValue = false)]
-        public object ImmutableState { get; set; }
+        public virtual object ImmutableState { get; set; }
 
         /// <summary>
         /// A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.
         /// </summary>
         [DataMember(Name = "locations", IsRequired = true)]
-        public IList<ThreadFlowLocation> Locations { get; set; }
+        public virtual IList<ThreadFlowLocation> Locations { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the thread flow.
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ThreadFlow DeepClone()
+        public virtual ThreadFlow DeepClone()
         {
             return (ThreadFlow)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ThreadFlowLocation.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -40,51 +40,51 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// The code location.
         /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
-        public Location Location { get; set; }
+        public virtual Location Location { get; set; }
 
         /// <summary>
         /// The call stack leading to this location.
         /// </summary>
         [DataMember(Name = "stack", IsRequired = false, EmitDefaultValue = false)]
-        public Stack Stack { get; set; }
+        public virtual Stack Stack { get; set; }
 
         /// <summary>
         /// A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.
         /// </summary>
         [DataMember(Name = "kinds", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<string> Kinds { get; set; }
+        public virtual IList<string> Kinds { get; set; }
 
         /// <summary>
         /// An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.
         /// </summary>
         [DataMember(Name = "taxa", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ReportingDescriptorReference> Taxa { get; set; }
+        public virtual IList<ReportingDescriptorReference> Taxa { get; set; }
 
         /// <summary>
         /// The name of the module that contains the code that is executing.
         /// </summary>
         [DataMember(Name = "module", IsRequired = false, EmitDefaultValue = false)]
-        public string Module { get; set; }
+        public virtual string Module { get; set; }
 
         /// <summary>
         /// A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.
         /// </summary>
         [DataMember(Name = "state", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, MultiformatMessageString> State { get; set; }
+        public virtual IDictionary<string, MultiformatMessageString> State { get; set; }
 
         /// <summary>
         /// An integer representing a containment hierarchy within the thread flow.
         /// </summary>
         [DataMember(Name = "nestingLevel", IsRequired = false, EmitDefaultValue = false)]
-        public int NestingLevel { get; set; }
+        public virtual int NestingLevel { get; set; }
 
         /// <summary>
         /// An integer representing the temporal order in which execution reached this location.
@@ -92,13 +92,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "executionOrder", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int ExecutionOrder { get; set; }
+        public virtual int ExecutionOrder { get; set; }
 
         /// <summary>
         /// The Coordinated Universal Time (UTC) date and time at which this location was executed.
         /// </summary>
         [DataMember(Name = "executionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
-        public DateTime ExecutionTimeUtc { get; set; }
+        public virtual DateTime ExecutionTimeUtc { get; set; }
 
         /// <summary>
         /// Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is "essential", "important", "unimportant". Default: "important".
@@ -107,19 +107,19 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DefaultValue(ThreadFlowLocationImportance.Important)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public ThreadFlowLocationImportance Importance { get; set; }
+        public virtual ThreadFlowLocationImportance Importance { get; set; }
 
         /// <summary>
         /// A web request associated with this thread flow location.
         /// </summary>
         [DataMember(Name = "webRequest", IsRequired = false, EmitDefaultValue = false)]
-        public WebRequest WebRequest { get; set; }
+        public virtual WebRequest WebRequest { get; set; }
 
         /// <summary>
         /// A web response associated with this thread flow location.
         /// </summary>
         [DataMember(Name = "webResponse", IsRequired = false, EmitDefaultValue = false)]
-        public WebResponse WebResponse { get; set; }
+        public virtual WebResponse WebResponse { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the threadflow location.
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ThreadFlowLocation DeepClone()
+        public virtual ThreadFlowLocation DeepClone()
         {
             return (ThreadFlowLocation)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/Tool.cs
+++ b/src/Sarif/Autogenerated/Tool.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -37,14 +37,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The analysis tool that was run.
         /// </summary>
         [DataMember(Name = "driver", IsRequired = true)]
-        public ToolComponent Driver { get; set; }
+        public virtual ToolComponent Driver { get; set; }
 
         /// <summary>
         /// Tool extensions that contributed to or reconfigured the analysis tool that was run.
         /// </summary>
         [DataMember(Name = "extensions", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponent> Extensions { get; set; }
+        public virtual IList<ToolComponent> Extensions { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the tool.
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public Tool DeepClone()
+        public virtual Tool DeepClone()
         {
             return (Tool)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ToolComponent.cs
+++ b/src/Sarif/Autogenerated/ToolComponent.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,119 +38,119 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// A unique identifer for the tool component in the form of a GUID.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// The name of the tool component.
         /// </summary>
         [DataMember(Name = "name", IsRequired = true)]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         /// <summary>
         /// The organization or company that produced the tool component.
         /// </summary>
         [DataMember(Name = "organization", IsRequired = false, EmitDefaultValue = false)]
-        public string Organization { get; set; }
+        public virtual string Organization { get; set; }
 
         /// <summary>
         /// A product suite to which the tool component belongs.
         /// </summary>
         [DataMember(Name = "product", IsRequired = false, EmitDefaultValue = false)]
-        public string Product { get; set; }
+        public virtual string Product { get; set; }
 
         /// <summary>
         /// A localizable string containing the name of the suite of products to which the tool component belongs.
         /// </summary>
         [DataMember(Name = "productSuite", IsRequired = false, EmitDefaultValue = false)]
-        public string ProductSuite { get; set; }
+        public virtual string ProductSuite { get; set; }
 
         /// <summary>
         /// A brief description of the tool component.
         /// </summary>
         [DataMember(Name = "shortDescription", IsRequired = false, EmitDefaultValue = false)]
-        public MultiformatMessageString ShortDescription { get; set; }
+        public virtual MultiformatMessageString ShortDescription { get; set; }
 
         /// <summary>
         /// A comprehensive description of the tool component.
         /// </summary>
         [DataMember(Name = "fullDescription", IsRequired = false, EmitDefaultValue = false)]
-        public MultiformatMessageString FullDescription { get; set; }
+        public virtual MultiformatMessageString FullDescription { get; set; }
 
         /// <summary>
         /// The name of the tool component along with its version and any other useful identifying information, such as its locale.
         /// </summary>
         [DataMember(Name = "fullName", IsRequired = false, EmitDefaultValue = false)]
-        public string FullName { get; set; }
+        public virtual string FullName { get; set; }
 
         /// <summary>
         /// The tool component version, in whatever format the component natively provides.
         /// </summary>
         [DataMember(Name = "version", IsRequired = false, EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public virtual string Version { get; set; }
 
         /// <summary>
         /// The tool component version in the format specified by Semantic Versioning 2.0.
         /// </summary>
         [DataMember(Name = "semanticVersion", IsRequired = false, EmitDefaultValue = false)]
-        public string SemanticVersion { get; set; }
+        public virtual string SemanticVersion { get; set; }
 
         /// <summary>
         /// The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).
         /// </summary>
         [DataMember(Name = "dottedQuadFileVersion", IsRequired = false, EmitDefaultValue = false)]
-        public string DottedQuadFileVersion { get; set; }
+        public virtual string DottedQuadFileVersion { get; set; }
 
         /// <summary>
         /// A string specifying the UTC date (and optionally, the time) of the component's release.
         /// </summary>
         [DataMember(Name = "releaseDateUtc", IsRequired = false, EmitDefaultValue = false)]
-        public string ReleaseDateUtc { get; set; }
+        public virtual string ReleaseDateUtc { get; set; }
 
         /// <summary>
         /// The absolute URI from which the tool component can be downloaded.
         /// </summary>
         [DataMember(Name = "downloadUri", IsRequired = false, EmitDefaultValue = false)]
-        public Uri DownloadUri { get; set; }
+        public virtual Uri DownloadUri { get; set; }
 
         /// <summary>
         /// The absolute URI at which information about this version of the tool component can be found.
         /// </summary>
         [DataMember(Name = "informationUri", IsRequired = false, EmitDefaultValue = false)]
-        public Uri InformationUri { get; set; }
+        public virtual Uri InformationUri { get; set; }
 
         /// <summary>
         /// A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.
         /// </summary>
         [DataMember(Name = "globalMessageStrings", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, MultiformatMessageString> GlobalMessageStrings { get; set; }
+        public virtual IDictionary<string, MultiformatMessageString> GlobalMessageStrings { get; set; }
 
         /// <summary>
         /// An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.
         /// </summary>
         [DataMember(Name = "notifications", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ReportingDescriptor> Notifications { get; set; }
+        public virtual IList<ReportingDescriptor> Notifications { get; set; }
 
         /// <summary>
         /// An array of reportingDescriptor objects relevant to the analysis performed by the tool component.
         /// </summary>
         [DataMember(Name = "rules", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ReportingDescriptor> Rules { get; set; }
+        public virtual IList<ReportingDescriptor> Rules { get; set; }
 
         /// <summary>
         /// An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.
         /// </summary>
         [DataMember(Name = "taxa", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ReportingDescriptor> Taxa { get; set; }
+        public virtual IList<ReportingDescriptor> Taxa { get; set; }
 
         /// <summary>
         /// An array of the artifactLocation objects associated with the tool component.
         /// </summary>
         [DataMember(Name = "locations", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ArtifactLocation> Locations { get; set; }
+        public virtual IList<ArtifactLocation> Locations { get; set; }
 
         /// <summary>
         /// The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "language", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue("en-US")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public string Language { get; set; }
+        public virtual string Language { get; set; }
 
         /// <summary>
         /// The kinds of data contained in this object.
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "contents", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(FlagsEnumConverter))]
-        public ToolComponentContents Contents { get; set; }
+        public virtual ToolComponentContents Contents { get; set; }
 
         /// <summary>
         /// Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.
@@ -174,38 +174,38 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "isComprehensive", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool IsComprehensive { get; set; }
+        public virtual bool IsComprehensive { get; set; }
 
         /// <summary>
         /// The semantic version of the localized strings defined in this component; maintained by components that provide translations.
         /// </summary>
         [DataMember(Name = "localizedDataSemanticVersion", IsRequired = false, EmitDefaultValue = false)]
-        public string LocalizedDataSemanticVersion { get; set; }
+        public virtual string LocalizedDataSemanticVersion { get; set; }
 
         /// <summary>
         /// The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.
         /// </summary>
         [DataMember(Name = "minimumRequiredLocalizedDataSemanticVersion", IsRequired = false, EmitDefaultValue = false)]
-        public string MinimumRequiredLocalizedDataSemanticVersion { get; set; }
+        public virtual string MinimumRequiredLocalizedDataSemanticVersion { get; set; }
 
         /// <summary>
         /// The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model.
         /// </summary>
         [DataMember(Name = "associatedComponent", IsRequired = false, EmitDefaultValue = false)]
-        public ToolComponentReference AssociatedComponent { get; set; }
+        public virtual ToolComponentReference AssociatedComponent { get; set; }
 
         /// <summary>
         /// Translation metadata, required for a translation, not populated by other component types.
         /// </summary>
         [DataMember(Name = "translationMetadata", IsRequired = false, EmitDefaultValue = false)]
-        public TranslationMetadata TranslationMetadata { get; set; }
+        public virtual TranslationMetadata TranslationMetadata { get; set; }
 
         /// <summary>
         /// An array of toolComponentReference objects to declare the taxonomies supported by the tool component.
         /// </summary>
         [DataMember(Name = "supportedTaxonomies", IsRequired = false, EmitDefaultValue = false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public IList<ToolComponentReference> SupportedTaxonomies { get; set; }
+        public virtual IList<ToolComponentReference> SupportedTaxonomies { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the tool component.
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ToolComponent DeepClone()
+        public virtual ToolComponent DeepClone()
         {
             return (ToolComponent)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/ToolComponentReference.cs
+++ b/src/Sarif/Autogenerated/ToolComponentReference.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The 'name' property of the referenced toolComponent.
         /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         /// <summary>
         /// An index into the referenced toolComponent in tool.extensions.
@@ -46,13 +46,13 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// The 'guid' property of the referenced toolComponent.
         /// </summary>
         [DataMember(Name = "guid", IsRequired = false, EmitDefaultValue = false)]
-        public string Guid { get; set; }
+        public virtual string Guid { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the toolComponentReference.
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public ToolComponentReference DeepClone()
+        public virtual ToolComponentReference DeepClone()
         {
             return (ToolComponentReference)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/TranslationMetadata.cs
+++ b/src/Sarif/Autogenerated/TranslationMetadata.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -36,37 +36,37 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The name associated with the translation metadata.
         /// </summary>
         [DataMember(Name = "name", IsRequired = true)]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         /// <summary>
         /// The full name associated with the translation metadata.
         /// </summary>
         [DataMember(Name = "fullName", IsRequired = false, EmitDefaultValue = false)]
-        public string FullName { get; set; }
+        public virtual string FullName { get; set; }
 
         /// <summary>
         /// A brief description of the translation metadata.
         /// </summary>
         [DataMember(Name = "shortDescription", IsRequired = false, EmitDefaultValue = false)]
-        public MultiformatMessageString ShortDescription { get; set; }
+        public virtual MultiformatMessageString ShortDescription { get; set; }
 
         /// <summary>
         /// A comprehensive description of the translation metadata.
         /// </summary>
         [DataMember(Name = "fullDescription", IsRequired = false, EmitDefaultValue = false)]
-        public MultiformatMessageString FullDescription { get; set; }
+        public virtual MultiformatMessageString FullDescription { get; set; }
 
         /// <summary>
         /// The absolute URI from which the translation metadata can be downloaded.
         /// </summary>
         [DataMember(Name = "downloadUri", IsRequired = false, EmitDefaultValue = false)]
-        public Uri DownloadUri { get; set; }
+        public virtual Uri DownloadUri { get; set; }
 
         /// <summary>
         /// The absolute URI from which information related to the translation metadata can be downloaded.
         /// </summary>
         [DataMember(Name = "informationUri", IsRequired = false, EmitDefaultValue = false)]
-        public Uri InformationUri { get; set; }
+        public virtual Uri InformationUri { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the translation metadata.
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public TranslationMetadata DeepClone()
+        public virtual TranslationMetadata DeepClone()
         {
             return (TranslationMetadata)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/VersionControlDetails.cs
+++ b/src/Sarif/Autogenerated/VersionControlDetails.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -38,38 +38,38 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// </summary>
         [DataMember(Name = "repositoryUri", IsRequired = true)]
         [JsonConverter(typeof(UriConverter))]
-        public Uri RepositoryUri { get; set; }
+        public virtual Uri RepositoryUri { get; set; }
 
         /// <summary>
         /// A string that uniquely and permanently identifies the revision within the repository.
         /// </summary>
         [DataMember(Name = "revisionId", IsRequired = false, EmitDefaultValue = false)]
-        public string RevisionId { get; set; }
+        public virtual string RevisionId { get; set; }
 
         /// <summary>
         /// The name of a branch containing the revision.
         /// </summary>
         [DataMember(Name = "branch", IsRequired = false, EmitDefaultValue = false)]
-        public string Branch { get; set; }
+        public virtual string Branch { get; set; }
 
         /// <summary>
         /// A tag that has been applied to the revision.
         /// </summary>
         [DataMember(Name = "revisionTag", IsRequired = false, EmitDefaultValue = false)]
-        public string RevisionTag { get; set; }
+        public virtual string RevisionTag { get; set; }
 
         /// <summary>
         /// A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.
         /// </summary>
         [DataMember(Name = "asOfTimeUtc", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
-        public DateTime AsOfTimeUtc { get; set; }
+        public virtual DateTime AsOfTimeUtc { get; set; }
 
         /// <summary>
         /// The location in the local file system to which the root of the repository was mapped at the time of the analysis.
         /// </summary>
         [DataMember(Name = "mappedTo", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactLocation MappedTo { get; set; }
+        public virtual ArtifactLocation MappedTo { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the version control details.
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public VersionControlDetails DeepClone()
+        public virtual VersionControlDetails DeepClone()
         {
             return (VersionControlDetails)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/WebRequest.cs
+++ b/src/Sarif/Autogenerated/WebRequest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -40,49 +40,49 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// The request protocol. Example: 'http'.
         /// </summary>
         [DataMember(Name = "protocol", IsRequired = false, EmitDefaultValue = false)]
-        public string Protocol { get; set; }
+        public virtual string Protocol { get; set; }
 
         /// <summary>
         /// The request version. Example: '1.1'.
         /// </summary>
         [DataMember(Name = "version", IsRequired = false, EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public virtual string Version { get; set; }
 
         /// <summary>
         /// The target of the request.
         /// </summary>
         [DataMember(Name = "target", IsRequired = false, EmitDefaultValue = false)]
-        public string Target { get; set; }
+        public virtual string Target { get; set; }
 
         /// <summary>
         /// The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.
         /// </summary>
         [DataMember(Name = "method", IsRequired = false, EmitDefaultValue = false)]
-        public string Method { get; set; }
+        public virtual string Method { get; set; }
 
         /// <summary>
         /// The request headers.
         /// </summary>
         [DataMember(Name = "headers", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, string> Headers { get; set; }
+        public virtual IDictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// The request parameters.
         /// </summary>
         [DataMember(Name = "parameters", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, string> Parameters { get; set; }
+        public virtual IDictionary<string, string> Parameters { get; set; }
 
         /// <summary>
         /// The body of the request.
         /// </summary>
         [DataMember(Name = "body", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactContent Body { get; set; }
+        public virtual ArtifactContent Body { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the request.
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public WebRequest DeepClone()
+        public virtual WebRequest DeepClone()
         {
             return (WebRequest)DeepCloneCore();
         }

--- a/src/Sarif/Autogenerated/WebResponse.cs
+++ b/src/Sarif/Autogenerated/WebResponse.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Gets a value indicating the type of object implementing <see cref="ISarifNode" />.
         /// </summary>
-        public SarifNodeKind SarifNodeKind
+        public virtual SarifNodeKind SarifNodeKind
         {
             get
             {
@@ -40,43 +40,43 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "index", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public int Index { get; set; }
+        public virtual int Index { get; set; }
 
         /// <summary>
         /// The response protocol. Example: 'http'.
         /// </summary>
         [DataMember(Name = "protocol", IsRequired = false, EmitDefaultValue = false)]
-        public string Protocol { get; set; }
+        public virtual string Protocol { get; set; }
 
         /// <summary>
         /// The response version. Example: '1.1'.
         /// </summary>
         [DataMember(Name = "version", IsRequired = false, EmitDefaultValue = false)]
-        public string Version { get; set; }
+        public virtual string Version { get; set; }
 
         /// <summary>
         /// The response status code. Example: 451.
         /// </summary>
         [DataMember(Name = "statusCode", IsRequired = false, EmitDefaultValue = false)]
-        public int StatusCode { get; set; }
+        public virtual int StatusCode { get; set; }
 
         /// <summary>
         /// The response reason. Example: 'Not found'.
         /// </summary>
         [DataMember(Name = "reasonPhrase", IsRequired = false, EmitDefaultValue = false)]
-        public string ReasonPhrase { get; set; }
+        public virtual string ReasonPhrase { get; set; }
 
         /// <summary>
         /// The response headers.
         /// </summary>
         [DataMember(Name = "headers", IsRequired = false, EmitDefaultValue = false)]
-        public IDictionary<string, string> Headers { get; set; }
+        public virtual IDictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// The body of the response.
         /// </summary>
         [DataMember(Name = "body", IsRequired = false, EmitDefaultValue = false)]
-        public ArtifactContent Body { get; set; }
+        public virtual ArtifactContent Body { get; set; }
 
         /// <summary>
         /// Specifies whether a response was received from the server.
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [DataMember(Name = "noResponseReceived", IsRequired = false, EmitDefaultValue = false)]
         [DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        public bool NoResponseReceived { get; set; }
+        public virtual bool NoResponseReceived { get; set; }
 
         /// <summary>
         /// Key/value pairs that provide additional information about the response.
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <summary>
         /// Creates a deep copy of this instance.
         /// </summary>
-        public WebResponse DeepClone()
+        public virtual WebResponse DeepClone()
         {
             return (WebResponse)DeepCloneCore();
         }

--- a/src/Sarif/ToDotNet/ToDotNet.targets
+++ b/src/Sarif/ToDotNet/ToDotNet.targets
@@ -21,7 +21,7 @@
     
     <Exec Command="&quot;$(NuGetPath)\NuGet.exe&quot; restore &quot;$(MSBuildThisFileDirectory)packages.config&quot; -PackagesDirectory &quot;$(MSBuildThisFileDirectory)\..\..\packages&quot; -ConfigFile &quot;$(NuGetConfigPath)&quot; -Verbosity quiet" />
     <Message Importance="high" Text="Generating SARIF object model..." />
-    <Exec Command="&quot;$(JsonSchemaToDotNetPath)&quot; --schema-name Sarif --schema-file-path &quot;%(JsonSchemaFile.FullPath)&quot; --output-directory &quot;$(_ObjectModelOutputDirectory)&quot; --force-overwrite --namespace-name %(JsonSchemaFile.Namespace) --root-class-name %(JsonSchemaFile.RootClassName) --copyright-file-path &quot;%(JsonSchemaFile.CopyrightFilePath)&quot; --hints-file-path &quot;%(JsonSchemaFile.HintsFilePath)&quot; --generate-cloning-code --protected-init-methods" />
+    <Exec Command="&quot;$(JsonSchemaToDotNetPath)&quot; --schema-name Sarif --schema-file-path &quot;%(JsonSchemaFile.FullPath)&quot; --output-directory &quot;$(_ObjectModelOutputDirectory)&quot; --force-overwrite --namespace-name %(JsonSchemaFile.Namespace) --root-class-name %(JsonSchemaFile.RootClassName) --copyright-file-path &quot;%(JsonSchemaFile.CopyrightFilePath)&quot; --hints-file-path &quot;%(JsonSchemaFile.HintsFilePath)&quot; --generate-cloning-code --protected-init-methods --virtual-members" />
     <Message Text="Generated classes from @(JsonSchemaFile) -> $(_ObjectModelOutputDirectory)"/>
   </Target>
   <!--

--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.16</VersionPrefix>
+    <VersionPrefix>2.1.17</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -30,7 +30,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.15</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.16</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>


### PR DESCRIPTION
Enable -virtual-members on the Jschema ToDotNet command-line in order to emit core object model members as virtual.

Change also revises the SDK version # in build.props. All changes other than this, the relevant CSPROJ update and release note addition are auto-generated.