### PR TITLE
Fully expand require package.json.

### DIFF
--- a/npm/sarif-multitool/index.js
+++ b/npm/sarif-multitool/index.js
@@ -1,1 +1,1 @@
-module.exports = require(`${require('./package').name}-${process.platform}`)
+module.exports = require(`${require('./package.json').name}-${process.platform}`)


### PR DESCRIPTION
Adding ".json" to spare downstream Jest consumers from using moduleFileExtensions.