### PR TITLE
Fix #1713: EndTimeMustNotBeBeforeStartTime throws if endTimeUtc is absent

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.1.22** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.22) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.22) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.22) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.22)
+* BUGFIX: Fix bug in validation rule `EndTimeMustNotBeBeforeStartTime`, which threw if `invocation.startTimeUtc` was present but `endTimeUtc` was absent.
+
 ## **v2.1.21** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.21) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.21) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.21) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.21)
 * FEATURE: Provide an API `SarifPartitioner.Filter` that selects results according to a predicate, and filters `run.artifacts` to only those artifacts used by the included results.
 
@@ -238,36 +241,36 @@ Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no
 ## **v2.0.0-csd.2.beta.2019.01-24** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019.01-24) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019.01-24) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019.01-24)) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019.01-24))
 * BUGFIX: SDK compatibility update for sample apps.
 * BUGFIX: Add Sarif.Multitool.exe.config file to multitool package to resolve "Could not load file or assembly `Newtonsoft.Json, Version=9.0.0.0`" exception on using validate command.
-* API BREAKING: rename baselineState `existing` value to `unchanged`. Add new baselineState value `updated`. https://github.com/oasis-tcs/sarif-spec/issues/312
-* API BREAKING: unify result and notification failure levels (`note`, `warning`, `error`). Break out result evaluation state into `result.kind` property with values `pass`, `fail`, `open`, `review`, `notApplicable`. https://github.com/oasis-tcs/sarif-spec/issues/317
+* API BREAKING: rename baselineState `existing` value to `unchanged`. Add new baselineState value `updated`. [oasis-tcs/sarif-spec#312](https://github.com/oasis-tcs/sarif-spec/issues/312)
+* API BREAKING: unify result and notification failure levels (`note`, `warning`, `error`). Break out result evaluation state into `result.kind` property with values `pass`, `fail`, `open`, `review`, `notApplicable`. [oasis-tcs/sarif-spec#317](https://github.com/oasis-tcs/sarif-spec/issues/317)
 * API BREAKING: remove IRule entirely, in favor of utilizing ReportingDescriptor base class.
-* API BREAKING: define `toolComponent` object to persist tool data. The `tool.driver` component documents the standard driver metadata. `tool.extensions` is an array of `toolComponent` instances that describe extensions to the core analyzer. This change also deletes `tool.sarifLoggerVersion` (from the newly created `toolComponent` object) due to its lack of utility. Adds `result.extensionIndex` to allow results to be associated with a plug-in. `toolComponent` also added as a new file role. https://github.com/oasis-tcs/sarif-spec/issues/179
-* API BREAKING: Remove `run.resources` object. Rename `rule` object to `reportingDescriptor`. Move rule and notification reportingDescriptor objects to `tool.notificationDescriptors` and `tool.ruleDescriptors`. `resources.messageStrings` now located at `toolComponent.globalMessageStrings`. `rule.configuration` property now named `reportingDescriptor.defaultConfiguration`. `reportingConfiguration.defaultLevel` and `reportingConfiguration.defaultRank` simplified to `reportingConfiguration.level` and `reportingConfiguration.rank`. Actual runtime reportingConfiguration persisted to new array of reportingConfiguration objects at `invocation.reportingConfiguration`. https://github.com/oasis-tcs/sarif-spec/issues/311
-* API BREAKING: `run.richTextMessageMimeType` renamed to `run.markdownMessageMimeType`. `message.richText` renamed to `message.markdown`. `message.richMessageId` deleted. Create `multiformatMessageString` object, that holds plain text and markdown message format strings. `reportingDescriptor.messageStrings` is now a dictionary of these objects, keyed by message id. `reporting.Descriptor.richMessageStrings` dictionary is deleted. https://github.com/oasis-tcs/sarif-spec/issues/319
-* API BREAKING: `threadflowLocation.kind` is now `threadflowLocation.kinds`, an array of strings that categorize the thread flow location. https://github.com/oasis-tcs/sarif-spec/issues/202
-* API BREAKING: `file` renamed to `artifact`. `fileLocation` renamed to `artifactLocation`. `run.files` renamed to `run.artifacts`. https://github.com/oasis-tcs/sarif-spec/issues/309
+* API BREAKING: define `toolComponent` object to persist tool data. The `tool.driver` component documents the standard driver metadata. `tool.extensions` is an array of `toolComponent` instances that describe extensions to the core analyzer. This change also deletes `tool.sarifLoggerVersion` (from the newly created `toolComponent` object) due to its lack of utility. Adds `result.extensionIndex` to allow results to be associated with a plug-in. `toolComponent` also added as a new file role. [oasis-tcs/sarif-spec#179](https://github.com/oasis-tcs/sarif-spec/issues/179)
+* API BREAKING: Remove `run.resources` object. Rename `rule` object to `reportingDescriptor`. Move rule and notification reportingDescriptor objects to `tool.notificationDescriptors` and `tool.ruleDescriptors`. `resources.messageStrings` now located at `toolComponent.globalMessageStrings`. `rule.configuration` property now named `reportingDescriptor.defaultConfiguration`. `reportingConfiguration.defaultLevel` and `reportingConfiguration.defaultRank` simplified to `reportingConfiguration.level` and `reportingConfiguration.rank`. Actual runtime reportingConfiguration persisted to new array of reportingConfiguration objects at `invocation.reportingConfiguration`. [oasis-tcs/sarif-spec#311](https://github.com/oasis-tcs/sarif-spec/issues/311)
+* API BREAKING: `run.richTextMessageMimeType` renamed to `run.markdownMessageMimeType`. `message.richText` renamed to `message.markdown`. `message.richMessageId` deleted. Create `multiformatMessageString` object, that holds plain text and markdown message format strings. `reportingDescriptor.messageStrings` is now a dictionary of these objects, keyed by message id. `reporting.Descriptor.richMessageStrings` dictionary is deleted. [oasis-tcs/sarif-spec#319](https://github.com/oasis-tcs/sarif-spec/issues/319)
+* API BREAKING: `threadflowLocation.kind` is now `threadflowLocation.kinds`, an array of strings that categorize the thread flow location. [oasis-tcs/sarif-spec#202](https://github.com/oasis-tcs/sarif-spec/issues/202)
+* API BREAKING: `file` renamed to `artifact`. `fileLocation` renamed to `artifactLocation`. `run.files` renamed to `run.artifacts`. [oasis-tcs/sarif-spec#309](https://github.com/oasis-tcs/sarif-spec/issues/309)
 
 ## **v2.0.0-csd.2.beta.2019-01-09** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2019-01-09) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2019-01-09) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2019-01-09) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2019-01-09)
 * BUGFIX: Result matching improvements in properties persistence.
 * FEATURE: Fortify FPR converter improvements.
 * API NON-BREAKING: Remove uniqueness requirement from `result.locations`.
-* API NON-BREAKING: Add `run.newlineSequences` to schema. https://github.com/oasis-tcs/sarif-spec/issues/169
-* API NON-BREAKING: Add `rule.deprecatedIds` to schema. https://github.com/oasis-tcs/sarif-spec/issues/293
-* API NON-BREAKING: Add `versionControlDetails.mappedTo`. https://github.com/oasis-tcs/sarif-spec/issues/248
+* API NON-BREAKING: Add `run.newlineSequences` to schema. [oasis-tcs/sarif-spec#169](https://github.com/oasis-tcs/sarif-spec/issues/169)
+* API NON-BREAKING: Add `rule.deprecatedIds` to schema. [oasis-tcs/sarif-spec#293](https://github.com/oasis-tcs/sarif-spec/issues/293)
+* API NON-BREAKING: Add `versionControlDetails.mappedTo`. [oasis-tcs/sarif-spec#248](https://github.com/oasis-tcs/sarif-spec/issues/248)
 * API NON-BREAKING: Add result.rank`. Add `ruleConfiguration.defaultRank`.
-* API NON-BREAKING: Add `file.sourceLocation` and `region.sourceLanguage` to guide in snippet colorization. `run.defaultSourceLanguage` provides a default value. https://github.com/oasis-tcs/sarif-spec/issues/286
-* API NON-BREAKING: default values for `result.rank` and `ruleConfiguration.defaultRank` is now -1.0 (from 0.0). https://github.com/oasis-tcs/sarif-spec/issues/303
-* API BREAKING: Remove `run.architecture` https://github.com/oasis-tcs/sarif-spec/issues/262
-* API BREAKING: `result.message` is now a required property https://github.com/oasis-tcs/sarif-spec/issues/283
-* API BREAKING: Rename `tool.fileVersion` to `tool.dottedQuadFileVersion` https://github.com/oasis-tcs/sarif-spec/issues/274
-* API BREAKING: Remove `open` from valid rule default configuration levels. https://github.com/oasis-tcs/sarif-spec/issues/288. The transformer remaps this value to `note`.
-* API BREAKING: `run.columnKind` default value is now `unicodeCodePoints`. https://github.com/Microsoft/sarif-sdk/pull/1160. The transformer will inject `utf16CodeUnits`, however, when this property is absent, as this value is a more appropriate default for the Windows platform.
+* API NON-BREAKING: Add `file.sourceLocation` and `region.sourceLanguage` to guide in snippet colorization. `run.defaultSourceLanguage` provides a default value. [oasis-tcs/sarif-spec#286](https://github.com/oasis-tcs/sarif-spec/issues/286)
+* API NON-BREAKING: default values for `result.rank` and `ruleConfiguration.defaultRank` is now -1.0 (from 0.0). [oasis-tcs/sarif-spec#303](https://github.com/oasis-tcs/sarif-spec/issues/303)
+* API BREAKING: Remove `run.architecture` [oasis-tcs/sarif-spec#262](https://github.com/oasis-tcs/sarif-spec/issues/262)
+* API BREAKING: `result.message` is now a required property [oasis-tcs/sarif-spec#283](https://github.com/oasis-tcs/sarif-spec/issues/283)
+* API BREAKING: Rename `tool.fileVersion` to `tool.dottedQuadFileVersion` [oasis-tcs/sarif-spec#274](https://github.com/oasis-tcs/sarif-spec/issues/274)
+* API BREAKING: Remove `open` from valid rule default configuration levels. The transformer remaps this value to `note`. [oasis-tcs/sarif-spec#288](https://github.com/oasis-tcs/sarif-spec/issues/288)
+* API BREAKING: `run.columnKind` default value is now `unicodeCodePoints`. The transformer will inject `utf16CodeUnits`, however, when this property is absent, as this value is a more appropriate default for the Windows platform. [#1160](https://github.com/Microsoft/sarif-sdk/pull/1160)
 * API BREAKING: Make `run.logicalLocations` an array, not a dictionary. Add result.logicalLocationIndex to point to associated logical location.
 * API BREAKING: `run.externalFiles` renamed to `run.externalPropertyFiles`, which is not a bundle of external property file objects. NOTE: no transformation will be provided for legacy versions of the external property files API.
 * API BREAKING: rework `result.provenance` object, including moving result.conversionProvenance to `result.provenance.conversionSources`. NOTE: no transformation currently exists for this update.
 * API BREAKING: Make `run.files` an array, not a dictionary. Add fileLocation.fileIndex to point to a file object associated with the location within `run.files`.
 * API BREAKING: Make `resources.rules` an array, not a dictionary. Add result.ruleIndex to point to a rule object associated with the result within `resources.rules`.
-* API BREAKING: `run.logicalLocations` now requires unique array elements. https://github.com/oasis-tcs/sarif-spec/issues/304
+* API BREAKING: `run.logicalLocations` now requires unique array elements. [oasis-tcs/sarif-spec#304](https://github.com/oasis-tcs/sarif-spec/issues/304)
 
 ## **v2.0.0-csd.2.beta.2018-10-10.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.0.0-csd.2.beta.2018-10-10.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.0.0-csd.2.beta.2018-10-10.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.0.0-csd.2.beta.2018-10-10.2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.0.0-csd.2.beta.2018-10-10.2)
 * BUGFIX: Don`t emit v2 analysisTarget if there is no v1 resultFile.

--- a/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/AnalyzeOptionsBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         [Option(
             'c',
             "config",
-            HelpText = "Path to policy file that will be used to configure analysis. This defaults to 'default.configuration.xml' beside the main tool; passing value of 'default' or removing that file will configure BinSkim to use built-in settings.")]
+            HelpText = "Path to policy file that will be used to configure analysis. This defaults to 'default.configuration.xml' beside the main tool; passing value of 'default' or removing that file will configure the tool to use its built-in settings.")]
         public string ConfigurationFilePath { get; set; }
 
         [Option(

--- a/src/Sarif.Multitool/Rules/SARIF1007.EndTimeMustNotBeBeforeStartTime.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1007.EndTimeMustNotBeBeforeStartTime.cs
@@ -31,7 +31,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected override void Analyze(Invocation invocation, string invocationPointer)
         {
-            if (invocation.StartTimeUtc > invocation.EndTimeUtc)
+            // Compare the start and end times only if both are present.
+            if (invocation.StartTimeUtc != default &&
+                invocation.EndTimeUtc != default &&
+                invocation.StartTimeUtc > invocation.EndTimeUtc)
             {
                 string endTimePointer = invocationPointer.AtProperty(SarifPropertyName.EndTimeUtc);
 

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
@@ -17,6 +17,14 @@
           "commandLine": "CodeScanner.exe *.dll end time after start time",
           "startTime": "2016-08-25T21:26:42.049Z",
           "endTime": "2016-08-25T21:26:42.051Z"
+        },
+        {
+          "commandLine": "CodeScanner.exe *.dll end time absent",
+          "startTime": "2016-08-25T21:26:42.049Z"
+        },
+        {
+          "commandLine": "CodeScanner.exe *.dll start time absent",
+          "endTime": "2016-08-25T21:26:42.051Z"
         }
       ],
       "properties": {

--- a/src/build.props
+++ b/src/build.props
@@ -11,25 +11,24 @@
     <Product Condition=" '$(Product)' == '' ">Microsoft SARIF SDK</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
     
-    <!-- VersionPrefix denotes the current version of the SDK. Must be updated before every nuget drop. -->
-    <VersionPrefix>2.1.21</VersionPrefix>
-    
+    <!--
+    VersionPrefix denotes the current version of the SDK. You must update it before every nuget drop.
+
+    Whenever you increment VersionPrefix, copy the old value into PreviousVersionPrefix.
+    PreviousVersionPrefix is defined here, not because our MSBuild .props or .targets files use it
+    (they don't), but rather to make it convenient for you to increment the version number by
+    having all the relevant values in one place. This property is actually used by the PowerShell
+    script that hides ("delists") the previous package versions on nuget.org.
+    -->
+    <VersionPrefix>2.1.22</VersionPrefix>
+    <PreviousVersionPrefix>2.1.21</PreviousVersionPrefix>
+
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
       
     <!-- The stable Version of SARIF Specifications. -->
     <StableSarifVersion>2.1.0</StableSarifVersion>
 
-    <!--
-    Whenever you increment VersionPrefix, copy the old value into the following property.
-
-    This property is defined here, not because our MSBuild .props or .targets
-    files use it (they don't), but rather to make it convenient for you to
-    increment the version number by having all the relevant values in one
-    place. This property is actually used by the PowerShell script that
-    hides the previous package versions on nuget.org.
-    -->
-    <PreviousVersionPrefix>2.1.20</PreviousVersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
@michaelcfanning @ScottLouvau This bug was reported last night by Paul Anderson of the SARIF TC.

Also:
- Remove hard-coded mention of a specific tool from the command line help text.
- Finish cleaning up the hyperlinks in the release history.
- In build.props, move `PreviousVersionPrefix` right under `VersionPrefix` to make it less likely to neglect to update it.