### PR TITLE
Fix #1698 (invalid file URIs); Fix #1699 (invalid ruleIndex property)

### DIFF
--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -183,10 +183,8 @@ module.exports = function (results, data) {
 
     if (Object.keys(sarifRules).length > 0) {
 
-        let ruleIndex = 0;
         Object.keys(sarifRules).forEach(function (ruleId) {
             let rule = sarifRules[ruleId];
-            rule.ruleIndex = ruleIndex++;
             sarifLog.runs[0].tool.driver.rules.push(rule);
         });
     }

--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -9,6 +9,7 @@ const lodash = require("lodash");
 const fs = require("fs");
 const utf8 = require("utf8");
 const jschardet = require("jschardet");
+const url = require('url')
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -71,7 +72,7 @@ module.exports = function (results, data) {
             // Create a new entry in the files dictionary.
             sarifFiles[result.filePath] = {
                 location: {
-                    uri: result.filePath
+                    uri: url.pathToFileURL(result.filePath)
                 }
             };
 
@@ -111,7 +112,7 @@ module.exports = function (results, data) {
                             {
                                 physicalLocation: {
                                     artifactLocation: {
-                                        uri: result.filePath,
+                                        uri: url.pathToFileURL(result.filePath),
                                         index: sarifArtifactIndices[result.filePath]
                                     }
                                 }


### PR DESCRIPTION
**NOTE** I know Chris has a day job. This PR is just FYI to him, although I do have a question below that he might shed some light on.

In the course of writing the [SARIF Tutorials](https://github.com/microsoft/sarif-tutorials), I wanted to use the output of the ESLint SARIF formatter as an [example](https://github.com/microsoft/sarif-tutorials/blob/master/docs/Introduction.md#simple-example), and I came across two bugs:

#1698: file paths must be expressed as valid URIs
#1699: ruleIndex is not a valid property of reportingDescriptor

This PR fixes both bugs.

While we're at it: I noticed that the [published version](https://www.npmjs.com/package/eslint.formatter.sarif) of the ESLint SARIF formatter npm module is still the (very) old 2.0.0 version, and also that the web page marks this module as "Deprecated".

**Chris** or **Michael**, Why is it marked "Deprecated"?
**Chris**, did you leave behind instructions for updating the published npm module?

@michaelcfanning @EasyRhin0 @EasyRhinoMSFT 