### PR TITLE
Splitting key value on first ':' only

### DIFF
--- a/src/Sarif.WorkItemFiling/Extensions.cs
+++ b/src/Sarif.WorkItemFiling/Extensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItemFiling
 
                 foreach (string fieldKvp in fieldKvps)
                 {
-                    string[] kv = fieldKvp.Split(':');
+                    string[] kv = fieldKvp.Split(new char[] { ':' }, 2);
 
                     if (kv.Length == 2)
                     {


### PR DESCRIPTION
Splitting key value on first ':' only as value itself could contain a ':' which should be respected.