### PR TITLE
Always assign Guids on Baseline

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -8,7 +8,7 @@
 * BUGFIX: Result Matching now omits previously Absent results.
 * BUGFIX: Result Matching properly compares results from the same RuleID when multiple Rules match the same source line.
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
-* BUGFIX: Result Matching assigned Guids and uses Result.Guid as default CorrelationGuid in matched Results.
+* BUGFIX: Result Matching always assigns Result.CorrelationGuid and Result.Guid.
 * BUGFIX: Null hardening in Result Matching
 * BUGFIX: Console logger now outputs file location, if available, when writing notifications.
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -8,7 +8,7 @@
 * BUGFIX: Result Matching now omits previously Absent results.
 * BUGFIX: Result Matching properly compares results from the same RuleID when multiple Rules match the same source line.
 * BUGFIX: Result Matching works when a result moves and has the line number in the message.
-* BUGFIX: Result Matching uses Result.Guid as default CorrelationGuid in matched Results.
+* BUGFIX: Result Matching assigned Guids and uses Result.Guid as default CorrelationGuid in matched Results.
 * BUGFIX: Null hardening in Result Matching
 * BUGFIX: Console logger now outputs file location, if available, when writing notifications.
 

--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -75,6 +75,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             out Dictionary<string, object> originalResultMatchingProperties)
         {
             Result result = PreviousResult.Result.DeepClone();
+            result.Guid = result.Guid ?? Guid.NewGuid().ToString(SarifConstants.GuidFormat);
+            result.CorrelationGuid = result.CorrelationGuid ?? result.Guid;
             result.BaselineState = BaselineState.Absent;
 
             if (!PreviousResult.Result.TryGetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, out originalResultMatchingProperties))
@@ -96,9 +98,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             Dictionary<string, object> resultMatchingProperties,
             out Dictionary<string, object> originalResultMatchingProperties)
         {
-            // Result is New.
+            // Result is New. Use the Result's own Guid as the CorrelationGuid; assign one if not assigned by the producer
             Result result = CurrentResult.Result.DeepClone();
-            result.CorrelationGuid = result.Guid ?? Guid.NewGuid().ToString(SarifConstants.GuidFormat);
+            result.Guid = result.Guid ?? Guid.NewGuid().ToString(SarifConstants.GuidFormat);
+            result.CorrelationGuid = result.CorrelationGuid ?? result.Guid;
             result.BaselineState = BaselineState.New;
 
             if (!CurrentResult.Result.TryGetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, out originalResultMatchingProperties))
@@ -128,7 +131,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             // Result exists.
             Result result = CurrentResult.Result.DeepClone();
-            result.CorrelationGuid = PreviousResult.Result.CorrelationGuid ?? PreviousResult.Result.Guid;
+            result.Guid = result.Guid ?? Guid.NewGuid().ToString(SarifConstants.GuidFormat);
+            result.CorrelationGuid = PreviousResult.Result.CorrelationGuid ?? PreviousResult.Result.Guid ?? result.Guid;
             result.BaselineState = BaselineState.Unchanged;
 
             if (!PreviousResult.Result.TryGetProperty(SarifLogResultMatcher.ResultMatchingResultPropertyName, out originalResultMatchingProperties))

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -237,6 +237,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result newSuppressedResult = matchedRun.Results.Single(r => r.Message.Text == "New suppressed result.");
 
             newSuppressedResult.Suppressions.Count.Should().Be(1);
+            AssertBaselinedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -247,6 +248,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlySuppressed = matchedRun.Results.Single(r => r.Message.Text == "Existing, originally unsuppressed result.");
 
             existingResultNewlySuppressed.Suppressions.Count.Should().Be(1);
+            AssertBaselinedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -257,6 +259,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlySuppressed = matchedRun.Results.Single(r => r.Message.Text == "Result suppressed in both runs.");
 
             existingResultNewlySuppressed.Suppressions.Count.Should().Be(1);
+            AssertBaselinedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -267,6 +270,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlyUnsuppressed = matchedRun.Results.Single(r => r.Message.Text == "Existing, originally suppressed result.");
 
             existingResultNewlyUnsuppressed.Suppressions.Should().BeNull();
+            AssertBaselinedRunInvariants(matchedRun);
         }
 
         /// <summary>
@@ -414,6 +418,20 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
                 matchedRun.Results[i].Properties = originalRun.Results[i].Properties;
 
                 matchedRun.Results[i].ValueEquals(originalRun.Results[i]).Should().BeTrue();
+            }
+        }
+
+        private void AssertBaselinedRunInvariants(Run baselinedRun)
+        {
+            // Ensure all results always have a BaselineState, CorrelationGuid, and Guid assigned after baselining.
+            // The CorrelationGuid provides a stable identity to identify a Result matching across Runs.
+            // The Guid should be the default CorrelationGuid, so that matched Results have an identity mappable to the first occurrence of the Result (even before it was baselined)
+            // The Guid also needs to be defined to provided an identity to attach other data (like Annotations) to the Result consistently.
+            foreach(Result result in baselinedRun.Results ?? Enumerable.Empty<Result>())
+            {
+                Assert.NotNull(result.Guid);
+                Assert.NotNull(result.CorrelationGuid);
+                Assert.NotEqual(BaselineState.None, result.BaselineState);
             }
         }
     }

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result newSuppressedResult = matchedRun.Results.Single(r => r.Message.Text == "New suppressed result.");
 
             newSuppressedResult.Suppressions.Count.Should().Be(1);
-            AssertBaselinedRunInvariants(matchedRun);
+            AssertMatchedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlySuppressed = matchedRun.Results.Single(r => r.Message.Text == "Existing, originally unsuppressed result.");
 
             existingResultNewlySuppressed.Suppressions.Count.Should().Be(1);
-            AssertBaselinedRunInvariants(matchedRun);
+            AssertMatchedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlySuppressed = matchedRun.Results.Single(r => r.Message.Text == "Result suppressed in both runs.");
 
             existingResultNewlySuppressed.Suppressions.Count.Should().Be(1);
-            AssertBaselinedRunInvariants(matchedRun);
+            AssertMatchedRunInvariants(matchedRun);
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             Result existingResultNewlyUnsuppressed = matchedRun.Results.Single(r => r.Message.Text == "Existing, originally suppressed result.");
 
             existingResultNewlyUnsuppressed.Suppressions.Should().BeNull();
-            AssertBaselinedRunInvariants(matchedRun);
+            AssertMatchedRunInvariants(matchedRun);
         }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             }
         }
 
-        private void AssertBaselinedRunInvariants(Run baselinedRun)
+        private void AssertMatchedRunInvariants(Run baselinedRun)
         {
             // Ensure all results always have a BaselineState, CorrelationGuid, and Guid assigned after baselining.
             // The CorrelationGuid provides a stable identity to identify a Result matching across Runs.
@@ -429,9 +429,9 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             // The Guid also needs to be defined to provided an identity to attach other data (like Annotations) to the Result consistently.
             foreach(Result result in baselinedRun.Results ?? Enumerable.Empty<Result>())
             {
-                Assert.NotNull(result.Guid);
-                Assert.NotNull(result.CorrelationGuid);
-                Assert.NotEqual(BaselineState.None, result.BaselineState);
+                result.Guid.Should().NotBeNullOrEmpty();
+                result.CorrelationGuid.Should().NotBeNullOrEmpty();
+                result.BaselineState.Should().NotBe(BaselineState.None);
             }
         }
     }

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -403,11 +403,13 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
             {
                 // The Result objects won't be identical because the results in the matched run
                 // will have their baseline state set, and they have a "ResultMatching" property
-                // bag property.
+                // bag property, and Guid and CorrelationGuid set
                 matchedRun.Results[i].BaselineState.Should().Be(BaselineState.Unchanged);
                 matchedRun.Results[i].Properties.Should().ContainKey("ResultMatching");
 
                 // But aside from that they should be the same:
+                matchedRun.Results[i].Guid = originalRun.Results[i].Guid;
+                matchedRun.Results[i].CorrelationGuid = originalRun.Results[i].CorrelationGuid;
                 matchedRun.Results[i].BaselineState = originalRun.Results[i].BaselineState;
                 matchedRun.Results[i].Properties = originalRun.Results[i].Properties;
 


### PR DESCRIPTION
Amend a previous change to ensure a Guid and CorrelationGuid are *always* assigned to all Baselined results.

This fixes the case where baselining has happened with an older SARIF SDK and so an identity wasn't previously assigned. It now consistently assigns a Guid as well, if the producing tool didn't. This ensures a CorrelationGuid will always be available to identify the Results we're mapping to each other over time and also to provide an identity to associate any outside-of-SARIF metadata with the Result.