### PR TITLE
Missing pdb location reporting

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -10,6 +10,7 @@
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
 * BUGFIX: Result Matching uses Result.Guid as default CorrelationGuid in matched Results.
 * BUGFIX: Null hardening in Result Matching
+* BUGFIX: Console logger now outputs file location, if when writing notifications.
 
 ## **v2.1.19** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.19) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.19) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.19) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.19)
 * Sort driver skimmers by rule id + name during analysis, in order to improve deterministic ordering of log file data.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -10,7 +10,7 @@
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
 * BUGFIX: Result Matching uses Result.Guid as default CorrelationGuid in matched Results.
 * BUGFIX: Null hardening in Result Matching
-* BUGFIX: Console logger now outputs file location, if when writing notifications.
+* BUGFIX: Console logger now outputs file location, if available, when writing notifications.
 
 ## **v2.1.19** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.19) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.19) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.19) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.19)
 * Sort driver skimmers by rule id + name during analysis, in order to improve deterministic ordering of log file data.

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             string message = result.GetMessageText(rule);
 
-            // TODO we need better retrieval for locations than these defaults
+            // TODO we need better retrieval for locations than these defaults.
             // Note that we can potentially emit many messages from a single result
             PhysicalLocation physicalLocation = result.Locations?.First().PhysicalLocation;
 
@@ -178,18 +178,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             ValidateKindAndLevel(kind, level);
 
-            if (uri != null)
-            {
-                // If a path refers to a URI of form file://blah, we will convert to the local path           
-                if (uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeFile)
-                {
-                    path = uri.LocalPath;
-                }
-                else
-                {
-                    path = uri.ToString();
-                }
-            }
+            path = ConstructPathFromUri(uri);
 
             string issueType = null;
 
@@ -320,7 +309,12 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new InvalidOperationException("Unknown notification level: " + notification.Level);
             }
 
-            var sb = new StringBuilder(_toolName + " : ");
+            // TODO we need better retrieval for locations than these defaults.
+            // Note that we can potentially emit many messages from a single result
+            PhysicalLocation physicalLocation = notification.Locations?.First().PhysicalLocation;
+            Uri uri = physicalLocation?.ArtifactLocation?.Uri;
+
+            var sb = new StringBuilder((ConstructPathFromUri(uri) ?? _toolName) + " : ");
 
             sb.Append(issueType + " ");
 
@@ -337,6 +331,26 @@ namespace Microsoft.CodeAnalysis.Sarif
             sb.Append(notification.Message.Text);
 
             return sb.ToString();
+        }
+
+        private static string ConstructPathFromUri(Uri uri)
+        {
+            string path = null;
+
+            if (uri != null)
+            {
+                // If a path refers to a URI of form file://blah, we will convert to the local path           
+                if (uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeFile)
+                {
+                    path = uri.LocalPath;
+                }
+                else
+                {
+                    path = uri.ToString();
+                }
+            }
+
+            return path;
         }
     }
 }

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -268,14 +268,14 @@ namespace Microsoft.CodeAnalysis.Sarif
                 case FailureLevel.Note:
                     if (Verbose)
                     {
-                        WriteLineToConsole(FormatNotificationMessage(notification));
+                        WriteLineToConsole(FormatNotificationMessage(notification, _toolName));
                     }
                     break;
 
                 // These notification types are always emitted.
                 case FailureLevel.Error:
                 case FailureLevel.Warning:
-                    WriteLineToConsole(FormatNotificationMessage(notification));
+                    WriteLineToConsole(FormatNotificationMessage(notification, _toolName));
                     break;
 
                 default:
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
         }
 
-        private string FormatNotificationMessage(Notification notification)
+        static internal string FormatNotificationMessage(Notification notification, string toolName)
         {
             string issueType = null;
 
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             PhysicalLocation physicalLocation = notification.Locations?.First().PhysicalLocation;
             Uri uri = physicalLocation?.ArtifactLocation?.Uri;
 
-            var sb = new StringBuilder((ConstructPathFromUri(uri) ?? _toolName) + " : ");
+            var sb = new StringBuilder((ConstructPathFromUri(uri) ?? toolName) + " : ");
 
             sb.Append(issueType + " ");
 

--- a/src/Sarif/ConsoleLogger.cs
+++ b/src/Sarif/ConsoleLogger.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             string message = result.GetMessageText(rule);
 
             // TODO we need better retrieval for locations than these defaults.
-            // Note that we can potentially emit many messages from a single result
+            // Note that we can potentially emit many messages from a single result.
             PhysicalLocation physicalLocation = result.Locations?.First().PhysicalLocation;
 
             WriteToConsole(
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
 
             // TODO we need better retrieval for locations than these defaults.
-            // Note that we can potentially emit many messages from a single result
+            // Note that we can potentially emit many messages from a single result.
             PhysicalLocation physicalLocation = notification.Locations?.First().PhysicalLocation;
             Uri uri = physicalLocation?.ArtifactLocation?.Uri;
 

--- a/src/Test.UnitTests.Sarif/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/ConsoleLoggerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
-using System.Security;
 using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif;
 using Xunit;

--- a/src/Test.UnitTests.Sarif/ConsoleLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/ConsoleLoggerTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Security;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Sarif;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif
+{
+    public class ConsoleLoggerTests
+    {
+        [Fact]
+        public void ConsoleLogger_EmitsNotificationLocationMessageOrToolName()
+        {
+            string messageGuid = Guid.NewGuid().ToString();
+            string toolName = Guid.NewGuid().ToString();
+            string uriGuid = Guid.NewGuid().ToString();
+            Uri uri = new Uri(uriGuid, UriKind.RelativeOrAbsolute);
+
+            var notification = new Notification
+            {
+                Message = new Message
+                {
+                    Text = messageGuid
+                },
+
+                Locations = new[]
+                {
+                    new Location
+                    {
+                         PhysicalLocation = new PhysicalLocation
+                         {
+                             ArtifactLocation = new ArtifactLocation
+                             {
+                                 Uri = uri
+                             }
+                         }
+                    }
+                }
+            };
+
+            // If a notification has one or more locations, the first one should be 
+            // present as part of the console out message.
+            string output = ConsoleLogger.FormatNotificationMessage(notification, toolName);
+            output.Should().Contain(uriGuid);
+            output.Should().NotContain(toolName);
+            output.Should().Contain(messageGuid);
+
+            // In the absence of notificaiton locations, the tool name should be 
+            // present as part of the console out message.
+            notification.Locations = null;
+            output = ConsoleLogger.FormatNotificationMessage(notification, toolName);
+            output.Should().NotContain(uriGuid);
+            output.Should().Contain(toolName);
+            output.Should().Contain(messageGuid);
+        }
+    }
+}


### PR DESCRIPTION
Update console logger to emit the first location URL, if available, when outputting notifications. This SDK fix flows to the PDB error reporting in the driver framework.

@rtaket @ScottLouvau @lgolding 