### PR TITLE
Fix #1785: Misspelled property in schema

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,11 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## **v2.1.26** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.26) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.26) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.26)
+## **v2.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.26) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.26) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.26)
 * PACKAGE BREAKING: Update tool directory to netstandard2.1, to reflect use of that version of .NET Core.
+* FEATURE: Multitool `rewrite` command performance when populating regions and snippets is greatly improved.
+* FEATURE: Multitool `insert` option now supports `Guids` value to populate `Result.Guid`.
+* BUGFIX: Fix typo in schema: suppression.state should be suppression.status according to the spec. [#1785](https://github.com/microsoft/sarif-sdk/issues/1785)
+* BUGFIX: Multitool `rewrite` no longer throws when it encounters an invalid value (such as -1) for a region property.
 
 ## **v2.1.25** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.25) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.25) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.25)
 * FEATURE: The baseliner (available through the Multitool's `match-results-forward` command) now populates `result.provenance.firstDetectionTimeUtc` so you can now track the age of each issue. [#1737](https://github.com/microsoft/sarif-sdk/issues/1737)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## **v2.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.26) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.26) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.26)
+## **v2.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.0)
 * PACKAGE BREAKING: Update tool directory to netstandard2.1, to reflect use of that version of .NET Core.
 * FEATURE: Multitool `rewrite` command performance when populating regions and snippets is greatly improved.
 * FEATURE: Multitool `insert` option now supports `Guids` value to populate `Result.Guid`.

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             Separator = ';',
             HelpText =
             "Optionally present data, expressed as a semicolon-delimited list, that should be inserted into the log file. " +
-            "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets " +
+            "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, Guids, " +
             "and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToInsert { get; set; }
 

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -76,7 +76,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(SolutionDir)\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include=".\DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="..\Sarif\Schemata\sarif-2.1.0-rtm.4.json" Link="sarif-2.1.0.json" />
+    <EmbeddedResource Include="..\Sarif\Schemata\sarif-2.1.0-rtm.5.json" Link="sarif-2.1.0.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Sarif.Multitool/ValidateCommand.cs
+++ b/src/Sarif.Multitool/ValidateCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
             else
             {
-                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0-rtm.4.json";
+                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0-rtm.5.json";
 
                 using (Stream stream = this.GetType().Assembly.GetManifestResourceStream(schemaResource))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/Sarif/Autogenerated/Suppression.cs
+++ b/src/Sarif/Autogenerated/Suppression.cs
@@ -47,11 +47,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         public virtual SuppressionKind Kind { get; set; }
 
         /// <summary>
-        /// A string that indicates the state of the suppression.
+        /// A string that indicates the status of the suppression.
         /// </summary>
-        [DataMember(Name = "state", IsRequired = false, EmitDefaultValue = false)]
+        [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public virtual SuppressionState State { get; set; }
+        public virtual SuppressionStatus Status { get; set; }
 
         /// <summary>
         /// A string representing the justification for the suppression.
@@ -87,8 +87,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="kind">
         /// An initialization value for the <see cref="P:Kind" /> property.
         /// </param>
-        /// <param name="state">
-        /// An initialization value for the <see cref="P:State" /> property.
+        /// <param name="status">
+        /// An initialization value for the <see cref="P:Status" /> property.
         /// </param>
         /// <param name="justification">
         /// An initialization value for the <see cref="P:Justification" /> property.
@@ -99,9 +99,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Suppression(string guid, SuppressionKind kind, SuppressionState state, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
+        public Suppression(string guid, SuppressionKind kind, SuppressionStatus status, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(guid, kind, state, justification, location, properties);
+            Init(guid, kind, status, justification, location, properties);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Guid, other.Kind, other.State, other.Justification, other.Location, other.Properties);
+            Init(other.Guid, other.Kind, other.Status, other.Justification, other.Location, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -141,11 +141,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Suppression(this);
         }
 
-        protected virtual void Init(string guid, SuppressionKind kind, SuppressionState state, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
+        protected virtual void Init(string guid, SuppressionKind kind, SuppressionStatus status, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Guid = guid;
             Kind = kind;
-            State = state;
+            Status = status;
             Justification = justification;
             if (location != null)
             {

--- a/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (left.State != right.State)
+            if (left.Status != right.Status)
             {
                 return false;
             }
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 result = (result * 31) + obj.Kind.GetHashCode();
-                result = (result * 31) + obj.State.GetHashCode();
+                result = (result * 31) + obj.Status.GetHashCode();
                 if (obj.Justification != null)
                 {
                     result = (result * 31) + obj.Justification.GetHashCode();

--- a/src/Sarif/Autogenerated/SuppressionStatus.cs
+++ b/src/Sarif/Autogenerated/SuppressionStatus.cs
@@ -6,10 +6,10 @@ using System.CodeDom.Compiler;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// A string that indicates the state of the suppression.
+    /// A string that indicates the status of the suppression.
     /// </summary>
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "1.1.0.0")]
-    public enum SuppressionState
+    public enum SuppressionStatus
     {
         None,
         Accepted,

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -896,12 +896,12 @@
       }
     }
   ],
-  "Suppression.State": [
+  "Suppression.Status": [
     {
       "kind": "EnumHint",
       "arguments": {
-        "typeName": "SuppressionState",
-        "description": "A string that indicates the state of the suppression.",
+        "typeName": "SuppressionStatus",
+        "description": "A string that indicates the status of the suppression.",
         "zeroValueName": "None",
         "memberNames": [
           "Accepted",

--- a/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
+++ b/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema",
-  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.4.json",
-  "description": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema: a standard format for the output of static analysis tools.",
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema",
+  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.5.json",
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema: a standard format for the output of static analysis tools.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
@@ -2715,8 +2715,8 @@
           ]
         },
 
-        "state": {
-          "description": "A string that indicates the state of the suppression.",
+        "status": {
+          "description": "A string that indicates the status of the suppression.",
           "enum": [
             "accepted",
             "underReview",

--- a/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.5.json
+++ b/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.5.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.4 JSON Schema",
-  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json",
+  "title": "SARIF External Property File Schema Version 2.1.0-rtm.5 JSON Schema",
+  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json",
   "type": "object",
   "properties": {
 
@@ -30,7 +30,7 @@
 
     "conversion": {
       "description": "A conversion object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/conversion"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/conversion"
     },
 
     "graphs": {
@@ -40,13 +40,13 @@
       "default": [],
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/graph"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/graph"
       }
     },
 
     "externalizedProperties": {
       "description": "Key/value pairs that provide additional information that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/propertyBag"
     },
 
     "artifacts": {
@@ -55,7 +55,7 @@
       "minItems": 0,
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/artifact"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/artifact"
       }
     },
 
@@ -66,7 +66,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/invocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/invocation"
       }
     },
 
@@ -77,7 +77,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/logicalLocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/logicalLocation"
       }
     },
 
@@ -88,7 +88,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/threadFlowLocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/threadFlowLocation"
       }
     },
 
@@ -99,7 +99,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/result"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/result"
       }
     },
 
@@ -110,13 +110,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
     "driver": {
       "description": "The analysis tool object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
     },
 
     "extensions": {
@@ -126,7 +126,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -137,7 +137,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -148,7 +148,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -159,7 +159,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/address"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/address"
       }
     },
 
@@ -170,7 +170,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/webRequest"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/webRequest"
       }
     },
 
@@ -181,13 +181,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/webResponse"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/webResponse"
       }
     },
 
     "properties": {
       "description": "Key/value pairs that provide additional information about the external properties.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/propertyBag"
     }
   },
   "required": [ "version" ],

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 {
     public static class VersionConstants
     {
-        public const string SchemaVersionAsPublishedToSchemaStoreOrg = "2.1.0-rtm.4";
+        public const string SchemaVersionAsPublishedToSchemaStoreOrg = "2.1.0-rtm.5";
         public const string StableSarifVersion = "2.1.0";
     }
 }

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                         case "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.1.json":
                         {
                             modifiedLog |= ApplyRtm2and3Changes(logObject);
+                            modifiedLog |= ApplyRtm5Changes(logObject);
                             break;
                         }
                         default:
@@ -97,6 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
 
@@ -108,6 +110,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
 
@@ -121,6 +124,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
 
@@ -134,6 +138,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
 
@@ -155,6 +160,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
 
@@ -174,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                     modifiedLog |= ApplyRtm0Changes(logObject);
                     modifiedLog |= ApplyRtm1Changes(logObject);
                     modifiedLog |= ApplyRtm2and3Changes(logObject);
+                    modifiedLog |= ApplyRtm5Changes(logObject);
                     break;
                 }
             }
@@ -234,6 +241,30 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 {
                     // https://github.com/oasis-tcs/sarif-spec/issues/414
                     modifiedLog |= ConvertResultLogicalLocationToArray(run);
+                }
+            }
+
+            return modifiedLog;
+        }
+
+        private static bool ApplyRtm5Changes(JObject sarifLog)
+        {
+            bool modifiedLog = false;
+
+            if (sarifLog["runs"] is JArray runs)
+            {
+                foreach (JObject run in runs)
+                {
+                    if (run["results"] is JArray results)
+                    {
+                        foreach (JObject result in results)
+                        {
+                            if (result["suppression"] is JObject suppression)
+                            {
+                                modifiedLog = RenameProperty(suppression, "state", "status");
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/Inputs/FilterByPredicate.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/Inputs/FilterByPredicate.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/Inputs/Partition.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/Inputs/Partition.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/Inputs/RunWithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/Inputs/RunWithArtifacts.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifLogger/SimpleExample.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifLogger/SimpleExample.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/build.props
+++ b/src/build.props
@@ -24,11 +24,11 @@
       NOTE: Version in scripts/BuildMultitoolForNpm.ps1 also has to be updated for each release
       until it adopts the same versions as the SDK itself.
     -->
-    <VersionPrefix>2.1.25</VersionPrefix>
-    <PreviousVersionPrefix>2.1.24</PreviousVersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
+    <PreviousVersionPrefix>2.1.25</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
-    <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
+    <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>
       
     <!-- The stable Version of SARIF Specifications. -->
     <StableSarifVersion>2.1.0</StableSarifVersion>


### PR DESCRIPTION
Per the spec, `suppression.state` should have been `suppression.status`.

Also:
- Mention Scott's new `Guid` value for inserting optional data in the `HelpText` for the `insert` option.
- Mention Scott's work in the release history.