### PR TITLE
NPM Build Enable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 init:
   - git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ branches:
     - sarif-v1
 
 install:
-  - ps: .\dotnet-install.ps1 --version 2.1.506
+  - ps: .\dotnet-install.ps1 --version 2.2.402
+  - ps: .\dotnet-install.ps1 --version 3.1.101
 
 configuration:
   - Release

--- a/npm/sarif-multitool-darwin/README.md
+++ b/npm/sarif-multitool-darwin/README.md
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# sarif-multitool
+
+Use the SARIF Multitool to transform, enrich, filter, result match, and do other common operations against SARIF files.
+This is a platform-specific package; please use [sarif-multitool](https://www.npmjs.com/package/@microsoft/sarif-multitool), which will download and invoke the right version of the Multitool for you.

--- a/npm/sarif-multitool-darwin/bin.js
+++ b/npm/sarif-multitool-darwin/bin.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const {status} = require('child_process').spawnSync(
+	require('./'),
+	process.argv.slice(2),
+	{ shell: true, stdio: 'inherit' }
+)
+process.exit(status)

--- a/npm/sarif-multitool-darwin/index.d.ts
+++ b/npm/sarif-multitool-darwin/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * An absolute path to the Sarif.Multitool executable.
+ * ```
+ * import {spawnSync} from 'child_process'
+ * import multitoolPath from '@microsoft/sarif-multitool'
+ * spawnSync(multitoolPath, ['help'], { stdio: 'inherit' })
+ * ```
+ */
+declare const _default: string;
+export = _default;

--- a/npm/sarif-multitool-darwin/index.js
+++ b/npm/sarif-multitool-darwin/index.js
@@ -1,0 +1,1 @@
+module.exports = require('path').join(__dirname, 'Sarif.Multitool')

--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-darwin",
 	"description": "SARIF Multitool for MacOS (Darwin)",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-darwin",
 	"description": "SARIF Multitool for MacOS (Darwin)",
-	"version": "0.0.9",
+	"version": "0.1.0",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-darwin",
 	"description": "SARIF Multitool for MacOS (Darwin)",
-	"version": "0.1.0",
+	"version": "{version}",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@microsoft/sarif-multitool-darwin",
+	"description": "SARIF Multitool for MacOS (Darwin)",
+	"version": "0.0.8",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repository": {
+	  "type": "git",
+	  "url": "https://github.com/microsoft/sarif-sdk"
+	},
+	"os": ["darwin"],
+	"bin": "./bin.js"
+}

--- a/npm/sarif-multitool-linux/README.md
+++ b/npm/sarif-multitool-linux/README.md
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# sarif-multitool
+
+Use the SARIF Multitool to transform, enrich, filter, result match, and do other common operations against SARIF files.
+This is a platform-specific package; please use [sarif-multitool](https://www.npmjs.com/package/@microsoft/sarif-multitool), which will download and invoke the right version of the Multitool for you.

--- a/npm/sarif-multitool-linux/bin.js
+++ b/npm/sarif-multitool-linux/bin.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const {status} = require('child_process').spawnSync(
+	require('./'),
+	process.argv.slice(2),
+	{ shell: true, stdio: 'inherit' }
+)
+process.exit(status)

--- a/npm/sarif-multitool-linux/index.d.ts
+++ b/npm/sarif-multitool-linux/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * An absolute path to the Sarif.Multitool executable.
+ * ```
+ * import {spawnSync} from 'child_process'
+ * import multitoolPath from '@microsoft/sarif-multitool'
+ * spawnSync(multitoolPath, ['help'], { stdio: 'inherit' })
+ * ```
+ */
+declare const _default: string;
+export = _default;

--- a/npm/sarif-multitool-linux/index.js
+++ b/npm/sarif-multitool-linux/index.js
@@ -1,0 +1,1 @@
+module.exports = require('path').join(__dirname, 'Sarif.Multitool')

--- a/npm/sarif-multitool-linux/package.json
+++ b/npm/sarif-multitool-linux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-linux",
 	"description": "SARIF Multitool for Linux",
-	"version": "0.0.1",
+	"version": "0.0.9",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-linux/package.json
+++ b/npm/sarif-multitool-linux/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@microsoft/sarif-multitool-linux",
+	"description": "SARIF Multitool for Linux",
+	"version": "0.0.1",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repository": {
+	  "type": "git",
+	  "url": "https://github.com/microsoft/sarif-sdk"
+	},
+	"os": ["linux"],
+	"bin": "./bin.js"
+}

--- a/npm/sarif-multitool-linux/package.json
+++ b/npm/sarif-multitool-linux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-linux",
 	"description": "SARIF Multitool for Linux",
-	"version": "0.0.9",
+	"version": "0.1.0",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-linux/package.json
+++ b/npm/sarif-multitool-linux/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-linux",
 	"description": "SARIF Multitool for Linux",
-	"version": "0.1.0",
+	"version": "{version}",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-win32/README.md
+++ b/npm/sarif-multitool-win32/README.md
@@ -1,0 +1,9 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# sarif-multitool
+
+Use the SARIF Multitool to transform, enrich, filter, result match, and do other common operations against SARIF files.
+This is a platform-specific package; please use [sarif-multitool](https://www.npmjs.com/package/@microsoft/sarif-multitool), which will download and invoke the right version of the Multitool for you.

--- a/npm/sarif-multitool-win32/bin.js
+++ b/npm/sarif-multitool-win32/bin.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const {status} = require('child_process').spawnSync(
+	require('./'),
+	process.argv.slice(2),
+	{ shell: true, stdio: 'inherit' }
+)
+process.exit(status)

--- a/npm/sarif-multitool-win32/index.d.ts
+++ b/npm/sarif-multitool-win32/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * An absolute path to the Sarif.Multitool executable.
+ * ```
+ * import {spawnSync} from 'child_process'
+ * import multitoolPath from '@microsoft/sarif-multitool'
+ * spawnSync(multitoolPath, ['help'], { stdio: 'inherit' })
+ * ```
+ */
+declare const _default: string;
+export = _default;

--- a/npm/sarif-multitool-win32/index.js
+++ b/npm/sarif-multitool-win32/index.js
@@ -1,0 +1,1 @@
+module.exports = require('path').join(__dirname, 'Sarif.Multitool.exe')

--- a/npm/sarif-multitool-win32/package.json
+++ b/npm/sarif-multitool-win32/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-win32",
 	"description": "SARIF Multitool for Windows (Win32)",
-	"version": "0.0.9",
+	"version": "0.1.0",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-win32/package.json
+++ b/npm/sarif-multitool-win32/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@microsoft/sarif-multitool-win32",
+	"description": "SARIF Multitool for Windows (Win32)",
+	"version": "0.0.5",
+	"author": "Microsoft",
+	"license": "MIT",
+	"repository": {
+	  "type": "git",
+	  "url": "https://github.com/microsoft/sarif-sdk"
+	},
+	"os": ["win32"],
+	"bin": "./bin.js"
+}

--- a/npm/sarif-multitool-win32/package.json
+++ b/npm/sarif-multitool-win32/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-win32",
 	"description": "SARIF Multitool for Windows (Win32)",
-	"version": "0.0.5",
+	"version": "0.0.9",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-win32/package.json
+++ b/npm/sarif-multitool-win32/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@microsoft/sarif-multitool-win32",
 	"description": "SARIF Multitool for Windows (Win32)",
-	"version": "0.1.0",
+	"version": "{version}",
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool/README.md
+++ b/npm/sarif-multitool/README.md
@@ -1,0 +1,32 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# sarif-multitool
+
+Use the SARIF Multitool to transform, enrich, filter, result match, and do other common operations against SARIF files.
+See [Multitool Usage](https://github.com/microsoft/sarif-sdk/blob/master/docs/multitool-usage.md) for mode documentation and specific examples.
+
+## Usage (Console) 
+```
+npm i -g @microsoft/sarif-multitool
+npx @microsoft/sarif-multitool <args>
+```
+
+## Usage (TypeScript)
+```ts
+ import {spawnSync} from 'child_process'
+ import multitoolPath from '@microsoft/sarif-multitool'
+ 
+ spawnSync(multitoolPath, ['<args>'], { stdio: 'inherit' })
+ ```
+
+## Version numbers
+
+This package will have version 0.x.y as a pre-release, and then will follow the SARIF SDK versioning scheme.
+See the [Release History](https://github.com/microsoft/sarif-sdk/blob/master/src/ReleaseHistory.md) for changes in each version.
+
+## Contributing
+
+Contribute to the SARIF Multitool at [Sarif SDK](https://github.com/microsoft/sarif-sdk#sarif-sdk).

--- a/npm/sarif-multitool/bin.js
+++ b/npm/sarif-multitool/bin.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const {status} = require('child_process').spawnSync(
+	require('./'),
+	process.argv.slice(2),
+	{ shell: true, stdio: 'inherit' }
+)
+process.exit(status)

--- a/npm/sarif-multitool/index.d.ts
+++ b/npm/sarif-multitool/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * An absolute path to the Sarif.Multitool executable.
+ * ```
+ * import {spawnSync} from 'child_process'
+ * import multitoolPath from '@microsoft/sarif-multitool'
+ * spawnSync(multitoolPath, ['help'], { stdio: 'inherit' })
+ * ```
+ */
+declare const _default: string;
+export = _default;

--- a/npm/sarif-multitool/index.js
+++ b/npm/sarif-multitool/index.js
@@ -1,0 +1,1 @@
+module.exports = require(`${require('./package').name}-${process.platform}`)

--- a/npm/sarif-multitool/package.json
+++ b/npm/sarif-multitool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/sarif-multitool",
-	"version": "0.1.0",
+	"version": "{version}",
 	"author": "Microsoft",
 	"description": "SARIF Multitool",
 	"license": "MIT",
@@ -11,8 +11,8 @@
 	"os": ["darwin", "linux", "win32"],
 	"bin": "./bin.js",
 	"optionalDependencies": {
-		"@microsoft/sarif-multitool-darwin": "^0.1.0",
-		"@microsoft/sarif-multitool-linux": "^0.1.0",
-		"@microsoft/sarif-multitool-win32": "^0.1.0"
+		"@microsoft/sarif-multitool-darwin": "^{version}",
+		"@microsoft/sarif-multitool-linux": "^{version}",
+		"@microsoft/sarif-multitool-win32": "^{version}"
 	}
 }

--- a/npm/sarif-multitool/package.json
+++ b/npm/sarif-multitool/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@microsoft/sarif-multitool",
+	"version": "0.0.9",
+	"author": "Microsoft",
+	"description": "SARIF Multitool",
+	"license": "MIT",
+	"repository": {
+	  "type": "git",
+	  "url": "https://github.com/microsoft/sarif-sdk"
+	},
+	"os": ["darwin", "linux", "win32"],
+	"bin": "./bin.js",
+	"optionalDependencies": {
+		"@microsoft/sarif-multitool-darwin": "^0.0.8",
+		"@microsoft/sarif-multitool-linux": "^0.0.1",
+		"@microsoft/sarif-multitool-win32": "^0.0.5"
+	}
+}

--- a/npm/sarif-multitool/package.json
+++ b/npm/sarif-multitool/package.json
@@ -11,8 +11,8 @@
 	"os": ["darwin", "linux", "win32"],
 	"bin": "./bin.js",
 	"optionalDependencies": {
-		"@microsoft/sarif-multitool-darwin": "^0.0.8",
-		"@microsoft/sarif-multitool-linux": "^0.0.1",
-		"@microsoft/sarif-multitool-win32": "^0.0.5"
+		"@microsoft/sarif-multitool-darwin": "^0.0.9",
+		"@microsoft/sarif-multitool-linux": "^0.0.9",
+		"@microsoft/sarif-multitool-win32": "^0.0.9"
 	}
 }

--- a/npm/sarif-multitool/package.json
+++ b/npm/sarif-multitool/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/sarif-multitool",
-	"version": "0.0.9",
+	"version": "0.1.0",
 	"author": "Microsoft",
 	"description": "SARIF Multitool",
 	"license": "MIT",
@@ -11,8 +11,8 @@
 	"os": ["darwin", "linux", "win32"],
 	"bin": "./bin.js",
 	"optionalDependencies": {
-		"@microsoft/sarif-multitool-darwin": "^0.0.9",
-		"@microsoft/sarif-multitool-linux": "^0.0.9",
-		"@microsoft/sarif-multitool-win32": "^0.0.9"
+		"@microsoft/sarif-multitool-darwin": "^0.1.0",
+		"@microsoft/sarif-multitool-linux": "^0.1.0",
+		"@microsoft/sarif-multitool-win32": "^0.1.0"
 	}
 }

--- a/scripts/BeforeBuild.ps1
+++ b/scripts/BeforeBuild.ps1
@@ -38,6 +38,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
 Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
 Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1
 Import-Module -Force $PSScriptRoot\Projects.psm1
@@ -70,8 +72,6 @@ function Install-VersionConstantsFile {
 
     & $PSScriptRoot\New-VersionConstantsFile.ps1 $targetProjectDirectory $rootNamespace
 }
-
-$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 
 if (-not $NoClean) {
     Remove-BuildOutput

--- a/scripts/BeforeBuild.ps1
+++ b/scripts/BeforeBuild.ps1
@@ -96,7 +96,7 @@ if (-not $NoRestore) {
 
 if (-not $NoObjectModel) {
     # Generate the SARIF object model classes from the SARIF JSON schema.
-    msbuild /verbosity:minimal /target:BuildAndInjectObjectModel $SourceRoot\Sarif\Sarif.csproj /fileloggerparameters:Verbosity=detailed`;LogFile=CodeGen.log
+    dotnet msbuild /verbosity:minimal /target:BuildAndInjectObjectModel $SourceRoot\Sarif\Sarif.csproj /fileloggerparameters:Verbosity=detailed`;LogFile=CodeGen.log
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "SARIF object model generation failed."
     }

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -34,7 +34,7 @@ dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcore
 dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
 
 Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
-New-Item -ItemType Directory -Path $npmBuildFolder\
+New-DirectorySafely $npmBuildFolder\
 Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder\
 Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32\
 Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux\

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -33,11 +33,12 @@ dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcore
 dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r linux-x64
 dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
 
-Write-Information "Merging binaries and NPM configuration..."
-# Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder
-Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32
-Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux
-Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin
+Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
+New-Item -ItemType Directory -Path $npmBuildFolder\
+Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder\
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32\
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux\
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin\
 
 # To Publish:
 # from [sarif-sdk]\bld\bin\AnyCPU_Release\Sarif.Multitool\npm, run:

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -51,7 +51,7 @@ if (-not $SkipBuild) {
 
 # TEMP: Use 0.x.y numbering until NPM package shape settled, then follow SDK version exactly by removing the hardcoded set
 $sarifVersion = Get-PackageVersion
-$sarifVersion = "0.1.25"
+$sarifVersion = "0.1.26"
 
 Write-Information "Injecting Sarif SDK version $sarifVersion for NPM Packages..."
 foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -68,7 +68,7 @@ foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {
 # After merging outputs, delete the other 250MB copies of the Multitool single file exes (saving only the bld\Publish\npm copy)
 if (-not $NoPostClean) {
     Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0
-    Remove-DirectorySafely $projectBinDirectory\Publish
+    Remove-DirectorySafely $projectBinDirectory\Publish\netcoreapp3.0
 }
 
 Write-Information "$ScriptName SUCCEEDED."

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -37,9 +37,9 @@ $npmBuildFolder = "$BuildRoot\Publish\npm"
 
 if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r win-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r linux-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r osx-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r win-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r linux-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r osx-x64
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
     New-DirectorySafely $npmBuildFolder\

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Build, and package the Sarif Multitool NPM package.
+.DESCRIPTION
+    Builds the Sarif Multitool NPM package, including building the .NET Core 3.0 single-file-exe of the Multitool for all supported platforms.
+.PARAMETER Configuration
+    The build configuration: Release or Debug. Default=Release
+#>
+
+[CmdletBinding()]
+param(
+    [string]
+    [ValidateSet("Debug", "Release")]
+    $Configuration="Release"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\Projects.psm1
+
+$project = "Sarif.Multitool"
+$projectBinDirectory = (Get-ProjectBinDirectory $project $Configuration)
+$npmSourceFolder = "$RepoRoot\npm"
+$npmBuildFolder = "$projectBinDirectory\npm"
+
+Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r win-x64
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r linux-x64
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
+
+Write-Information "Merging binaries and NPM configuration..."
+Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux
+Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin
+
+# To Publish:
+# from [sarif-sdk]\bld\bin\AnyCPU_Release\Sarif.Multitool\npm, run:
+#  npm login   (Once; need a token from npmjs.com)
+# for each sarif-multitool folder...
+#  Update the version numbers, if desired.
+#  npm publish --access public
+
+Write-Information "$ScriptName SUCCEEDED."

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -29,9 +29,9 @@ $npmSourceFolder = "$RepoRoot\npm"
 $npmBuildFolder = "$projectBinDirectory\npm"
 
 Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
-dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r win-x64
-dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r linux-x64
-dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r win-x64
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r linux-x64
+dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r osx-x64
 
 Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
 New-DirectorySafely $npmBuildFolder\

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -37,9 +37,9 @@ $npmBuildFolder = "$BuildRoot\Publish\npm"
 
 if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r win-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r linux-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 --no-restore -r osx-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r win-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r linux-x64
+    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r osx-x64
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
     New-DirectorySafely $npmBuildFolder\

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -34,7 +34,7 @@ dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcore
 dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
 
 Write-Information "Merging binaries and NPM configuration..."
-Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder
+# Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder
 Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32
 Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux
 Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -49,9 +49,10 @@ if (-not $SkipBuild) {
     Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin\
 }
 
+# TEMP: Use 0.x.y numbering until NPM package shape settled, then follow SDK version exactly by removing the hardcoded set
 $sarifVersion = Get-PackageVersion
-# TEMP: Use 0.x.y numbering until NPM package shape settled, then follow SDK version exactly by removing the next line
-$sarifVersion = $sarifVersion -replace "2\.", "0."
+$sarifVersion = "0.1.25"
+
 Write-Information "Injecting Sarif SDK version $sarifVersion for NPM Packages..."
 foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {
     Find-AndReplaceInFile "$package\package.json" "0\.1\.0" $sarifVersion

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -1,8 +1,8 @@
 <#
 .SYNOPSIS
-    Build, and package the Sarif Multitool NPM package.
+    Build and package the Sarif Multitool NPM package.
 .DESCRIPTION
-    Builds the Sarif Multitool NPM package, including building the .NET Core 3.0 single-file-exe of the Multitool for all supported platforms.
+    Builds the Sarif.Multitool NPM package, including building the .NET Core 3.0 single-file-exe of the Multitool for all supported platforms.
 .PARAMETER Configuration
     The build configuration: Release or Debug. Default=Release
 #>
@@ -37,9 +37,9 @@ $npmBuildFolder = "$BuildRoot\Publish\npm"
 
 if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r win-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r linux-x64
-    dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r osx-x64
+    foreach ($runtime in "win-x64", "linux-x64", "osx-x64") {
+        dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r $runtime
+    }
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
     New-DirectorySafely $npmBuildFolder\
@@ -55,7 +55,7 @@ $sarifVersion = "0.1.25"
 
 Write-Information "Injecting Sarif SDK version $sarifVersion for NPM Packages..."
 foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {
-    Find-AndReplaceInFile "$package\package.json" "0\.1\.0" $sarifVersion
+    Find-AndReplaceInFile "$package\package.json" "{version}" $sarifVersion
 }
 
 

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -26,7 +26,7 @@ Import-Module -Force $PSScriptRoot\Projects.psm1
 $project = "Sarif.Multitool"
 $projectBinDirectory = (Get-ProjectBinDirectory $project $Configuration)
 $npmSourceFolder = "$RepoRoot\npm"
-$npmBuildFolder = "$projectBinDirectory\npm"
+$npmBuildFolder = "$BuildRoot\Publish\npm"
 
 Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
 dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r win-x64

--- a/scripts/BuildPackagesFromSigningDirectory.ps1
+++ b/scripts/BuildPackagesFromSigningDirectory.ps1
@@ -15,6 +15,8 @@ param(
     $Configuration="Release"
 )
 
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
 Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
 Import-Module -Force $PSScriptRoot\Projects.psm1
 Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1

--- a/scripts/DeleteTestOutputs.ps1
+++ b/scripts/DeleteTestOutputs.ps1
@@ -1,8 +1,8 @@
 <#
 .SYNOPSIS
-    Build, and package the Sarif Multitool NPM package.
+    Delete test outputs from bld\bin to reduce published content size.
 .DESCRIPTION
-    Builds the Sarif Multitool NPM package, including building the .NET Core 3.0 single-file-exe of the Multitool for all supported platforms.
+    Deletes all test project outputs from bld\bin; reduces published size by ~450 MB.
 .PARAMETER Configuration
     The build configuration: Release or Debug. Default=Release
 #>

--- a/scripts/DeleteTestOutputs.ps1
+++ b/scripts/DeleteTestOutputs.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Build, and package the Sarif Multitool NPM package.
+.DESCRIPTION
+    Builds the Sarif Multitool NPM package, including building the .NET Core 3.0 single-file-exe of the Multitool for all supported platforms.
+.PARAMETER Configuration
+    The build configuration: Release or Debug. Default=Release
+#>
+
+[CmdletBinding()]
+param(
+    [string]
+    [ValidateSet("Debug", "Release")]
+    $Configuration="Release"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$InformationPreference = "Continue"
+
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
+Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
+Import-Module -Force $PSScriptRoot\Projects.psm1
+
+Write-Information "Removing Test Outputs before Publish..."
+foreach ($project in $Projects.Tests) {
+    $projectBinDirectory = (Get-ProjectBinDirectory $project $configuration)
+    Remove-DirectorySafely $projectBinDirectory
+}
+
+Write-Information "$ScriptName SUCCEEDED."

--- a/scripts/DelistCurrentPackages.ps1
+++ b/scripts/DelistCurrentPackages.ps1
@@ -12,6 +12,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
 Import-Module $PSScriptRoot\NuGetUtilities.psm1
 
 Hide-NuGetPackages

--- a/scripts/Get-VersionConstants.ps1
+++ b/scripts/Get-VersionConstants.ps1
@@ -16,6 +16,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
 Import-Module $PSScriptRoot\ScriptUtilities.psm1 -Force
 
 $assemblyAttributesXPath = "/msbuild:Project/msbuild:PropertyGroup[@Label='AssemblyAttributes']"

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -19,7 +19,7 @@ $NuGetSamplesPackageRoot = "$SourceRoot\Samples\packages"
 $NuGetConfigFile = "$RepoRoot\NuGet.Config"
 
 $PackageSource = "https://nuget.org"
-$PackageOutputDirectoryRoot = Join-Path $BinRoot NuGet
+$PackageOutputDirectoryRoot = Join-Path $BuildRoot "Publish\NuGet"
 
 function Get-PackageVersion([switch]$previous) {
     $versionPrefix, $schemaVersion, $stableSarifVersion = & $PSScriptRoot\Get-VersionConstants.ps1 -Previous:$previous

--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -150,7 +150,8 @@ function Hide-NuGetPackages {
 
 Export-ModuleMember -Function `
     Hide-NuGetPackages, `
-    New-NuGetPackages
+    New-NuGetPackages, `
+    Get-PackageVersion
 
 Export-ModuleMember -Variable `
     NuGetConfigFile, `

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -36,11 +36,14 @@ $Projects.Applications = @(
 $Projects.Products = $Projects.Libraries + $Projects.Applications
 
 $Projects.Tests = @(
+    "Test.EndToEnd.Baselining"
+    "Test.FunctionalTests.Sarif",
     "Test.UnitTests.Sarif",
     "Test.UnitTests.Sarif.Converters",
-    "Test.UnitTests.Sarif.Driver",
-    "Test.FunctionalTests.Sarif",
-    "Test.UnitTests.Sarif.Multitool"
+    "Test.UnitTests.Sarif.Driver",    
+    "Test.UnitTests.Sarif.Multitool",
+    "Test.UnitTests.Sarif.WorkItemFiling",
+    "Test.Utilities.Sarif"
     )
 
 $Projects.All = $Projects.Products + $Projects.Tests

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -38,7 +38,7 @@ $failedTestProjects = @()
 foreach ($project in $Projects.Tests) {
     foreach ($framework in $Frameworks.Application) {
 
-        if (-not $AppVeyor -and $framework -ne "netcoreapp2.0") { continue; }
+        if ((-not $AppVeyor) -and ($framework -ne "netcoreapp2.0")) { continue; }
 
         Write-Information "Running tests in ${project}: $framework..."
         Push-Location $SourceRoot\$project

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -28,11 +28,11 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 
+$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
+
 Import-Module -Force $PSScriptRoot\ScriptUtilities.psm1
 Import-Module -Force $PSScriptRoot\NuGetUtilities.psm1
 Import-Module -Force $PSScriptRoot\Projects.psm1
-
-$ScriptName = $([io.Path]::GetFileNameWithoutExtension($PSCommandPath))
 
 $failedTestProjects = @()
 foreach ($project in $Projects.Tests) {

--- a/scripts/ScriptUtilities.psm1
+++ b/scripts/ScriptUtilities.psm1
@@ -54,12 +54,24 @@ function Write-CommandLine($exeName, $arguments) {
     Write-Verbose "$exeName $($arguments -join ' ')"
 }
 
+function Find-AndReplaceInFile($filePath, $value, $withValue) {
+    $tempFilePath = "$filePath.tmp"
+    if (Test-Path -Path $tempFilePath) { 
+        Remove-Item $tempFilePath 
+    }
+
+    (Get-Content -Path $filePath) -replace $value, $withValue | Add-Content -Path $tempFilePath -Force
+    Remove-Item $filePath
+    Move-Item -Path $tempFilePath -Destination $filePath
+}
+
 Export-ModuleMember -Function `
     Exit-WithFailureMessage, `
     New-DirectorySafely, `
     Remove-DirectorySafely, `
     Get-ProjectBinDirectory, `
-    Write-CommandLine
+    Write-CommandLine, `
+    Find-AndReplaceInFile
 
 Export-ModuleMember -Variable `
     BinRoot, `

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -3,15 +3,17 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <!-- If ready to go to VS 2019+ only: -->
-    <!-- <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks> -->
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-
     <!-- To Publish single-file exes, run: 
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r win-x64
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r linux-x64
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r win-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r linux-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r osx-x64
+
+      For settings which we want only for these builds, we use [Condition="'$(RuntimeIdentifier)' != ''"] to identify them
     -->
+
+    <!-- Keep default targets to allow VS2017 use; our build pool is Hosted VS2017 only. -->
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RuntimeIdentifier)' != ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
 
     <!-- When dotnet publish run, produce trimmed single-file exe -->
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -8,14 +8,14 @@
       dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r linux-x64
       dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r osx-x64
 
-      For settings which we want only for these builds, we use [Condition="'$(RuntimeIdentifier)' != ''"] to identify them
+      We use [Condition="'$(RuntimeIdentifier)' != ''"] to identify settings used only for these builds.      
     -->
 
-    <!-- Keep default targets to allow VS2017 use; our build pool is Hosted VS2017 only. -->
+    <!-- Keep default targets to allow VS2017 use and builds in the Azure 'Hosted VS2017' build agent pool -->
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(RuntimeIdentifier)' != ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RuntimeIdentifier)' != ''">$(TargetFrameworks);netcoreapp3.0</TargetFrameworks>
 
-    <!-- When dotnet publish run, produce trimmed single-file exe -->
+    <!-- Publish trimmed single-file exe -->
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
     <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
 

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -2,11 +2,27 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+
+    <!-- If ready to go to VS 2019+ only: -->
+    <!-- <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks> -->
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+
+    <!-- To Publish single-file exes, run: 
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r win-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r linux-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 /p:TargetFrameworks=netcoreapp3.0 -r osx-x64
+    -->
+
+    <!-- When dotnet publish run, produce trimmed single-file exe -->
+    <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
+    <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
+
+    <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
+    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 
   <!-- PackAsTool is supported/recommended for .NET Core >= 2.1 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 

--- a/src/build.props
+++ b/src/build.props
@@ -42,7 +42,7 @@
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(OutputSubDir)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>
     <PublishDir>$(OutputPath)\Publish\$(TargetFramework)\</PublishDir>
-    <PublishDir Condition=" '$(RuntimeIdentifier)' != '' ">$(OutputPath)\Publish\$(TargetFramework)\$(RuntimeIdentifier)\</PublishDir>
+    <PublishDir Condition=" '$(RuntimeIdentifier)' != '' ">$(PublishDir)\$(RuntimeIdentifier)\</PublishDir>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MsBuildThisFileDirectory)</SolutionDir>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/build.props
+++ b/src/build.props
@@ -42,6 +42,7 @@
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(OutputSubDir)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>
     <PublishDir>$(OutputPath)\Publish\$(TargetFramework)\</PublishDir>
+    <PublishDir Condition=" '$(RuntimeIdentifier)' != '' ">$(OutputPath)\Publish\$(TargetFramework)\$(RuntimeIdentifier)\</PublishDir>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(MsBuildThisFileDirectory)</SolutionDir>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/build.props
+++ b/src/build.props
@@ -20,6 +20,10 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
+    <!-- 
+      NOTE: Version in scripts/BuildMultitoolForNpm.ps1 also has to be updated for each release
+      until it adopts the same versions as the SDK itself.
+    -->
     <VersionPrefix>2.1.24</VersionPrefix>
     <PreviousVersionPrefix>2.1.23</PreviousVersionPrefix>
 


### PR DESCRIPTION
Enabling build of NPM package with .NET Core 3.0 single-file-exe packaging of the Sarif.Multitool.

NOTES
- This does not add .NET Core 3.0 as a target by default because that forces VS2019+ and our AzureDevOps build pool does not have VS2019 instances.
- Sarif.Multitool.csproj adds settings conditionally when a runtime has been specified to stay VS2017 compatible; this build has been structured so it runs safely before or after BuildAndTest.ps1.
- Sarif.csproj must be built with the current targets also included, because src/Sarif/obj/project.assets.json is written on every build and breaks NuGet packaging if written without the framework targets that the NuGet package is using.
- Consolidated on "dotnet" for build and test everywhere to unblock .NET Core 3.0 build; should also enable builds where VS is not installed.
- .NET Core 3.0 makes *huge* builds, so outputs are trimmed before publish.
- Published artifact size went from 792MB to 1,564MB (.NET Core 3) to 347MB (trimmed).
- Build times go from ~20-25 minutes to ~10-15 minutes despite extra builds due to the huge publish time savings.

CHANGES
- Adding NPM packaging configuration under /npm (by @jeffersonking).
- Added scripts/BuildMultitoolForNpm.ps1 to build .NET Core 3.0 multitool, single file exes, and completed NPM packages.
- Added scripts/DeleteTestOutputs.ps1 to clean build outputs for publish.
- Added missing test projects to scripts/Projects.psm1.
- Added missing $ScriptPath definitions to avoid error while reporting errors from some scripts.
- Modified output path of published content (NuGet and NPM packages) to bld/Publish to allow AzureDevOps build to easily upload just the needed content; a cleaned bld/bin is also published so we retain signed binaries of everything.
- Added Multitool documentation (separately); linking from NPM READMEs.

