### PR TITLE
Fix #1695: SarifLogger.Optimized cannot be set.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,15 +1,13 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## **v2.1.19** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.19) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.19) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.19) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.19)
+## **v2.1.20** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.20) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.20) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.20) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.20)
 * API BREAKING: Remove helper method `SarifUtilities.DeserializeObject` introduced in 2.1.15 to fix [#1577](https://github.com/microsoft/sarif-sdk/issues/1577).
 Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no need to work around it with this helper method. `JsonConvert.DeserializeObject` works fine.
 * FEATURE: Expanding Sarif SDK query mode to support Result.Uri, string StartsWith/EndsWith/Contains.
-* FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context
-for a given Result have an integrated way to retrieve it.
-
-## **v2.1.18** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.18) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.18) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.18) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.18)
+* FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context for a given Result have an integrated way to retrieve it.
 * FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
 * BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
+* BUGFIX: SarifLogger.Optimized could not be set from the command line. [#1695](https://github.com/microsoft/sarif-sdk/issues/1695)
 * BUGFIX: Result Matching now omits previously Absent results.
 * BUGFIX: Result Matching properly compares results from the same RuleID when multiple Rules match the same source line.
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.

--- a/src/Sarif.Driver/DriverExtensionMethods.cs
+++ b/src/Sarif.Driver/DriverExtensionMethods.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             if (analyzeOptions.Verbose) { loggingOptions |= LoggingOptions.Verbose; }
             if (analyzeOptions.PrettyPrint) { loggingOptions |= LoggingOptions.PrettyPrint; }
             if (analyzeOptions.Force) { loggingOptions |= LoggingOptions.OverwriteExistingOutputFile; }
+            if (analyzeOptions.Optimize) { loggingOptions |= LoggingOptions.Optimize; }
 
             return loggingOptions;
         }

--- a/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeCommandBase.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 
 namespace Microsoft.CodeAnalysis.Sarif.Driver

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -78,5 +78,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             "rich-return-code",
             HelpText = "Emit a 'rich' return code consisting of a bitfield of conditions (as opposed to 0 or 1 indicating success or failure.")]
         public bool RichReturnCode { get; set; }
+
+        [Option(
+            'z',
+            "optimize",
+            HelpText = "Omit redundant properties, producing a smaller but non-human-readable log.")]
+        public bool Optimize { get; set; }
     }
 }

--- a/src/Sarif/Writers/LoggingOptions.cs
+++ b/src/Sarif/Writers/LoggingOptions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         // Overwrite previous version of log file, if it exists.
         OverwriteExistingOutputFile = 0x4,
 
-        All = PrettyPrint | Verbose | OverwriteExistingOutputFile
+        // Omit redundant properties, producing a smaller but non-human-readable log.
+        Optimize = 0x8,
+
+        All = PrettyPrint | Verbose | OverwriteExistingOutputFile | Optimize
     }
 }

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -198,23 +198,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         public IDictionary<string, HashData> AnalysisTargetToHashDataMap { get; }
         public IDictionary<ReportingDescriptor, int> RuleToIndexMap { get; }
 
-        public bool ComputeFileHashes { get { return _dataToInsert.HasFlag(OptionallyEmittedData.Hashes); } }
+        public bool ComputeFileHashes => _dataToInsert.HasFlag(OptionallyEmittedData.Hashes);
 
-        public bool PersistBinaryContents { get { return _dataToInsert.HasFlag(OptionallyEmittedData.BinaryFiles); } }
+        public bool PersistBinaryContents => _dataToInsert.HasFlag(OptionallyEmittedData.BinaryFiles);
 
-        public bool PersistTextFileContents { get { return _dataToInsert.HasFlag(OptionallyEmittedData.TextFiles); } }
+        public bool PersistTextFileContents => _dataToInsert.HasFlag(OptionallyEmittedData.TextFiles);
 
-        public bool PersistEnvironment { get { return _dataToInsert.HasFlag(OptionallyEmittedData.EnvironmentVariables); } }
+        public bool PersistEnvironment => _dataToInsert.HasFlag(OptionallyEmittedData.EnvironmentVariables);
 
-        public bool OverwriteExistingOutputFile { get { return _loggingOptions.HasFlag(LoggingOptions.OverwriteExistingOutputFile); } }
+        public bool OverwriteExistingOutputFile => _loggingOptions.HasFlag(LoggingOptions.OverwriteExistingOutputFile);
 
-        public bool PrettyPrint { get { return _loggingOptions.HasFlag(LoggingOptions.PrettyPrint); } }
+        public bool PrettyPrint => _loggingOptions.HasFlag(LoggingOptions.PrettyPrint);
 
-        public bool Verbose { get { return _loggingOptions.HasFlag(LoggingOptions.Verbose); } }
+        public bool Verbose => _loggingOptions.HasFlag(LoggingOptions.Verbose);
 
-        // Whether to omit redundant properties; log become non-human-readable but much smaller.
-        // We haven't decided how to expose this, so I'm putting the property to control the relevant code without an external way to set it yet.
-        public bool Optimized { get; internal set; } = true;
+        public bool Optimize => _loggingOptions.HasFlag(LoggingOptions.Optimize);
 
         public virtual void Dispose()
         {
@@ -411,7 +409,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 encoding);
 
             // Remove redundant Uri and UriBaseId once index has been set
-            if (this.Optimized)
+            if (this.Optimize)
             {
                 fileLocation.Uri = null;
                 fileLocation.UriBaseId = null;

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -147,7 +147,8 @@ namespace Microsoft.CodeAnalysis.Sarif.FunctionalTests.Multitool
                 OutputFilePath = actualLogFilePath,
                 Quiet = true,
                 UpdateInputsToCurrentSarif = updateInputsToCurrentSarif,
-                PrettyPrint = true
+                PrettyPrint = true,
+                Optimize = true
             };
 
             var mockFileSystem = new Mock<IFileSystem>();

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -746,6 +746,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     logger.OverwriteExistingOutputFile.Should().BeFalse();
                     logger.PrettyPrint.Should().BeFalse();
                     logger.Verbose.Should().BeFalse();
+                    logger.Optimize.Should().BeFalse();
                     break;
                 }
                 case LoggingOptions.OverwriteExistingOutputFile:
@@ -753,6 +754,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     logger.OverwriteExistingOutputFile.Should().BeTrue();
                     logger.PrettyPrint.Should().BeFalse();
                     logger.Verbose.Should().BeFalse();
+                    logger.Optimize.Should().BeFalse();
                     break;
                 }
                 case LoggingOptions.PrettyPrint:
@@ -760,6 +762,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     logger.OverwriteExistingOutputFile.Should().BeFalse();
                     logger.PrettyPrint.Should().BeTrue();
                     logger.Verbose.Should().BeFalse();
+                    logger.Optimize.Should().BeFalse();
                     break;
                 }
                 case LoggingOptions.Verbose:
@@ -767,6 +770,15 @@ namespace Microsoft.CodeAnalysis.Sarif
                     logger.OverwriteExistingOutputFile.Should().BeFalse();
                     logger.PrettyPrint.Should().BeFalse();
                     logger.Verbose.Should().BeTrue();
+                    logger.Optimize.Should().BeFalse();
+                    break;
+                }
+                case LoggingOptions.Optimize:
+                {
+                    logger.OverwriteExistingOutputFile.Should().BeFalse();
+                    logger.PrettyPrint.Should().BeFalse();
+                    logger.Verbose.Should().BeFalse();
+                    logger.Optimize.Should().BeTrue();
                     break;
                 }
                 case LoggingOptions.All:
@@ -774,6 +786,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     logger.OverwriteExistingOutputFile.Should().BeTrue();
                     logger.PrettyPrint.Should().BeTrue();
                     logger.Verbose.Should().BeTrue();
+                    logger.Optimize.Should().BeTrue();
                     break;
                 }
                 default:

--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
     <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.19</VersionPrefix>
+    <VersionPrefix>2.1.20</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
@@ -30,7 +30,7 @@
     place. These properties are actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
-    <PreviousVersionPrefix>2.1.18</PreviousVersionPrefix>
+    <PreviousVersionPrefix>2.1.17</PreviousVersionPrefix>
     <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
     <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>


### PR DESCRIPTION
We introduce an option to set the `Optimize` flag on the `SarifLogger`, which results in a smaller but non-human-readable log file.

There are a few issues to consider:
- I changed the name of the flag from `Optimized` to `Optimize` because the other option names (`pretty-print`, `overwrite-output-file`, etc.) are imperative verbs, whereas `Optimized` was an adjective.
- It wasn't clear whether this flag belongs on `CommonOptionsBase` or `AnalyzeOptionsBase`. Some options that control file contents (`hashes`, `environment`, `invocation-properties`) are on `AnalyzeOptionsBase`, while others (`insert`, `remove`) are on `CommonOptionsBase`. We should make a call and move them to one place or the other.
- Setting `Default` to `true` on a `Boolean` option doesn't work (we've run into this before). Setting it to `false` reverses the behavior we had until now, where it was _hard-coded_ to `true`. We should either decide it's ok to change that behavior, or change the name and the sense of the flag (for example, `human-readable`).

Please comment on these issues.