### PR TITLE
Fix #1673 (property bag testing); Fix #1687 (NuGet packaging warning)

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,9 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.1.18** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.18) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.18) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.18) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.18)
+* FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
+* BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
+
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * API NON-BREAKING: emit all core object model members as 'virtual'.
 * FEATURE: Introduce SarifConsolidator to shrink large log files. [#1675](https://github.com/microsoft/sarif-sdk/issues/1675)
@@ -106,16 +110,16 @@
 * API BREAKING: Improve `address` object design. [oasis-tcs/sarif-spec#401](https://github.com/oasis-tcs/sarif-spec/issues/401)
 
 ## **v2.1.0-beta.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.2)
-* API NON-BREAKING: Change `request.target` type to string. https://github.com/oasis-tcs/sarif-spec/issues/362
-* API BREAKING: anyOf `physicalLocation.artifactLocation` and `physicalLocation.address` is required. https://github.com/oasis-tcs/sarif-spec/issues/353
+* API NON-BREAKING: Change `request.target` type to string. [oasis-tcs/sarif-spec#362](https://github.com/oasis-tcs/sarif-spec/issues/362)
+* API BREAKING: anyOf `physicalLocation.artifactLocation` and `physicalLocation.address` is required. [oasis-tcs/sarif-spec#353](https://github.com/oasis-tcs/sarif-spec/issues/353)
 * API BREAKING: Rename `run.defaultFileEncoding` to `run.defaultEncoding`.
-* API NON-BREAKING: Add `threadFlowLocation.taxa`. https://github.com/oasis-tcs/sarif-spec/issues/381
+* API NON-BREAKING: Add `threadFlowLocation.taxa`. [oasis-tcs/sarif-spec#381](https://github.com/oasis-tcs/sarif-spec/issues/381)
 * API BREAKING: anyOf `message.id` and `message.text` is required.
-* API NON-BREAKING: Add `request.noResponseReceived` and `request.failureReason`. https://github.com/oasis-tcs/sarif-spec/issues/378
+* API NON-BREAKING: Add `request.noResponseReceived` and `request.failureReason`. [oasis-tcs/sarif-spec#378](https://github.com/oasis-tcs/sarif-spec/issues/378)
 * API BREAKING: anyOf `externalPropertyFileReference.guid` and `externalPropertyFileReference.location` is required.
 * API BREAKING: `artifact.length` should have `default: -1, minimum: -1` values.
 * API BREAKING: Rename `fix.changes` to `fix.artifactChanges`.
-* API BREAKING: Each redaction token in an originalUriBaseId represents a unique location. https://github.com/oasis-tcs/sarif-spec/issues/377
+* API BREAKING: Each redaction token in an originalUriBaseId represents a unique location. [oasis-tcs/sarif-spec#377](https://github.com/oasis-tcs/sarif-spec/issues/377)
 * API BREAKING: Rename file related enums in `artifact.roles`.
 * API BREAKING: anyOf `artifactLocation.uri` and `artifactLocation.index` is required.
 * API BREAKING: `multiformatMessageString.text` is required.
@@ -136,17 +140,17 @@
 * API BREAKING: `request.index` should have default: -1, minimum: -1.
 * API BREAKING: `response.index` should have default: -1, minimum: -1.
 * API NON-BREAKING: `externalProperties.version` is not a required property if it is not root element.
-* API NON-BREAKING: Add artifact roles for configuration files. https://github.com/oasis-tcs/sarif-spec/issues/372
-* API NON-BREAKING: Add suppression.justification. https://github.com/oasis-tcs/sarif-spec/issues/373
-* API NON-BREAKING: Associate descriptor metadata with thread flow locations. https://github.com/oasis-tcs/sarif-spec/issues/381
-* API BREAKING: Move `location.physicalLocation.id` to `location.id`. https://github.com/oasis-tcs/sarif-spec/issues/375
+* API NON-BREAKING: Add artifact roles for configuration files. [oasis-tcs/sarif-spec#372](https://github.com/oasis-tcs/sarif-spec/issues/372)
+* API NON-BREAKING: Add suppression.justification. [oasis-tcs/sarif-spec#373](https://github.com/oasis-tcs/sarif-spec/issues/373)
+* API NON-BREAKING: Associate descriptor metadata with thread flow locations. [oasis-tcs/sarif-spec#381](https://github.com/oasis-tcs/sarif-spec/issues/381)
+* API BREAKING: Move `location.physicalLocation.id` to `location.id`. [oasis-tcs/sarif-spec#375](https://github.com/oasis-tcs/sarif-spec/issues/375)
 * API BREAKING: `result.stacks` array should have unique items.
 * API BREAKING: `result.relatedLocations` array should have unique items.
-* API BREAKING: Separate `suppression` `status` from `kind`. https://github.com/oasis-tcs/sarif-spec/issues/371
+* API BREAKING: Separate `suppression` `status` from `kind`. [oasis-tcs/sarif-spec#371](https://github.com/oasis-tcs/sarif-spec/issues/371)
 * API BREAKING: `reportingDescriptorReference` requires anyOf (`index`, `guid`, `id`).
 * API BREAKING: Rename `request` object and related properties to `webRequest`.
 * API BREAKING: Rename `response` object and related properties to `webResponse`.
-* API NON-BREAKING: Add `locationRelationship` object. https://github.com/oasis-tcs/sarif-spec/issues/375
+* API NON-BREAKING: Add `locationRelationship` object. [oasis-tcs/sarif-spec#375](https://github.com/oasis-tcs/sarif-spec/issues/375)
 * API BREAKING: `externalPropertyFileReference.itemCount` can be 0 and defaults to minimum: -1, default: -1.
 * API BREAKING: `threadFlowLocation.executionOrder` can be 0 and defaults to -1, so minimum: -1, default: -1
 * API BREAKING: Rename artifact role `traceFile` to `tracedFile`.
@@ -161,21 +165,21 @@
 * API BREAKING: Change `notification.physicalLocation` of type `physicalLocation` to `notification.locations` of type `locations`.
 
 ## **v2.1.0-beta.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.1))
-* API BREAKING: Change `request.uri` to `request.target`. https://github.com/oasis-tcs/sarif-spec/issues/362
+* API BREAKING: Change `request.uri` to `request.target`. [oasis-tcs/sarif-spec#362](https://github.com/oasis-tcs/sarif-spec/issues/362)
 
 ## **v2.1.0-beta.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.0-beta.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.0-beta.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.0-beta.0)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.0-beta.0))
-* API BREAKING: All SARIF state dictionaries now contains multiformat strings as values. https://github.com/oasis-tcs/sarif-spec/issues/361
-* API NON-BREAKING: Define `request` and `response` objects. https://github.com/oasis-tcs/sarif-spec/issues/362
+* API BREAKING: All SARIF state dictionaries now contains multiformat strings as values. [oasis-tcs/sarif-spec#361](https://github.com/oasis-tcs/sarif-spec/issues/361)
+* API NON-BREAKING: Define `request` and `response` objects. [oasis-tcs/sarif-spec#362](https://github.com/oasis-tcs/sarif-spec/issues/362)
 
 ## **v2.0.0-csd.2.beta.2019.04-03.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.3)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.3))
-* API BREAKING: Rename `reportingDescriptor.descriptor` to `reportingDescriptor.target`. https://github.com/oasis-tcs/sarif-spec/issues/356
-* API NON-BREAKING: Remove `canPrecedeOrFollow` from relationship kind list. https://github.com/oasis-tcs/sarif-spec/issues/356
+* API BREAKING: Rename `reportingDescriptor.descriptor` to `reportingDescriptor.target`. [oasis-tcs/sarif-spec#356](https://github.com/oasis-tcs/sarif-spec/issues/356)
+* API NON-BREAKING: Remove `canPrecedeOrFollow` from relationship kind list. [oasis-tcs/sarif-spec#356](https://github.com/oasis-tcs/sarif-spec/issues/356)
 
 ## **v2.0.0-csd.2.beta.2019.04-03.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.2)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.2))
-* API NON-BREAKING: Add `module` to `address.kind`. https://github.com/oasis-tcs/sarif-spec/issues/353
-* API BREAKING: `address.baseAddress` & `address.offset` to int. https://github.com/oasis-tcs/sarif-spec/issues/353
-* API BREAKING: Update how reporting descriptors describe their taxonomic relationships. https://github.com/oasis-tcs/sarif-spec/issues/356
-* API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. https://github.com/oasis-tcs/sarif-spec/issues/168
+* API NON-BREAKING: Add `module` to `address.kind`. [oasis-tcs/sarif-spec#353](https://github.com/oasis-tcs/sarif-spec/issues/353)
+* API BREAKING: `address.baseAddress` & `address.offset` to int. [oasis-tcs/sarif-spec#353](https://github.com/oasis-tcs/sarif-spec/issues/353)
+* API BREAKING: Update how reporting descriptors describe their taxonomic relationships. [oasis-tcs/sarif-spec#356](https://github.com/oasis-tcs/sarif-spec/issues/356)
+* API NON-BREAKING: Add `initialState` and `immutableState` properties to thread flow object. Add `immutableState` to `graphTraversal` object. [oasis-tcs/sarif-spec#168](https://github.com/oasis-tcs/sarif-spec/issues/168)
 
 ## **v2.0.0-csd.2.beta.2019.04-03.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.04-03.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.04-03.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.04-03.1)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.04-03.1))
 * API BREAKING: Rename `message.messageId` property to `message.id`. https://github.com/oasis-tcs/sarif-spec/issues/352

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -273,8 +273,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             {
                 string normalizedSpecifier = specifier;
 
-                Uri uri;
-                if (Uri.TryCreate(specifier, UriKind.RelativeOrAbsolute, out uri))
+                if (Uri.TryCreate(specifier, UriKind.RelativeOrAbsolute, out Uri uri))
                 {
                     if (uri.IsAbsoluteUri && (uri.IsFile || uri.IsUnc))
                     {
@@ -305,9 +304,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             RuntimeConditions runtimeErrors,
             string filePath = null)
         {
-            var context = new TContext();
-            context.Logger = logger;
-            context.RuntimeErrors = runtimeErrors;
+            var context = new TContext
+            {
+                Logger = logger,
+                RuntimeErrors = runtimeErrors
+            };
 
             if (filePath != null)
             {
@@ -449,11 +450,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         private IEnumerable<string> GenerateSensitiveTokensList()
         {
-            var result = new List<String>();
-
-            result.Add(Environment.MachineName);
-            result.Add(Environment.UserName);
-            result.Add(Environment.UserDomainName);
+            var result = new List<string>
+            {
+                Environment.MachineName,
+                Environment.UserName,
+                Environment.UserDomainName
+            };
 
             string userDnsDomain = Environment.GetEnvironmentVariable("USERDNSDOMAIN");
             string logonServer = Environment.GetEnvironmentVariable("LOGONSERVER");

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -61,8 +61,6 @@ namespace Microsoft.CodeAnalysis.Sarif
                         propertyName));
             }
 
-            // Avoid a crash if the string-valued property we are attempting to retrieve has
-            // a null value in the JSON file.
             if (Properties[propertyName] == null) { return null; }
 
             if (!Properties[propertyName].IsString)

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                         propertyName));
             }
 
+            // Avoid a crash if the string-valued property we are attempting to retrieve has
+            // a null value in the JSON file.
             if (Properties[propertyName] == null) { return null; }
 
             if (!Properties[propertyName].IsString)

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -161,6 +161,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             if (value == null)
             {
+                // This is consistent with what the PropertyBagConverter does when it encounters
+                // a null-valued property. Whether we create a property bag dictionary entry
+                // by deserializing a null from the log file or by calling SetProperty("aProp", null),
+                // the internal representation is the same: a null value in the Properties
+                // dictionary.
                 Properties[propertyName] = null;
             }
             else

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis.Sarif
                         propertyName));
             }
 
+            if (Properties[propertyName] == null) { return null; }
+
             if (!Properties[propertyName].IsString)
             {
                 throw new InvalidOperationException(SdkResources.CallGenericGetProperty);
@@ -84,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return true;
             }
 
-            value = default(T);
+            value = default;
             return false;
         }
 
@@ -155,10 +157,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void SetProperty<T>(string propertyName, T value)
         {
-            if (Properties == null)
-            {
-                Properties = new Dictionary<string, SerializedPropertyInfo>();
-            }
+            Properties = Properties ?? new Dictionary<string, SerializedPropertyInfo>();
 
             bool isString = typeof(T) == typeof(string);
 
@@ -217,10 +216,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public void RemoveProperty(string propertyName)
         {
-            if (Properties != null)
-            {
-                Properties.Remove(propertyName);
-            }
+                Properties?.Remove(propertyName);
         }
 
         [JsonIgnore]

--- a/src/Sarif/Core/PropertyBagHolder.cs
+++ b/src/Sarif/Core/PropertyBagHolder.cs
@@ -17,8 +17,6 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public class PropertyBagHolder : IPropertyBagHolder
     {
-        private const string NullValue = "null";
-
         protected PropertyBagHolder()
         {
             Tags = new TagsCollection(this);
@@ -74,10 +72,8 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             string value = Properties[propertyName].SerializedValue;
 
-            // Remove the quotes around the serialized value ("x" => x) -- unless it's null.
-            return value.Equals(NullValue, StringComparison.Ordinal)
-                ? null
-                : value.Substring(1, value.Length - 2);
+            // Remove the quotes around the serialized value ("x" => x).
+            return value.Substring(1, value.Length - 2);
         }
 
         public bool TryGetProperty<T>(string propertyName, out T value)
@@ -163,13 +159,14 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             bool isString = typeof(T) == typeof(string);
 
-            string serializedValue;
             if (value == null)
             {
-                serializedValue = NullValue;
+                Properties[propertyName] = null;
             }
             else
             {
+                string serializedValue;
+
                 if (isString)
                 {
                     serializedValue = JsonConvert.ToString(value);
@@ -190,9 +187,9 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                     serializedValue = JsonConvert.SerializeObject(value, settings);
                 }
-            }
 
-            Properties[propertyName] = new SerializedPropertyInfo(serializedValue, isString);
+                Properties[propertyName] = new SerializedPropertyInfo(serializedValue, isString);
+            }
         }
 
         public void SetPropertiesFrom(IPropertyBagHolder other)

--- a/src/Test.FunctionalTests.Sarif/PropertyBagConverterTests.cs
+++ b/src/Test.FunctionalTests.Sarif/PropertyBagConverterTests.cs
@@ -56,9 +56,9 @@ namespace Microsoft.CodeAnalysis.Sarif.FunctionalTests
             };
 
             var settings = new JsonSerializerSettings { Formatting = Formatting.Indented };
-            string originalLogText = JsonConvert.SerializeObject(originalLog, settings);
+            string originalLogContents = JsonConvert.SerializeObject(originalLog, settings);
 
-            SarifLog deserializedLog = SarifUtilities.DeserializeObject<SarifLog>(originalLogText);
+            SarifLog deserializedLog = SarifUtilities.DeserializeObject<SarifLog>(originalLogContents);
             run = deserializedLog.Runs[0];
 
             int integerProperty = run.GetProperty<int>(intPropertyName);
@@ -75,9 +75,15 @@ namespace Microsoft.CodeAnalysis.Sarif.FunctionalTests
 
             run.GetProperty<DateTime>(dateTimePropertyName).Should().Be(dateTimePropertyValue);
 
-            string reserializedLog = JsonConvert.SerializeObject(deserializedLog, settings);
+            // In addition to checking the individual properties (which is nice for explicitness),
+            // we redundantly check that the entire SarifLog objects match.
+            // THIS ASSERTION IS COMMENTED OUT BECAUSE OF https://github.com/microsoft/sarif-sdk/issues/1689,
+            // "Generated code for property bag comparison is incorrect."
+            //originalLog.ValueEquals(deserializedLog).Should().BeTrue();
 
-            reserializedLog.Should().Be(originalLogText);
+            string reserializedLogContents = JsonConvert.SerializeObject(deserializedLog, settings);
+
+            reserializedLogContents.Should().Be(originalLogContents);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
+++ b/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT        
 // license. See LICENSE file in the project root for full license information. 
 
+using System;
+using System.Globalization;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Xunit;
@@ -14,12 +16,83 @@ namespace Microsoft.CodeAnalysis.Sarif
         private static string GetResourceContents(string resourceName)
             => s_extractor.GetResourceText($"RoundTripping.{resourceName}");
 
+        // Class used to test serialization and deserialization of an arbitrary class.
+        public class CustomObject
+        {
+            public DateTime DateTime { get; set; }
+            public string String { get; set; }
+        }
+
+        private static DateTime ParseUtcDateTime(string dateTime)
+        {
+            // DateTimeStyles.AdjustToUniversal is necessary because otherwise DateTime.Parse
+            // adjusts the time from UTC to local time (for example, in Redmond, it subtracts
+            // 7 hours). We want the hours field to be exactly as specified in the test file.
+            return DateTime.Parse(dateTime, provider: null, DateTimeStyles.AdjustToUniversal);
+        }
+
         [Fact]
-        public void SarifLog_CanBeRoundTripped()
+        public void SarifLog_PropertyBagProperties_CanBeRoundTripped()
         {
             string originalContents = GetResourceContents("RoundTripping.sarif");
 
-            SarifLog log = JsonConvert.DeserializeObject<SarifLog>(originalContents);
+            SarifLog log = SarifUtilities.DeserializeObject<SarifLog>(originalContents);
+
+            PropertyBagHolder holder = log.Runs[0].Results[0];
+
+            DateTime dateTimeProperty = holder.GetProperty<DateTime>("dateTime");
+            dateTimeProperty.Should().Be(ParseUtcDateTime("2019-09-25T15:07:01Z"));
+
+            string stringProperty = holder.GetProperty("string");
+            stringProperty.Should().Be("Hello, string!");
+
+            int intProperty = holder.GetProperty<int>("int");
+            intProperty.Should().Be(42);
+
+            long longProperty = holder.GetProperty<long>("long");
+            longProperty.Should().Be(5000000000);
+
+            // This integer-valued JSON property is too big for an Int32.
+            Action action = () => holder.GetProperty<int>("long");
+            action.Should().Throw<JsonReaderException>();
+
+            bool trueProperty = holder.GetProperty<bool>("true");
+            trueProperty.Should().BeTrue();
+
+            bool falseProperty = holder.GetProperty<bool>("false");
+            falseProperty.Should().BeFalse();
+
+            string nullProperty = holder.GetProperty("null");
+            nullProperty.Should().BeNull();
+
+            DateTime[] dateTimeArray = holder.GetProperty<DateTime[]>("dateTimeArray");
+            dateTimeArray.Length.Should().Be(2);
+            dateTimeArray[0].Should().Be(ParseUtcDateTime("2019-09-26T15:52:02Z"));
+            dateTimeArray[1].Should().Be(ParseUtcDateTime("2019-09-26T15:54Z"));
+
+            string[] stringArray = holder.GetProperty<string[]>("stringArray");
+            stringArray.Length.Should().Be(2);
+            stringArray[0].Should().Be("Thing One");
+            stringArray[1].Should().Be("Thing Two");
+
+            int[] intArray = holder.GetProperty<int[]>("intArray");
+            intArray.Length.Should().Be(2);
+            intArray[0].Should().Be(54);
+            intArray[1].Should().Be(-54);
+
+            bool[] boolArray = holder.GetProperty<bool[]>("boolArray");
+            boolArray.Length.Should().Be(2);
+            boolArray[0].Should().Be(true);
+            boolArray[1].Should().Be(false);
+
+            string[] nullArray = holder.GetProperty<string[]>("nullArray");
+            nullArray.Length.Should().Be(2);
+            nullArray[0].Should().BeNull();
+            nullArray[1].Should().BeNull();
+
+            CustomObject customObject = holder.GetProperty<CustomObject>("customObject");
+            customObject.DateTime.Should().Be(ParseUtcDateTime("1776-07-04T12:00Z"));
+            customObject.String.Should().Be("The 4th");
 
             string roundTrippedContents = JsonConvert.SerializeObject(log, Formatting.Indented);
 

--- a/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
+++ b/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
@@ -56,6 +56,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             Action action = () => holder.GetProperty<int>("long");
             action.Should().Throw<JsonReaderException>();
 
+            double doubleProperty = holder.GetProperty<double>("double");
+            doubleProperty.Should().Be(3.14159265);
+
             bool trueProperty = holder.GetProperty<bool>("true");
             trueProperty.Should().BeTrue();
 

--- a/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
+++ b/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT        
+// license. See LICENSE file in the project root for full license information. 
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif
+{
+    public class RoundTrippingTests
+    {
+        private static ResourceExtractor s_extractor = new ResourceExtractor(typeof(RoundTrippingTests));
+
+        private static string GetResourceContents(string resourceName)
+            => s_extractor.GetResourceText($"RoundTripping.{resourceName}");
+
+        [Fact]
+        public void SarifLog_CanBeRoundTripped()
+        {
+            string originalContents = GetResourceContents("RoundTripping.sarif");
+
+            SarifLog log = JsonConvert.DeserializeObject<SarifLog>(originalContents);
+
+            string roundTrippedContents = JsonConvert.SerializeObject(log, Formatting.Indented);
+
+            roundTrippedContents.Should().Be(originalContents);
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
+++ b/src/Test.UnitTests.Sarif/RoundTrippingTests.cs
@@ -66,9 +66,15 @@ namespace Microsoft.CodeAnalysis.Sarif
             nullProperty.Should().BeNull();
 
             DateTime[] dateTimeArray = holder.GetProperty<DateTime[]>("dateTimeArray");
-            dateTimeArray.Length.Should().Be(2);
+            dateTimeArray.Length.Should().Be(3);
             dateTimeArray[0].Should().Be(ParseUtcDateTime("2019-09-26T15:52:02Z"));
             dateTimeArray[1].Should().Be(ParseUtcDateTime("2019-09-26T15:54Z"));
+            // Round-tripping works exactly with up to 7 decimal digits after the seconds. This
+            // is because Newtonsoft.Json's default DateTime serialization places the first seven
+            // decimal digits at the end of the Ticks count (for example, 637051101051234567).
+            // If the next digit is less than 5, the comparison will work precisely no matter
+            // how many additional digits there are; otherwise, the comparison will fail).
+            dateTimeArray[2].Should().Be(ParseUtcDateTime("2019-09-26T15:55:05.12345673"));
 
             string[] stringArray = holder.GetProperty<string[]>("stringArray");
             stringArray.Length.Should().Be(2);

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -54,6 +54,7 @@
     <None Remove="TestData\PrereleaseCompatibilityTransformer\Inputs\V1.sarif" />
     <None Remove="TestData\PrereleaseCompatibilityTransformer\Inputs\WithExternalPropertyFiles.01-24.sarif" />
     <None Remove="TestData\PrereleaseCompatibilityTransformer\Inputs\WithSuppressions.sarif" />
+    <None Remove="TestData\RoundTripping\RoundTripping.sarif" />
     <None Remove="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithNotificationTime.sarif" />
     <None Remove="TestData\SarifCurrentToVersionOneVisitor\Inputs\OneRunWithNotificationTime.sarif" />
     <None Remove="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\MinimumWithLanguage.sarif" />
@@ -85,6 +86,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\RegressionTests.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\RegressionTests.sarif" />
+    <EmbeddedResource Include="TestData\RoundTripping\RoundTripping.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\NonDottedQuadFileVersion.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\ExpectedOutputs\ResultLocationsAsEmptyArray.sarif" />
     <EmbeddedResource Include="TestData\SarifVersionOneToCurrentVisitor\Inputs\NonDottedQuadFileVersion.sarif" />

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -19,6 +19,7 @@
             "string": "Hello, string!",
             "int": 42,
             "long": 5000000000,
+            "double": 3.14159265,
             "true": true,
             "false": false,
             "null": null,

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -15,7 +15,7 @@
             "text": "Hello."
           },
           "properties": {
-            "dateTime": "2019-09-25T15:07:01Z",
+            "dateTime": "2019-09-25T15:07:01",
             "string": "Hello, string!",
             "int": 42,
             "long": 5000000000,
@@ -23,8 +23,9 @@
             "false": false,
             "null": null,
             "dateTimeArray": [
-  "2019-09-26T15:52:02Z",
-  "2019-09-26T15:54Z"
+  "2019-09-26T15:52:02",
+  "2019-09-26T15:54",
+  "2019-09-26T15:55:05.123456789"
 ],
             "stringArray": [
   "Thing One",
@@ -43,7 +44,7 @@
   null
 ],
             "customObject": {
-  "DateTime": "1776-07-04T12:00Z",
+  "DateTime": "1776-07-04T12:00",
   "String": "The 4th"
 }
           }

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Bug1673Tester"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TST0001",
+          "message": {
+            "text": "Hello."
+          },
+          "properties": {
+            "date": "2019-09-25T15:07Z",
+            "string": "Hello, string!",
+            "integer": 42,
+            "bigInteger": 5000000000,
+            "true": true,
+            "false": false,
+            "dateArray": [
+  "2019-09-26T15:52Z",
+  "2019-09-26T15:54Z"
+],
+            "stringArray": [
+  "Thing One",
+  "Thing Two"
+],
+            "customObject": {
+  "date": "1776-07-04T12:00Z",
+  "string": "The 4th"
+}
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -21,6 +21,7 @@
             "bigInteger": 5000000000,
             "true": true,
             "false": false,
+            "null": null,
             "dateArray": [
   "2019-09-26T15:52Z",
   "2019-09-26T15:54Z"
@@ -28,6 +29,18 @@
             "stringArray": [
   "Thing One",
   "Thing Two"
+],
+            "integerArray": [
+  54,
+  -54
+],
+            "booleanArray": [
+  true,
+  false
+],
+            "nullArray": [
+  null,
+  null
 ],
             "customObject": {
   "date": "1776-07-04T12:00Z",

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -15,26 +15,26 @@
             "text": "Hello."
           },
           "properties": {
-            "date": "2019-09-25T15:07Z",
+            "dateTime": "2019-09-25T15:07:01Z",
             "string": "Hello, string!",
-            "integer": 42,
-            "bigInteger": 5000000000,
+            "int": 42,
+            "long": 5000000000,
             "true": true,
             "false": false,
             "null": null,
-            "dateArray": [
-  "2019-09-26T15:52Z",
+            "dateTimeArray": [
+  "2019-09-26T15:52:02Z",
   "2019-09-26T15:54Z"
 ],
             "stringArray": [
   "Thing One",
   "Thing Two"
 ],
-            "integerArray": [
+            "intArray": [
   54,
   -54
 ],
-            "booleanArray": [
+            "boolArray": [
   true,
   false
 ],
@@ -43,8 +43,8 @@
   null
 ],
             "customObject": {
-  "date": "1776-07-04T12:00Z",
-  "string": "The 4th"
+  "DateTime": "1776-07-04T12:00Z",
+  "String": "The 4th"
 }
           }
         }

--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.17</VersionPrefix>
+    <VersionPrefix>2.1.18</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -30,7 +30,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.16</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.17</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>
@@ -92,13 +92,17 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Microsoft/sarif-sdk</PackageProjectUrl>
-    <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2008860</PackageIconUrl>
+    <PackageIcon>triskelion.png</PackageIcon>
     <!--
     Don't complain about SemVer 2.0.0-compatible version strings.
     See https://github.com/NuGet/Home/issues/4687#issuecomment-393302779.
     -->
     <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\triskelion.png" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(MsBuildThisFileDirectory)Shared\CommonAssemblyInfo.cs" />


### PR DESCRIPTION
I added a comprehensive end-to-end test of round-tripping property bag properties. I also added a `DateTime` test to the `PropertyBagConverterTests` functional tests.

The problem that @ScottLouvau ran into with the `DateTime` test is related to my fix for #1577. I don't mean that my fix caused his problem; I mean that to avoid the problem, we need to do the same thing I did to fix #1577. For an explanation, see [this comment](https://github.com/microsoft/sarif-sdk/blob/83ecf0fa2d919a0be70a144464fc25d8b898a294/src/Sarif/SarifUtilities.cs#L190-L214) in SarifUtilities.cs.

In short, when Newtonsoft.Json deserializes a string-valued property that looks to it like a `DateTime`, its default behavior is to convert it to a `DateTime` object. That behavior breaks our property round-tripping. To avoid it, we need to call `JsonConvert.DeserializeObject` with a `JsonSerializerSettings` object that specifies `DateParseHandling.None`. That tells Newtonsoft.Json to leave string-valued properties alone and let us handle the `DateTime`-iness. In #1577, I introduced `SarifUtilities.DeserializeObject` to do exactly that.

@michaelcfanning and I have discussed this and we know it's not the end of the story. It's too easy to forget (or not to know about) the need to call the `SarifUtilities` method, which is exactly what happened in that existing unit test. But as far as verifying that our handling of property bag properties is good, I believe we now have sufficient test coverage to be confident of that.

Also:
- Fix a NuGet packaging warning.
- Improve our internal handling of property bag properties with `null` values.