### PR TITLE
Fix # 1737: SARIF result matcher does not populate firstDetectionTimeUtc

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.1.25** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.25) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.25) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.25)
+* FEATURE: The baseliner (available through the Multitool's `match-results-forward` command) now populates `result.provenance.firstDetectionTimeUtc` so you can now track the age of each issue. [#1737](https://github.com/microsoft/sarif-sdk/issues/1737)
+
 ## **v2.1.24** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.24) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.24) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.24) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.24)
 * FEATURE: Introduce API to partition log files by arbitrary criteria (method `SarifPartitioner.Partition` and class `PartitioningVisitor`).
 * BUGFIX: `Tool.CreateFromAssembly` now properly handles file versions that contain extra characters after the "dotted quad" string. [#1728](https://github.com/microsoft/sarif-sdk/issues/1728)

--- a/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline2
                     ExpectedBaselineState = BaselineState.New,
                     ExpectedFirstDetectionTime = currentRunStartTime
                 },
-                new FirstDetectionTimeTestCase // TODO TEST CASE SHOWING CURRENT RUN WINS FOR NEW AND PREV RUN WINS FOR EXISTING
+                new FirstDetectionTimeTestCase
                 {
                     Name = "New, current start and end times",
                     PreviousResult = null,
@@ -244,6 +244,34 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline2
                     CurrentRun = new Run(),
                     ExpectedBaselineState = BaselineState.Unchanged,
                     ExpectedFirstDetectionTime = firstDetectionTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "Existing, previous run wins",
+                    PreviousResult = new Result(),
+                    PreviousRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = previousRunEndTime
+                            }
+                        }
+                    },
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = currentRunEndTime
+                            }
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTime = previousRunEndTime
                 }
             };
 

--- a/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/MatchedResultsTests.cs
@@ -1,0 +1,291 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif;
+using Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline2
+{
+    public class MatchedResultsTests
+    {
+        private static readonly DateTime previousRunStartTime = DateTime.Parse("2019-01-28T15:03:40Z");
+        private static readonly DateTime previousRunEndTime = DateTime.Parse("2019-01-28T15:12:05Z");
+        private static readonly DateTime currentRunStartTime = DateTime.Parse("2020-01-28T15:03:40Z");
+        private static readonly DateTime currentRunEndTime = DateTime.Parse("2020-01-28T15:12:05Z");
+        private static readonly DateTime firstDetectionTime = DateTime.Parse("2020-01-28T15:03:40Z");
+
+        // If there is no detection time information available, the baseliner chooses the current time.
+        // We don't have an "IDateTimeService" to inject as a dependency, so just save the current time
+        // and assert that in all such cases, the first detection time is at least this value:
+        private static readonly DateTime fakeNow = DateTime.UtcNow;
+
+        private struct FirstDetectionTimeTestCase
+        {
+            public string Name;
+            public Result PreviousResult;
+            public Run PreviousRun;
+            public Result CurrentResult;
+            public Run CurrentRun;
+            public BaselineState ExpectedBaselineState;
+            public DateTime? ExpectedFirstDetectionTime;
+        }
+
+        private static readonly List<FirstDetectionTimeTestCase> firstDetectionTimeTestCases =
+            new List<FirstDetectionTimeTestCase>
+            {
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "New, no time information",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = null   // Means "expect the current time".
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "New, provenance, no time information",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result
+                    {
+                        Provenance = new ResultProvenance()
+                    },
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = null
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "New, provenance with time information",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result
+                    {
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = firstDetectionTime
+                        }
+                    },
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = firstDetectionTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "New, current run end time only",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = currentRunEndTime
+                            }
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = currentRunEndTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "New, current run start time only",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                StartTimeUtc = currentRunStartTime
+                            }
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = currentRunStartTime
+                },
+                new FirstDetectionTimeTestCase // TODO TEST CASE SHOWING CURRENT RUN WINS FOR NEW AND PREV RUN WINS FOR EXISTING
+                {
+                    Name = "New, current start and end times",
+                    PreviousResult = null,
+                    PreviousRun = new Run(),
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                StartTimeUtc = currentRunStartTime,
+                                EndTimeUtc = currentRunEndTime
+                            }
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = currentRunEndTime
+                },
+                new FirstDetectionTimeTestCase // TODO TEST CASE SHOWING CURRENT RUN WINS FOR NEW AND PREV RUN WINS FOR EXISTING
+                {
+                    Name = "New, current run wins",
+                    PreviousResult = null,
+                    PreviousRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = previousRunEndTime
+                            }
+                        }
+                    },
+                    CurrentResult = new Result(),
+                    CurrentRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = currentRunEndTime
+                            }
+                        }
+                    },
+                    ExpectedBaselineState = BaselineState.New,
+                    ExpectedFirstDetectionTime = currentRunEndTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "Absent, no time information",
+                    PreviousResult = new Result(),
+                    PreviousRun = new Run(),
+                    CurrentResult = null,
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.Absent,
+                    ExpectedFirstDetectionTime = null
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "Absent, time from previous run",
+                    PreviousResult = new Result(),
+                    PreviousRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = previousRunEndTime
+                            }
+                        }
+                    },
+                    CurrentResult = null,
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.Absent,
+                    ExpectedFirstDetectionTime = previousRunEndTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "Absent, time from previous result",
+                    PreviousResult = new Result
+                    {
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = firstDetectionTime // Should override the information from the run.
+                        }
+                    },
+                    PreviousRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = previousRunEndTime
+                            }
+                        }
+                    },
+                    CurrentResult = null,
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.Absent,
+                    ExpectedFirstDetectionTime = firstDetectionTime
+                },
+                new FirstDetectionTimeTestCase
+                {
+                    Name = "Unchanged, time from previous result", // No need to repeat all the "time selection" cases from tests above for the "Unchanged" case.
+                    PreviousResult = new Result
+                    {
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = firstDetectionTime
+                        }
+                    },
+                    PreviousRun = new Run
+                    {
+                        Invocations = new List<Invocation>
+                        {
+                            new Invocation
+                            {
+                                EndTimeUtc = previousRunEndTime
+                            }
+                        }
+                    },
+                    CurrentResult = new Result(), // Matches because the result matcher looks at only certain properties, and Provenance isn't one of them.
+                    CurrentRun = new Run(),
+                    ExpectedBaselineState = BaselineState.Unchanged,
+                    ExpectedFirstDetectionTime = firstDetectionTime
+                }
+            };
+
+        [Fact]
+        public void MatchedResults_SetsFirstDetectionTime()
+        {
+            var sb = new StringBuilder();
+
+            foreach (FirstDetectionTimeTestCase testCase in firstDetectionTimeTestCases)
+            {
+                DateTime expectedFirstDetectionTime = testCase.ExpectedFirstDetectionTime.HasValue
+                    ? testCase.ExpectedFirstDetectionTime.Value
+                    : fakeNow;
+
+                ExtractedResult previousExtracted = testCase.PreviousResult != null
+                    ? new ExtractedResult(testCase.PreviousResult, testCase.PreviousRun)
+                    : null;
+                ExtractedResult currentExtracted = testCase.CurrentResult != null
+                    ? new ExtractedResult(testCase.CurrentResult, testCase.CurrentRun)
+                    : null;
+                MatchedResults matchedResults = new MatchedResults(previousExtracted, currentExtracted);
+
+                Result result = matchedResults.CalculateBasedlinedResult(DictionaryMergeBehavior.InitializeFromMostRecent /* arbitrary */);
+
+                BaselineState actualBaselineState = result.BaselineState;
+                DateTime? actualFirstDetectionTime = result?.Provenance?.FirstDetectionTimeUtc;
+                if (actualFirstDetectionTime.HasValue && actualFirstDetectionTime.Value >= fakeNow)
+                {
+                    actualFirstDetectionTime = fakeNow;
+                }
+
+                if (actualBaselineState != testCase.ExpectedBaselineState ||
+                    actualFirstDetectionTime != expectedFirstDetectionTime)
+                {
+                    sb.AppendLine($"    Test: {testCase.Name}");
+                    sb.AppendLine($"        Expected: {testCase.ExpectedBaselineState}\t{testCase.ExpectedFirstDetectionTime}");
+                    sb.AppendLine($"        Actual:   {actualBaselineState}\t{actualFirstDetectionTime}");
+                }
+            }
+
+            sb.Length.Should().Be(0,
+                $"all test cases should pass, but the following test cases failed:\n{sb}");
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
+++ b/src/Test.UnitTests.Sarif/Baseline2/V2ResultMatcherTests.cs
@@ -324,6 +324,8 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
         [Fact]
         public void ResultMatchingBaseliner_WhenThereIsOnlyOneCurrentRun_CopiesSelectedRunData()
         {
+            DateTime firstDetectionTime = new DateTime(2019, 10, 7, 12, 13, 14);
+
             Run originalRun = new Run
             {
                 Tool = new Tool
@@ -347,12 +349,20 @@ namespace Microsoft.CodeAnalysis.Test.UnitTests.Sarif.Baseline
                     new Result
                     {
                         RuleId = TestConstants.RuleIds.Rule1,
-                        RuleIndex = 0
+                        RuleIndex = 0,
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = firstDetectionTime
+                        }
                     },
                     new Result
                     {
                         RuleId = TestConstants.RuleIds.Rule2,
-                        RuleIndex = 1
+                        RuleIndex = 1,
+                        Provenance = new ResultProvenance
+                        {
+                            FirstDetectionTimeUtc = firstDetectionTime
+                        }
                     }
                 },
                 Conversion = new Conversion

--- a/src/build.props
+++ b/src/build.props
@@ -20,8 +20,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.1.24</VersionPrefix>
-    <PreviousVersionPrefix>2.1.23</PreviousVersionPrefix>
+    <VersionPrefix>2.1.25</VersionPrefix>
+    <PreviousVersionPrefix>2.1.24</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
**This replaces the previous PR** and puts the logic in the right place: in Scott's result matcher, which replaced Everett's.

Roll the first detection time forward from the previous result if possible. Otherwise fall back to the time that the run was performed. Finally, fall back to "now" as the first detection time.

**NOTE** The logic embodies a couple of choices about which reasonable people might disagree:
- I choose "run end time" over "run start time" when both are available.
- I use "now" as the ultimate fallback if there's absolutely no other time information available.

Feel free to disagree.