### PR TITLE
Fix #1716: Use first-class properties for tool.driver.organization and .product

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## **v2.1.23** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.23) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.23) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.23) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.23)
-* FEATURE: `SarifLogger` now populates `tool.driver.organization` and `.product` instead of adding properties `"Company"` and `"ProductName"` to the driver's property bag. [#1716](https://github.com/microsoft/sarif-sdk/issues/1716)
+* FEATURE: `SarifLogger` now populates `tool.driver`'s `organization` and `product` properties instead of adding `"Company"` and `"ProductName"` to `tool.driver'`s property bag. [#1716](https://github.com/microsoft/sarif-sdk/issues/1716)
 
 ## **v2.1.22** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.22) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.22) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.22) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.22)
 * BUGFIX: Fix bug in validation rule `EndTimeMustNotBeBeforeStartTime`, which threw if `invocation.startTimeUtc` was present but `endTimeUtc` was absent.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.1.23** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.23) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.23) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.23) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.23)
+* FEATURE: `SarifLogger` now populates `tool.driver.organization` and `.product` instead of adding properties `"Company"` and `"ProductName"` to the driver's property bag. [#1716](https://github.com/microsoft/sarif-sdk/issues/1716)
+
 ## **v2.1.22** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.22) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.22) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.22) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.22)
 * BUGFIX: Fix bug in validation rule `EndTimeMustNotBeBeforeStartTime`, which threw if `invocation.startTimeUtc` was present but `endTimeUtc` was absent.
 
@@ -21,7 +24,7 @@
 ## **v2.1.19** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.19) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.19) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.19) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.19)
 * Sort driver skimmers by rule id + name during analysis, in order to improve deterministic ordering of log file data.
 * API BREAKING: Convert various public SARIF Driver framework API to prefer abstract ISet<string> type over HashSet<string>.
-* API BREAKING: Remove helper method `SarifUtilities.DeserializeObject` introduced in 2.1.15 to fix [#1577](https://github.com/microsoft/sarif-sdk/issues/1577).
+* API BREAKING: Remove helper method `SarifUtilities.DeserializeObject` introduced in 2.1.15 to fix. [#1577](https://github.com/microsoft/sarif-sdk/issues/1577)
 Now that an underlying bug in `PropertyBagConverter` has been fixed, there is no need to work around it with this helper method. `JsonConvert.DeserializeObject` works fine.
 * FEATURE: Expanding Sarif SDK query mode to support Result.Uri, string StartsWith/EndsWith/Contains.
 * FEATURE: Adding Result.Run and a populating method, so that methods which need the Run context for a given Result have an integrated way to retrieve it.

--- a/src/Sarif/Core/Tool.cs
+++ b/src/Sarif/Core/Tool.cs
@@ -39,22 +39,19 @@ namespace Microsoft.CodeAnalysis.Sarif
                     Version = version.ToString(),
                     DottedQuadFileVersion = dottedQuadFileVersion,
                     SemanticVersion = version.Major.ToString() + "." + version.Minor.ToString() + "." + version.Build.ToString(),
-                    Properties = CreatePropertiesFromFileVersionInfo(fileVersion)
+                    Organization = string.IsNullOrEmpty(fileVersion.CompanyName) ? null : fileVersion.CompanyName,
+                    Product = string.IsNullOrEmpty(fileVersion.ProductName) ? null : fileVersion.ProductName,
                 }
             };
+
+            SetDriverPropertiesFromFileVersionInfo(tool.Driver, fileVersion);
 
             return tool;
         }
 
-        private static IDictionary<string, SerializedPropertyInfo> CreatePropertiesFromFileVersionInfo(FileVersionInfo fileVersion)
+        private static void SetDriverPropertiesFromFileVersionInfo(ToolComponent driver, FileVersionInfo fileVersion)
         {
-            var toolComponent = new ToolComponent();
-
-            if (!string.IsNullOrEmpty(fileVersion.Comments)) { toolComponent.SetProperty("Comments", fileVersion.Comments); }
-            if (!string.IsNullOrEmpty(fileVersion.CompanyName)) { toolComponent.SetProperty("CompanyName", fileVersion.CompanyName); }
-            if (!string.IsNullOrEmpty(fileVersion.ProductName)) { toolComponent.SetProperty("ProductName", fileVersion.ProductName); }
-
-            return toolComponent.Properties;
+            if (!string.IsNullOrEmpty(fileVersion.Comments)) { driver.SetProperty("Comments", fileVersion.Comments); }
         }
 
         /// <summary>

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -201,7 +201,8 @@ namespace Microsoft.CodeAnalysis.Sarif.FunctionalTests.Multitool
             driver.FullName = null;
             driver.SemanticVersion = null;
             driver.DottedQuadFileVersion = null;
-            driver.Properties.Clear();
+            driver.Product = null;
+            driver.Properties?.Clear();
             actualLog.Runs[0].OriginalUriBaseIds = null;
 
             return JsonConvert.SerializeObject(actualLog, Formatting.Indented);

--- a/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
+++ b/src/Test.FunctionalTests.Sarif/Multitool/ValidateCommandTests.cs
@@ -202,6 +202,7 @@ namespace Microsoft.CodeAnalysis.Sarif.FunctionalTests.Multitool
             driver.SemanticVersion = null;
             driver.DottedQuadFileVersion = null;
             driver.Product = null;
+            driver.Organization = null;
             driver.Properties?.Clear();
             actualLog.Runs[0].OriginalUriBaseIds = null;
 

--- a/src/build.props
+++ b/src/build.props
@@ -20,8 +20,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.1.22</VersionPrefix>
-    <PreviousVersionPrefix>2.1.21</PreviousVersionPrefix>
+    <VersionPrefix>2.1.23</VersionPrefix>
+    <PreviousVersionPrefix>2.1.22</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
Today `SarifLogger` puts the `CompanyName` and `ProductName` properties of `FileVersionInfo` into the driver's property bag. But SARIF 2.1.0 has first-class properties `toolComponent.organization` and `.product`, so this PR changes the logger to use them.

`FileVersionInfo.Comment` remains in the driver's property bag.