### PR TITLE
Fix #1737: SarifLogBaseliner does not populate firstDetectionTimeUtc

### DIFF
--- a/src/Sarif/Baseline/SarifLogBaseliner.cs
+++ b/src/Sarif/Baseline/SarifLogBaseliner.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,22 +16,27 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             ResultComparator = comparator;
         }
 
-        public Run CreateBaselinedRun(Run baseLine, Run nextLog)
+        public Run CreateBaselinedRun(Run baseline, Run nextLog)
         {
             Run differencedRun = nextLog.DeepClone();
             differencedRun.Results = new List<Result>();
-            
+
+            DateTime now = DateTime.Now;
+            DateTime baselineRunTime = GetRunTime(baseline, now);
+            DateTime newRunTime = GetRunTime(nextLog, now);
+
             foreach (var result in nextLog.Results)
             {
                 Result newResult = result.DeepClone();
 
-                newResult.BaselineState = 
-                    baseLine.Results.Contains(result, ResultComparator) ? BaselineState.Unchanged : BaselineState.New;
+                Result baselineResult = baseline.Results.FirstOrDefault(r => ResultComparator.Equals(r, newResult));
+
+                SetResultBaselineInformation(newResult, baselineResult, newRunTime, baselineRunTime);
 
                 differencedRun.Results.Add(newResult);
             }
 
-            foreach (var result in baseLine.Results)
+            foreach (var result in baseline.Results)
             {
                 if (!nextLog.Results.Contains(result, ResultComparator))
                 {
@@ -41,6 +47,69 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
             }
 
             return differencedRun;
+        }
+
+        // Get the execution time from the specified run. This time will be used
+        // as the "first detection time" for results that don't already have that
+        // information. If the run doesn't have execution time information, it
+        // falls back to "now".
+        internal static DateTime GetRunTime(Run run, DateTime now)
+        {
+            DateTime runTime;
+
+            IList<Invocation> invocations = run.Invocations;
+            if (invocations?.Count > 0)
+            {
+                Invocation invocation = invocations[0];
+                runTime = invocation.EndTimeUtc;
+                if (runTime == DateTime.MinValue)
+                {
+                    runTime = invocation.StartTimeUtc;
+                }
+                if (runTime == DateTime.MinValue)
+                {
+                    runTime = now;
+                }
+            }
+            else
+            {
+                runTime = now;
+            }
+
+            return runTime;
+        }
+
+        // Set the baseline state and first detection time for the current result. If the
+        // matching result from the baseline has a first detection time, roll it forward.
+        // Otherwise, fall back to the time that the run was performed (for existing
+        // results, look at the baseline run; for new results, look at the current run).
+        // If the run doesn't have execution time information, it falls back to "now"
+        // (see GetRunTime).
+        internal static void SetResultBaselineInformation(
+            Result currentResult,
+            Result baselineResult, DateTime newRunTime, DateTime baselineRunTime)
+        {
+            if (baselineResult == null)
+            {
+                currentResult.BaselineState = BaselineState.New;
+                SetFirstDetectionTime(currentResult, newRunTime);
+            }
+            else
+            {
+                currentResult.BaselineState = BaselineState.Unchanged;
+
+                DateTime firstDetectionTime = baselineResult.Provenance != null && baselineResult.Provenance.FirstDetectionTimeUtc != DateTime.MinValue
+                    ? baselineResult.Provenance.FirstDetectionTimeUtc
+                    : baselineRunTime;
+
+                SetFirstDetectionTime(currentResult, firstDetectionTime);
+            }
+        }
+
+        private static void SetFirstDetectionTime(Result result, DateTime firstDetectionTime)
+        {
+            result.Provenance = result.Provenance ?? new ResultProvenance();
+            result.Provenance.FirstDetectionTimeUtc = firstDetectionTime;
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Baseline/DefaultBaselineUnitTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline/DefaultBaselineUnitTests.cs
@@ -81,7 +81,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline
         [Fact]
         public void DefaultBaseline_ChangedResultOnNonTrackedField_Existing()
         {
-
             Random random = RandomSarifLogGenerator.GenerateRandomAndLog(this.output);
             Run baseline = RandomSarifLogGenerator.GenerateRandomRunWithoutDuplicateIssues(random, DefaultBaseline.ResultBaselineEquals.DefaultInstance, random.Next(100) + 5);
             Run next = baseline.DeepClone();

--- a/src/Test.UnitTests.Sarif/Baseline2/SarifLogBaselinerTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/SarifLogBaselinerTests.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Baseline;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
+{
+    public class SarifLogBaselinerTests
+    {
+        private struct ResultBaselineInformationTestCase
+        {
+            public string Name;
+            public Result NewResult;
+            public Result BaselineResult;
+            public BaselineState ExpectedBaselineState;
+            public DateTime ExpectedFirstDetectionTimeUtc;
+        }
+
+        private static readonly DateTime newRunTime = new DateTime(2020, 1, 28, 10, 9, 16, DateTimeKind.Utc);
+        private static readonly DateTime baselineRunTime = new DateTime(2019, 12, 25, 7, 18, 25, DateTimeKind.Utc);
+        private static readonly DateTime baselineResultTime = new DateTime(2019, 8, 3, 21, 0, 1, DateTimeKind.Utc);
+
+        private static readonly List<ResultBaselineInformationTestCase> resultBaselineInformationTestCases =
+            new List<ResultBaselineInformationTestCase>
+            {
+                new ResultBaselineInformationTestCase
+                {
+                    Name = "New",
+                    NewResult = new Result(),
+                    BaselineResult = null,
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTimeUtc = newRunTime
+                },
+
+                new ResultBaselineInformationTestCase
+                {
+                    Name = "Existing",
+                    NewResult = new Result(),
+                    BaselineResult = new Result
+                    {
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = baselineResultTime
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTimeUtc = baselineResultTime
+                },
+
+                new ResultBaselineInformationTestCase
+                {
+                    Name = "Existing with provenance",
+                    NewResult = new Result
+                    {
+                        Provenance = new ResultProvenance()
+                    },
+                    BaselineResult = new Result
+                    {
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = baselineResultTime
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTimeUtc = baselineResultTime
+                },
+
+                new ResultBaselineInformationTestCase
+                {
+                    Name = "Existing with no baseline provenance",
+                    NewResult = new Result(),
+                    BaselineResult = new Result(),
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTimeUtc = baselineRunTime
+                },
+
+                new ResultBaselineInformationTestCase
+                {
+                    Name = "Existing with no baseline result time",
+                    NewResult = new Result(),
+                    BaselineResult = new Result
+                    {
+                        Provenance = new ResultProvenance()
+                    },
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTimeUtc = baselineRunTime
+                },
+            };
+
+        [Fact]
+        public void SarifLogBaseliner_CalculatesResultBaselineInformation()
+        {
+            var sb = new StringBuilder();
+
+            foreach (ResultBaselineInformationTestCase testCase in resultBaselineInformationTestCases)
+            {
+                // Clone the result so we don't write over our test case data.
+                Result newResult = testCase.NewResult.DeepClone();
+
+                SarifLogBaseliner.SetResultBaselineInformation(newResult, testCase.BaselineResult, newRunTime, baselineRunTime);
+
+                BaselineState actualBaselineState = newResult.BaselineState;
+                DateTime? actualFirstDetectionTimeUtc = newResult?.Provenance?.FirstDetectionTimeUtc;
+
+                if (actualBaselineState != testCase.ExpectedBaselineState ||
+                    actualFirstDetectionTimeUtc != testCase.ExpectedFirstDetectionTimeUtc)
+                {
+                    sb.AppendLine($"    Test: {testCase.Name}");
+                    sb.AppendLine($"        Expected: {testCase.ExpectedBaselineState}\t{testCase.ExpectedFirstDetectionTimeUtc}");
+                    sb.AppendLine($"        Actual:   {actualBaselineState}\t{actualFirstDetectionTimeUtc}");
+                }
+            }
+
+            sb.Length.Should().Be(0,
+                $"all test cases should pass, but the following test cases failed:\n{sb}");
+        }
+
+        private static readonly DateTime fakeNow = new DateTime(2020, 1, 28, 11, 9, 30, DateTimeKind.Utc);
+        private static readonly DateTime runStartTime = new DateTime(2019, 5, 1, 0, 52, 42, DateTimeKind.Utc);
+        private static readonly DateTime runEndTime = new DateTime(2019, 5, 1, 1, 2, 54, DateTimeKind.Utc);
+
+        private struct RunTimeTestCase
+        {
+            public string Name;
+            public Run Run;
+            public DateTime ExpectedRunTime;
+        }
+
+        private static readonly List<RunTimeTestCase> runTimeTestCases = new List<RunTimeTestCase>
+        {
+            new RunTimeTestCase
+            {
+                Name = "No invocations",
+                Run = new Run(),
+                ExpectedRunTime = fakeNow
+            },
+
+            new RunTimeTestCase
+            {
+                Name = "Empty invocations",
+                Run = new Run
+                {
+                    Invocations = new List<Invocation>()
+                },
+                ExpectedRunTime = fakeNow
+            },
+
+            new RunTimeTestCase
+            {
+                Name = "No start or end time",
+                Run = new Run
+                {
+                    Invocations = new List<Invocation>
+                    {
+                        new Invocation()
+                    }
+                },
+                ExpectedRunTime = fakeNow
+            },
+
+            new RunTimeTestCase
+            {
+                Name = "Start time only",
+                Run = new Run
+                {
+                    Invocations = new List<Invocation>
+                    {
+                        new Invocation
+                        {
+                            StartTimeUtc = runStartTime
+                        }
+                    }
+                },
+                ExpectedRunTime = runStartTime
+            },
+
+            new RunTimeTestCase
+            {
+                Name = "End time only",
+                Run = new Run
+                {
+                    Invocations = new List<Invocation>
+                    {
+                        new Invocation
+                        {
+                            EndTimeUtc = runEndTime
+                        }
+                    }
+                },
+                ExpectedRunTime = runEndTime
+            },
+
+            new RunTimeTestCase
+            {
+                Name = "Start and end times",
+                Run = new Run
+                {
+                    Invocations = new List<Invocation>
+                    {
+                        new Invocation
+                        {
+                            StartTimeUtc = runStartTime,
+                            EndTimeUtc = runEndTime
+                        }
+                    }
+                },
+                ExpectedRunTime = runEndTime
+            },
+        };
+
+        [Fact]
+        public void SarifLogBaseliner_CalculatesRunTime()
+        {
+            var sb = new StringBuilder();
+
+            foreach (RunTimeTestCase testCase in runTimeTestCases)
+            {
+                DateTime actualRunTime = SarifLogBaseliner.GetRunTime(testCase.Run, fakeNow);
+                if (actualRunTime != testCase.ExpectedRunTime)
+                {
+                    sb.AppendLine($"    Test: {testCase.Name}");
+                    sb.AppendLine($"        Expected: {testCase.ExpectedRunTime}");
+                    sb.AppendLine($"        Actual:   {actualRunTime}");
+                }
+            }
+
+            sb.Length.Should().Be(0,
+                $"all test cases should pass, but the following test cases failed:\n{sb}");
+        }
+    }
+}


### PR DESCRIPTION
Previously, the code just asked whether or not a result from the current log matched a result in the baseline. Now, we actually extract the matching result from the baseline so we can roll its first detection time forward. If the matching result has no first detection time, we fall back to the time that the run was performed. And if we can't find that, we fall back to "now" as the first detection time.

**NOTE** The logic embodies a couple of choices about which reasonable people might disagree:
- I choose "run end time" over "run start time" when both are available.
- I use "now" as the ultimate fallback if there's absolutely no other time information available.

Feel free to disagree.