### PR TITLE
Remove unused "Previous" properties from build.props

### DIFF
--- a/scripts/Get-VersionConstants.ps1
+++ b/scripts/Get-VersionConstants.ps1
@@ -32,7 +32,7 @@ if ($Previous) {
 }
 
 $versionPrefix = Get-VersionComponent "${PreviousNamePrefix}VersionPrefix"
-$schemaVersionAsPublishedToSchemaStoreOrg = Get-VersionComponent "${PreviousNamePrefix}SchemaVersionAsPublishedToSchemaStoreOrg"
-$stableSarifVersion = Get-VersionComponent "${PreviousNamePrefix}StableSarifVersion"
+$schemaVersionAsPublishedToSchemaStoreOrg = Get-VersionComponent SchemaVersionAsPublishedToSchemaStoreOrg
+$stableSarifVersion = Get-VersionComponent StableSarifVersion
 
 $versionPrefix, $schemaVersionAsPublishedToSchemaStoreOrg, $stableSarifVersion

--- a/src/build.props
+++ b/src/build.props
@@ -11,7 +11,7 @@
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
-    <!-- VersionPrefix denotes the current Semantic Version for the SDK. Must be updated before every nuget drop. -->
+    <!-- VersionPrefix denotes the current version of the SDK. Must be updated before every nuget drop. -->
     <VersionPrefix>2.1.21</VersionPrefix>
     
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
@@ -21,18 +21,15 @@
     <StableSarifVersion>2.1.0</StableSarifVersion>
 
     <!--
-    Whenever you increment VersionPrefix or VersionSuffix, copy the old value(s)
-    into the following properties.
+    Whenever you increment VersionPrefix, copy the old value into the following property.
 
-    These properties are defined here, not because our MSBuild .props or .targets
-    files use them (they don't), but rather to make it convenient for you to
+    This property is defined here, not because our MSBuild .props or .targets
+    files use it (they don't), but rather to make it convenient for you to
     increment the version number by having all the relevant values in one
-    place. These properties are actually used by the PowerShell script that
+    place. This property is actually used by the PowerShell script that
     hides the previous package versions on nuget.org.
     -->
     <PreviousVersionPrefix>2.1.20</PreviousVersionPrefix>
-    <PreviousSchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.3</PreviousSchemaVersionAsPublishedToSchemaStoreOrg>
-    <PreviousStableSarifVersion>2.1.0</PreviousStableSarifVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
NOTE: Ignore the title of the single commit below. I had switched from another branch and neglected to update the commit text in VS.