### PR TITLE
Baselining Improvements

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,11 +6,14 @@ Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no
 * FEATURE: Expanding Sarif SDK query mode to support Result.Uri, string StartsWith/EndsWith/Contains.
 * FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context for a given Result have an integrated way to retrieve it.
 * FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
+* FEATURE: Added Stream-based SarifLog.Load and Save overloads
 * BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
 * BUGFIX: SarifLogger.Optimized could not be set from the command line. [#1695](https://github.com/microsoft/sarif-sdk/issues/1695)
 * BUGFIX: Result Matching now omits previously Absent results.
 * BUGFIX: Result Matching properly compares results from the same RuleID when multiple Rules match the same source line.
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
+* BUGFIX: Result Matching uses Result.Guid as default CorrelationGuid in matched Results.
+* BUGFIX: Null hardening in Result Matching
 
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * API NON-BREAKING: emit all core object model members as 'virtual'.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,14 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## **v2.1.20** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.20) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.20) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.20) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.20)
-* Sort driver skimmers by rule id + name during analysis, in order to improve deterministic ordering of log file data.
-* API BREAKING: Convert various public SARIF Driver framework API to prefer abtract ISet<string> type over HashSet<string>.
-* API BREAKING: Remove helper method `SarifUtilities.DeserializeObject` introduced in 2.1.15 to fix [#1577](https://github.com/microsoft/sarif-sdk/issues/1577).
-Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no need to work around it with this helper method. `JsonConvert.DeserializeObject` works fine.
-* FEATURE: Expanding Sarif SDK query mode to support Result.Uri, string StartsWith/EndsWith/Contains.
-* FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context for a given Result have an integrated way to retrieve it.
-* FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
 * FEATURE: Added Stream-based SarifLog.Load and Save overloads
+* FEATURE: Enhanced property bag serialization unit testing. [#1673](https://github.com/microsoft/sarif-sdk/issues/1673)
 * BUGFIX: Fix packaging warning NU5048 during build. [#1687](https://github.com/microsoft/sarif-sdk/issues/1687)
 * BUGFIX: SarifLogger.Optimized could not be set from the command line. [#1695](https://github.com/microsoft/sarif-sdk/issues/1695)
 * BUGFIX: Result Matching now omits previously Absent results.
@@ -16,6 +10,14 @@ Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
 * BUGFIX: Result Matching uses Result.Guid as default CorrelationGuid in matched Results.
 * BUGFIX: Null hardening in Result Matching
+
+## **v2.1.19** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.19) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.19) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.19) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.19)
+* Sort driver skimmers by rule id + name during analysis, in order to improve deterministic ordering of log file data.
+* API BREAKING: Convert various public SARIF Driver framework API to prefer abstract ISet<string> type over HashSet<string>.
+* API BREAKING: Remove helper method `SarifUtilities.DeserializeObject` introduced in 2.1.15 to fix [#1577](https://github.com/microsoft/sarif-sdk/issues/1577).
+Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no need to work around it with this helper method. `JsonConvert.DeserializeObject` works fine.
+* FEATURE: Expanding Sarif SDK query mode to support Result.Uri, string StartsWith/EndsWith/Contains.
+* FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context for a given Result have an integrated way to retrieve it.
 
 ## **v2.1.17** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.17) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.17) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.17) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.17)
 * API NON-BREAKING: emit all core object model members as 'virtual'.

--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             // Result is New.
             Result result = CurrentResult.Result.DeepClone();
-            result.CorrelationGuid = Guid.NewGuid().ToString();
+            result.CorrelationGuid = result.Guid ?? Guid.NewGuid().ToString(SarifConstants.GuidFormat);
             result.BaselineState = BaselineState.New;
 
             if (!CurrentResult.Result.TryGetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, out originalResultMatchingProperties))
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             // Result exists.
             Result result = CurrentResult.Result.DeepClone();
-            result.CorrelationGuid = PreviousResult.Result.CorrelationGuid;
+            result.CorrelationGuid = PreviousResult.Result.CorrelationGuid ?? PreviousResult.Result.Guid;
             result.BaselineState = BaselineState.Unchanged;
 
             if (!PreviousResult.Result.TryGetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, out originalResultMatchingProperties))

--- a/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 
             foreach (SarifLog sarifLog in sarifLogs)
             {
-                if (sarifLog == null)
+                if (sarifLog?.Runs == null)
                 {
                     continue;
                 }

--- a/src/Sarif/Baseline/V2/WhatComparer.cs
+++ b/src/Sarif/Baseline/V2/WhatComparer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             {
                 foreach (var property in result.Result.Properties)
                 {
-                    yield return new WhatComponent(result.RuleId, "Property", "PropertyBag/" + property.Key, property.Value.SerializedValue);
+                    yield return new WhatComponent(result.RuleId, "Property", "PropertyBag/" + property.Key, property.Value?.SerializedValue);
                 }
             }
         }

--- a/src/Sarif/Baseline/V2/WhatComponent.cs
+++ b/src/Sarif/Baseline/V2/WhatComponent.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
 
         public WhatComponent(string category, string propertySet, string propertyName, string propertyValue)
         {
-            this.Category = category;
-            this.PropertySet = propertySet;
-            this.PropertyName = propertyName;
-            this.PropertyValue = propertyValue;
+            this.Category = category ?? "";
+            this.PropertySet = propertySet ?? "";
+            this.PropertyName = propertyName ?? "";
+            this.PropertyValue = propertyValue ?? "";
         }
 
         public override string ToString()


### PR DESCRIPTION
- Using Result.Guid as default for Result.CorrelationGuid in baselining (when first assigning BaselineGuid and when copying from an older matched result.
- Null hardening in Result Matching.
- Adding SarifLog.Load/Save overloads which take a Stream.