### PR TITLE
Result Matching Improvements

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -3,6 +3,7 @@
 ## **v2.1.18** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.18) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.18) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.18) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.18)
 * FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
 * BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
+* BUGFIX: Improve Result Matching sort and comparison.
 
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * API NON-BREAKING: emit all core object model members as 'virtual'.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -3,7 +3,9 @@
 ## **v2.1.18** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.18) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.18) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.18) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.18)
 * FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
 * BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
-* BUGFIX: Improve Result Matching sort and comparison.
+* BUGFIX: Result Matching now omits previously Absent results.
+* BUGFIX: Result Matching properly compares results from the same RuleID when multiple Rules match the same source line.
+* BUGFIX: Result Matching works when a result moves and has the line number in the message.
 
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * API NON-BREAKING: emit all core object model members as 'virtual'.

--- a/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
@@ -136,9 +136,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 
         private static void AddUnmatchedResults(List<ExtractedResult> baselineResults, List<ExtractedResult> currentResults, List<MatchedResults> matchedResults)
         {
+            // Add unmatched results from Baseline log which weren't already Absent in previous run
             foreach (ExtractedResult result in baselineResults)
             {
-                matchedResults.Add(new MatchedResults(result, null));
+                if (result.Result.BaselineState != BaselineState.Absent)
+                {
+                    matchedResults.Add(new MatchedResults(result, null));
+                }
             }
 
             foreach (ExtractedResult result in currentResults)

--- a/src/Sarif/Baseline/V2/ResultMatchingComparer.cs
+++ b/src/Sarif/Baseline/V2/ResultMatchingComparer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
+
+namespace Microsoft.CodeAnalysis.Sarif.Baseline
+{
+    /// <summary>
+    ///  ResultMatchingComparer sorts Results for the Result Matching algorithm.
+    /// </summary>
+    public class ResultMatchingComparer : IComparer<ExtractedResult>
+    {
+        public static ResultMatchingComparer Instance = new ResultMatchingComparer();
+
+        public int Compare(ExtractedResult left, ExtractedResult right)
+        {
+            // Compare by Where first
+            int whereCompare = WhereComparer.Instance.Compare(left, right);
+            if (whereCompare != 0) { return whereCompare; }
+
+            // If tied, compare by RuleId
+            // If multiple rules match a whole line, this ensures the right matches are compared to each other
+            int ruleCompare = left.Result.GetRule(left.OriginalRun).Id.CompareTo(right.Result.GetRule(right.OriginalRun).Id);
+            return ruleCompare;
+        }
+    }
+}

--- a/src/Sarif/Baseline/V2/V2ResultMatcher.cs
+++ b/src/Sarif/Baseline/V2/V2ResultMatcher.cs
@@ -43,12 +43,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
         public StatefulResultMatcher(IList<ExtractedResult> before, IList<ExtractedResult> after)
         {
-            // Sort results by 'Where' for matching
+            // Sort results by 'Where', then 'RuleId' for matching
             Before = new List<ExtractedResult>(before);
-            Before.Sort(WhereComparer.Instance);
+            Before.Sort(ResultMatchingComparer.Instance);
 
             After = new List<ExtractedResult>(after);
-            After.Sort(WhereComparer.Instance);
+            After.Sort(ResultMatchingComparer.Instance);
 
             // Set all match indices to -1 initially (no Results matched).
             MatchingIndexFromBefore = new int[Before.Count];

--- a/src/Sarif/Baseline/V2/WhatComparer.cs
+++ b/src/Sarif/Baseline/V2/WhatComparer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
@@ -199,19 +200,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             if (firstRegion != null)
             {
                 rawMessage = rawMessage
-                    .Replace(firstRegion.StartLine.ToString(), "~SL~")
-                    .Replace(firstRegion.StartColumn.ToString(), "~SC~")
-                    .Replace(firstRegion.EndLine.ToString(), "~EL~")
-                    .Replace(firstRegion.EndColumn.ToString(), "~EC~");
+                    .Replace(firstRegion.StartLine.ToString(CultureInfo.InvariantCulture), "~SL~")
+                    .Replace(firstRegion.StartColumn.ToString(CultureInfo.InvariantCulture), "~SC~")
+                    .Replace(firstRegion.EndLine.ToString(CultureInfo.InvariantCulture), "~EL~")
+                    .Replace(firstRegion.EndColumn.ToString(CultureInfo.InvariantCulture), "~EC~");
             }
 
             return rawMessage;
-        }
-
-        private static bool IsNonEmptyAndEquals(string left, string right)
-        {
-            return (string.IsNullOrEmpty(left) == false)
-                && string.Equals(left, right);
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Baseline2/OverallBaseliningTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/OverallBaseliningTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
+{
+    public class OverallBaseliningTests
+    {
+        private const string SampleFilePath = "elfie-arriba.sarif";
+        private SarifLog SampleLog { get; }
+
+        private static readonly ISarifLogMatcher matcher = ResultMatchingBaselinerFactory.GetDefaultResultMatchingBaseliner();
+        private static readonly ResourceExtractor extractor = new ResourceExtractor(typeof(OverallBaseliningTests));
+
+        public OverallBaseliningTests()
+        {
+            SampleLog = GetLogFromResource(SampleFilePath);
+        }
+
+        private static SarifLog GetLogFromResource(string filePath)
+        {
+            string fileContents = extractor.GetResourceText(filePath);
+            return JsonConvert.DeserializeObject<SarifLog>(fileContents);
+        }
+
+        private static SarifLog Baseline(SarifLog baseline, SarifLog current)
+        {
+            return matcher.Match(new[] { baseline }, new[] { current }).FirstOrDefault();
+        }
+
+        [Fact]
+        public void Overall_Identical()
+        {
+            SarifLog output = Baseline(SampleLog.DeepClone(), SampleLog.DeepClone());
+            output.Runs[0].Results.Where(result => result.BaselineState != BaselineState.Unchanged).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Overall_AbsentResultsInBaselineExcluded()
+        {
+            SarifLog baselineLog = SampleLog.DeepClone();
+
+            // Make the first result already Absent in the baseline run
+            baselineLog.Runs[0].Results[0].BaselineState = BaselineState.Absent;
+
+            // The Absent result should be excluded before matching, so the copy in the current run is considered 'New' rather than 'Unchanged'
+            SarifLog output = Baseline(baselineLog, SampleLog.DeepClone());
+            output.Runs[0].Results.Where(result => result.BaselineState == BaselineState.Unchanged).Should().HaveCount(SampleLog.Runs[0].Results.Count - 1);
+            output.Runs[0].Results.Where(result => result.BaselineState == BaselineState.New).Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void Overall_AbsentResultsInNewRunKept()
+        {
+            // The BaselineState for Results in the current run should be ignored, and will be overwritten by the outcome of the current baselining
+            SarifLog currentLog = SampleLog.DeepClone();
+            currentLog.Runs[0].Results[0].BaselineState = BaselineState.Absent;
+
+            SarifLog output = Baseline(SampleLog.DeepClone(), currentLog);
+            output.Runs[0].Results.Where(result => result.BaselineState != BaselineState.Unchanged).Should().BeEmpty();
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -4,12 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using FluentAssertions;
+
 using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Baseline;
 using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
 using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
+
 using Newtonsoft.Json;
+
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
@@ -82,6 +86,27 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             newRun.Results[2].Locations[0].PhysicalLocation.ArtifactLocation.Uri = new Uri("file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_rsa_privkey_NEW.pem");
 
             IEnumerable<MatchedResults> matches = CreateMatchedResults(SampleRun, newRun);
+            matches.Where(m => m.PreviousResult == null || m.CurrentResult == null).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void V2ResultMatcher_MessageContainsLineNumbers()
+        {
+            // Messages have line and column numbers removed before comparison, so results will still be "sufficiently similar"
+            // if the message references them and the results move to a different line.
+
+            Run firstRun = SampleRun.DeepClone();
+
+            Result result = firstRun.Results[2];
+            result.PartialFingerprints = null;
+            result.Message = new Message() { Text = $"Found issue on line {result.Locations[0].PhysicalLocation.Region.StartLine}" };
+
+            Run secondRun = firstRun.DeepClone();
+            result = secondRun.Results[2];
+            result.Locations[0].PhysicalLocation.Region.StartLine += 5;
+            result.Message = new Message() { Text = $"Found issue on line {result.Locations[0].PhysicalLocation.Region.StartLine}" };
+
+            IEnumerable<MatchedResults> matches = CreateMatchedResults(firstRun, secondRun);
             matches.Where(m => m.PreviousResult == null || m.CurrentResult == null).Should().BeEmpty();
         }
 
@@ -159,6 +184,47 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             IEnumerable<MatchedResults> matches = CreateMatchedResults(SampleRun, newRun);
             matches.Where(m => m.PreviousResult != null && m.CurrentResult != null).Should().HaveCount(5);
             matches.Where(m => m.PreviousResult == null || m.CurrentResult == null).Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void V2ResultMatcher_TwoRulesSameLine()
+        {
+            // Verify that two Results with identical locations but different RuleIDs sort in a consistent order
+            // so that they will be matched with each other.
+
+            // COMPLEX: Getting to the "sufficiently similar" check requires that they don't match beforehand due to:
+            //  - Identical where, so the results must move
+            //  - Unique identical what, so there must be other unmatched results which share every trait with the ones we're checking
+
+            Run firstRun = SampleRun.DeepClone();
+
+            // Copy the first Result and change the Rule only (they'll have same Message, Fingerprints, Location)
+            firstRun.Results[1] = firstRun.Results[0].DeepClone();
+            firstRun.Results[1].RuleId = "NewRuleId";
+
+            // Make another copy of each result and move them so that the results won't have any per-rule unique traits
+            firstRun.Results.Add(firstRun.Results[0].DeepClone());
+            firstRun.Results.Add(firstRun.Results[1].DeepClone());
+            firstRun.Results[5].Locations[0].PhysicalLocation.Region.StartLine += 1;
+            firstRun.Results[6].Locations[0].PhysicalLocation.Region.StartLine += 1;
+
+            Run secondRun = firstRun.DeepClone();
+
+            // Move all Results down
+            secondRun.Results[0].Locations[0].PhysicalLocation.Region.StartLine += 4;
+            secondRun.Results[1].Locations[0].PhysicalLocation.Region.StartLine += 4;
+
+            secondRun.Results[5].Locations[0].PhysicalLocation.Region.StartLine += 1;
+            secondRun.Results[6].Locations[0].PhysicalLocation.Region.StartLine += 1;
+
+            // Swap the order of them to reduce the chance they'll sort the same
+            Result swap = secondRun.Results[0];
+            secondRun.Results[0] = secondRun.Results[1];
+            secondRun.Results[1] = swap;
+
+            // Verify all Results match
+            IEnumerable<MatchedResults> matches = CreateMatchedResults(firstRun, secondRun);
+            matches.Where(m => m.PreviousResult == null || m.CurrentResult == null).Should().BeEmpty();
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -197,6 +197,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             //  - Unique identical what, so there must be other unmatched results which share every trait with the ones we're checking
 
             Run firstRun = SampleRun.DeepClone();
+            int countBeforeAdd = firstRun.Results.Count;
 
             // Copy the first Result and change the Rule only (they'll have same Message, Fingerprints, Location)
             firstRun.Results[1] = firstRun.Results[0].DeepClone();
@@ -205,8 +206,9 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             // Make another copy of each result and move them so that the results won't have any per-rule unique traits
             firstRun.Results.Add(firstRun.Results[0].DeepClone());
             firstRun.Results.Add(firstRun.Results[1].DeepClone());
-            firstRun.Results[5].Locations[0].PhysicalLocation.Region.StartLine += 1;
-            firstRun.Results[6].Locations[0].PhysicalLocation.Region.StartLine += 1;
+
+            firstRun.Results[countBeforeAdd].Locations[0].PhysicalLocation.Region.StartLine += 1;
+            firstRun.Results[countBeforeAdd + 1].Locations[0].PhysicalLocation.Region.StartLine += 1;
 
             Run secondRun = firstRun.DeepClone();
 
@@ -214,8 +216,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             secondRun.Results[0].Locations[0].PhysicalLocation.Region.StartLine += 4;
             secondRun.Results[1].Locations[0].PhysicalLocation.Region.StartLine += 4;
 
-            secondRun.Results[5].Locations[0].PhysicalLocation.Region.StartLine += 1;
-            secondRun.Results[6].Locations[0].PhysicalLocation.Region.StartLine += 1;
+            secondRun.Results[countBeforeAdd].Locations[0].PhysicalLocation.Region.StartLine += 1;
+            secondRun.Results[countBeforeAdd + 1].Locations[0].PhysicalLocation.Region.StartLine += 1;
 
             // Swap the order of them to reduce the chance they'll sort the same
             Result swap = secondRun.Results[0];


### PR DESCRIPTION
Based on issues found in Compliance Run result matching.

1. Exclude Results already 'Absent' in the Baseline from output. (Only report results absent the first time)
2. Sort Results by RuleID after 'where' criteria so matches from different rules on the same line are compared by Rule, as they should be.
3. Canonicalize any line and column numbers in Messages before comparison to match moved results where the message contains a line or column number.

These reduce mismatched results which should match from 76 to a handful.