### PR TITLE
Suppression state to status

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,11 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
-## **v2.1.26** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.26) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.26) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.26)
+## **v2.2.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.0)
 * PACKAGE BREAKING: Update tool directory to netstandard2.1, to reflect use of that version of .NET Core.
+* FEATURE: Multitool `rewrite` command performance when populating regions and snippets is greatly improved.
+* FEATURE: Multitool `insert` option now supports `Guids` value to populate `Result.Guid`.
+* API + SCHEMA BREAKING: Fix typo in schema: suppression.state should be suppression.status according to the spec. [#1785](https://github.com/microsoft/sarif-sdk/issues/1785)
+* BUGFIX: Multitool `rewrite` no longer throws when it encounters an invalid value (such as -1) for a region property.
 
 ## **v2.1.25** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.25) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.25) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.25)
 * FEATURE: The baseliner (available through the Multitool's `match-results-forward` command) now populates `result.provenance.firstDetectionTimeUtc` so you can now track the age of each issue. [#1737](https://github.com/microsoft/sarif-sdk/issues/1737)

--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             Separator = ';',
             HelpText =
             "Optionally present data, expressed as a semicolon-delimited list, that should be inserted into the log file. " +
-            "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets " +
-            "and NondeterministicProperties.")]
+            "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, " +
+            "Guids and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToInsert { get; set; }
 
         [Option(

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -76,7 +76,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(SolutionDir)\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include=".\DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="..\Sarif\Schemata\sarif-2.1.0-rtm.4.json" Link="sarif-2.1.0.json" />
+    <EmbeddedResource Include="..\Sarif\Schemata\sarif-2.1.0-rtm.5.json" Link="sarif-2.1.0.json" />
   </ItemGroup>
 
 </Project>

--- a/src/Sarif.Multitool/ValidateCommand.cs
+++ b/src/Sarif.Multitool/ValidateCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
             else
             {
-                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0-rtm.4.json";
+                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0-rtm.5.json";
 
                 using (Stream stream = this.GetType().Assembly.GetManifestResourceStream(schemaResource))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/Sarif/Autogenerated/Suppression.cs
+++ b/src/Sarif/Autogenerated/Suppression.cs
@@ -47,11 +47,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         public virtual SuppressionKind Kind { get; set; }
 
         /// <summary>
-        /// A string that indicates the state of the suppression.
+        /// A string that indicates the review status of the suppression.
         /// </summary>
-        [DataMember(Name = "state", IsRequired = false, EmitDefaultValue = false)]
+        [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.EnumConverter))]
-        public virtual SuppressionState State { get; set; }
+        public virtual SuppressionStatus Status { get; set; }
 
         /// <summary>
         /// A string representing the justification for the suppression.
@@ -87,8 +87,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="kind">
         /// An initialization value for the <see cref="P:Kind" /> property.
         /// </param>
-        /// <param name="state">
-        /// An initialization value for the <see cref="P:State" /> property.
+        /// <param name="status">
+        /// An initialization value for the <see cref="P:Status" /> property.
         /// </param>
         /// <param name="justification">
         /// An initialization value for the <see cref="P:Justification" /> property.
@@ -99,9 +99,9 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="properties">
         /// An initialization value for the <see cref="P:Properties" /> property.
         /// </param>
-        public Suppression(string guid, SuppressionKind kind, SuppressionState state, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
+        public Suppression(string guid, SuppressionKind kind, SuppressionStatus status, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
         {
-            Init(guid, kind, state, justification, location, properties);
+            Init(guid, kind, status, justification, location, properties);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.Guid, other.Kind, other.State, other.Justification, other.Location, other.Properties);
+            Init(other.Guid, other.Kind, other.Status, other.Justification, other.Location, other.Properties);
         }
 
         ISarifNode ISarifNode.DeepClone()
@@ -141,11 +141,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return new Suppression(this);
         }
 
-        protected virtual void Init(string guid, SuppressionKind kind, SuppressionState state, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
+        protected virtual void Init(string guid, SuppressionKind kind, SuppressionStatus status, string justification, Location location, IDictionary<string, SerializedPropertyInfo> properties)
         {
             Guid = guid;
             Kind = kind;
-            State = state;
+            Status = status;
             Justification = justification;
             if (location != null)
             {

--- a/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
+++ b/src/Sarif/Autogenerated/SuppressionEqualityComparer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 return false;
             }
 
-            if (left.State != right.State)
+            if (left.Status != right.Status)
             {
                 return false;
             }
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
 
                 result = (result * 31) + obj.Kind.GetHashCode();
-                result = (result * 31) + obj.State.GetHashCode();
+                result = (result * 31) + obj.Status.GetHashCode();
                 if (obj.Justification != null)
                 {
                     result = (result * 31) + obj.Justification.GetHashCode();

--- a/src/Sarif/Autogenerated/SuppressionStatus.cs
+++ b/src/Sarif/Autogenerated/SuppressionStatus.cs
@@ -6,10 +6,10 @@ using System.CodeDom.Compiler;
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
-    /// A string that indicates the state of the suppression.
+    /// A string that indicates the review status of the suppression.
     /// </summary>
     [GeneratedCode("Microsoft.Json.Schema.ToDotNet", "1.1.0.0")]
-    public enum SuppressionState
+    public enum SuppressionStatus
     {
         None,
         Accepted,

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -896,12 +896,12 @@
       }
     }
   ],
-  "Suppression.State": [
+  "Suppression.Status": [
     {
       "kind": "EnumHint",
       "arguments": {
-        "typeName": "SuppressionState",
-        "description": "A string that indicates the state of the suppression.",
+        "typeName": "SuppressionStatus",
+        "description": "A string that indicates the review status of the suppression.",
         "zeroValueName": "None",
         "memberNames": [
           "Accepted",

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -41,9 +41,8 @@
     <!--
     Marking these items as content causes them to be included in the NuGet package.
     -->
-    <Content Include="Schemata\sarif-2.1.0-rtm.5.json" />
-    <Content Include="Schemata\sarif-external-property-file-2.1.0-rtm.5.json" />
-
+    <Content Include="Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
+    <Content Include="Schemata\sarif-external-property-file-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
     <!-- This item will be added to the NuGet package, however. -->
     <Content Include="..\ReleaseHistory.md" />
   </ItemGroup>

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -41,8 +41,8 @@
     <!--
     Marking these items as content causes them to be included in the NuGet package.
     -->
-    <Content Include="Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
-    <Content Include="Schemata\sarif-external-property-file-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" />
+    <Content Include="Schemata\sarif-2.1.0-rtm.5.json" />
+    <Content Include="Schemata\sarif-external-property-file-2.1.0-rtm.5.json" />
 
     <!-- This item will be added to the NuGet package, however. -->
     <Content Include="..\ReleaseHistory.md" />

--- a/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
+++ b/src/Sarif/Schemata/sarif-2.1.0-rtm.5.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema",
-  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.4.json",
-  "description": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.4 JSON Schema: a standard format for the output of static analysis tools.",
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema",
+  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-2.1.0-rtm.5.json",
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0-rtm.5 JSON Schema: a standard format for the output of static analysis tools.",
   "additionalProperties": false,
   "type": "object",
   "properties": {
@@ -2715,8 +2715,8 @@
           ]
         },
 
-        "state": {
-          "description": "A string that indicates the state of the suppression.",
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
           "enum": [
             "accepted",
             "underReview",

--- a/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.5.json
+++ b/src/Sarif/Schemata/sarif-external-property-file-2.1.0-rtm.5.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "title": "SARIF External Property File Schema Version 2.1.0-rtm.4 JSON Schema",
-  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.4.json",
+  "title": "SARIF External Property File Schema Version 2.1.0-rtm.5 JSON Schema",
+  "id": "https://raw.githubusercontent.com/schemastore/schemastore/master/src/schemas/json/sarif-external-property-file-2.1.0-rtm.5.json",
   "type": "object",
   "properties": {
 
@@ -30,7 +30,7 @@
 
     "conversion": {
       "description": "A conversion object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/conversion"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/conversion"
     },
 
     "graphs": {
@@ -40,13 +40,13 @@
       "default": [],
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/graph"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/graph"
       }
     },
 
     "externalizedProperties": {
       "description": "Key/value pairs that provide additional information that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/propertyBag"
     },
 
     "artifacts": {
@@ -55,7 +55,7 @@
       "minItems": 0,
       "uniqueItems": true,
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/artifact"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/artifact"
       }
     },
 
@@ -66,7 +66,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/invocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/invocation"
       }
     },
 
@@ -77,7 +77,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/logicalLocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/logicalLocation"
       }
     },
 
@@ -88,7 +88,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/threadFlowLocation"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/threadFlowLocation"
       }
     },
 
@@ -99,7 +99,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/result"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/result"
       }
     },
 
@@ -110,13 +110,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
     "driver": {
       "description": "The analysis tool object that will be merged with an external run.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
     },
 
     "extensions": {
@@ -126,7 +126,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -137,7 +137,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -148,7 +148,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/toolComponent"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/toolComponent"
       }
     },
 
@@ -159,7 +159,7 @@
       "uniqueItems": false,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/address"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/address"
       }
     },
 
@@ -170,7 +170,7 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/webRequest"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/webRequest"
       }
     },
 
@@ -181,13 +181,13 @@
       "uniqueItems": true,
       "default": [],
       "items": {
-        "$ref": "sarif-2.1.0-rtm.4.json#/definitions/webResponse"
+        "$ref": "sarif-2.1.0-rtm.5.json#/definitions/webResponse"
       }
     },
 
     "properties": {
       "description": "Key/value pairs that provide additional information about the external properties.",
-      "$ref": "sarif-2.1.0-rtm.4.json#/definitions/propertyBag"
+      "$ref": "sarif-2.1.0-rtm.5.json#/definitions/propertyBag"
     }
   },
   "required": [ "version" ],

--- a/src/Sarif/VersionConstants.cs
+++ b/src/Sarif/VersionConstants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 {
     public static class VersionConstants
     {
-        public const string SchemaVersionAsPublishedToSchemaStoreOrg = "2.1.0-rtm.4";
+        public const string SchemaVersionAsPublishedToSchemaStoreOrg = "2.1.0-rtm.5";
         public const string StableSarifVersion = "2.1.0";
     }
 }

--- a/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
+++ b/src/Sarif/Writers/PrereleaseCompatibilityTransformer.cs
@@ -245,17 +245,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
 
         private static bool ConvertSuppressionStateToSuppressionStatus(JObject sarifLog)
         {
-            string suppressionsPathToUpdate = "runs[].results[].suppressions[]";
+            bool modifiedLog = false;
 
-            bool actionOnLeaf(JObject suppression)
+            if (sarifLog["runs"] is JArray runs)
             {
-                return RenameProperty(suppression, "state", "status");
+                foreach (JObject run in runs)
+                {
+                    if (run["results"] is JArray results)
+                    {
+                        foreach (JObject result in results)
+                        {
+                            if (result["suppressions"] is JArray suppressions)
+                            {
+                                foreach (JObject suppression in suppressions)
+                                {
+                                    modifiedLog = RenameProperty(suppression, "state", "status");
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
-            return PerformActionOnLeafNodeIfExists(
-                possiblePathToLeafNode: suppressionsPathToUpdate,
-                rootNode: sarifLog,
-                action: actionOnLeaf);
+            return modifiedLog;
         }
 
         private static bool ApplyRtm1Changes(JObject sarifLog)

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1001.SyntaxError.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/JSON1002.DeserializationError.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1003.UrisMustBeValid_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1007.EndTimeMustNotBeBeforeStartTime_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1012.EndLineMustNotBeLessThanStartLine_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1013.EndColumnMustNotBeLessThanStartColumn_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1014.UriBaseIdRequiresRelativeUri_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1016.ContextRegionRequiresRegion_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1017.InvalidIndex_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1017.InvalidIndex_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1017.InvalidIndex_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1017.InvalidIndex_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1015.UriMustBeAbsolute_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1017.InvalidIndex_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1017.InvalidIndex_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1017.InvalidIndex_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1017.InvalidIndex_Valid.sarif
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+    "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
     "version": "2.1.0",
     "runs": [
       {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Valid.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/AlwaysFalsePredicate.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/AlwaysFalsePredicate.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/AlwaysTruePredicate.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/AlwaysTruePredicate.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/RuleIdPredicate.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/ExpectedOutputs/RuleIdPredicate.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/Inputs/FilterByPredicate.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/FilterByPredicate/Inputs/FilterByPredicate.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST0001.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST0001.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST0002.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST0002.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST9999.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TST9999.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TrivialPartitionFunction.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/ExpectedOutputs/TrivialPartitionFunction.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/Inputs/Partition.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Partitioning/Partition/Inputs/Partition.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog2_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog3_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog4_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog5_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog6_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog7_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/AndroidStudio_issueLog8_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/attributeKeyMissing.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/extraComment.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/extraComment.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/fileEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/minimalIssueWithoutPackageOrHintElement.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/moduleEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/packageBeforeModule.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/packageEmpty.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/problemClassSeverityMissing.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssue.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssueWithEmptyHints.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/singleIssueWithHints.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/AndroidStudio/twoIssues.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/ArrayDataTypes.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/BadMissingString.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/ClangAnalyzer_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/DictionaryDataTypes.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/DivByZero.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/FileNumberCoverage.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/GarbageValueLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/MediumLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/MissingLocation.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ClangAnalyzer/RealLog.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/ContrastSecurity/WebGoat.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/CppCheck/CppCheck_issueLog1_raw.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_java.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_m0.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Fortify/bannedAPIs_m1.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/FortifyTest.fpr.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/FortifyTest.fpr.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/OneResultBasic.fpr.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/OneResultBasic.fpr.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/OneResultWithTwoTraces.fpr.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/OneResultWithTwoTraces.fpr.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/ScanWithFailureLevelMatrices.fpr.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/ScanWithFailureLevelMatrices.fpr.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/TwoResultsWithNodeRefs.fpr.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FortifyFpr/TwoResultsWithNodeRefs.fpr.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/FxCopExceptions.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/FxCopNoTargets.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/SarifSdkTest.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/FxCop/SarifSdkTest.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/MSBuild/NoErrors.txt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/MSBuild/NoErrors.txt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/MSBuild/SomeErrors.txt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/MSBuild/SomeErrors.txt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AA_IndexAlias.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AA_IndexAlias.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AA_RememberOldAlias.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AA_RememberOldAlias.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantBranch.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantBranch.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantLoop.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantLoop.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantSwitch.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_IrrelevantSwitch.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_SecondLoop.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AB_SecondLoop.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AF_LocalRemoteFunctions.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AF_LocalRemoteFunctions.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_AliasAndMaybeZero.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_AliasAndMaybeZero.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_AliasAndSetValue.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_AliasAndSetValue.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_BranchAndMaybeZero.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_BranchAndMaybeZero.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_BranchAndSetValue.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AM_BranchAndSetValue.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_Basic_C6053_4.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_Basic_C6053_4.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_Basic_C6387.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_Basic_C6387.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_FunctionAndInAnnotations.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_FunctionAndInAnnotations.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_InOptAnnotations.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_InOptAnnotations.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_OutWithDefect.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AN_OutWithDefect.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AdvancedC6305.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/AdvancedC6305.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C28182Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C28182Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example2.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example2.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example3.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6001Example3.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6011Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6011Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6059Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6059Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6200Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6200Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6305Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6305Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example2.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example2.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example3.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6385Example3.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example2.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example2.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example3.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/C6386Example3.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-001.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-001.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-002.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-002.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-003.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-003.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-005.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-005.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-008.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-008.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-010.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-010.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-011-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-011.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-011.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-013.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-013.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-014.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-014.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-016-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-016.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-016.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-017.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-017.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-020.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-020.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-021.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-021.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-022.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-022.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-023.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-023.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-024.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-024.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-031.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-031.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-032.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-032.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-035.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-035.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-036.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-036.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-037.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-037.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-038-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-038.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-038.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-039.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-039.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-040.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-040.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-041.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-041.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-042.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-042.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-043.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-043.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-045.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-045.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-046.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-046.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-047.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-047.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-048.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-048.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-049.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-049.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-050.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-050.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-051.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-051.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-052.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-052.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-054.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-054.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-055.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-055.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-057.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-057.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-058.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-058.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-059.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-059.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-060.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-060.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-061.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-061.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-062.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-062.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-063.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-063.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-065.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-065.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-066.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-066.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-067.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-067.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-070.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-070.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-071.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-071.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-072.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-072.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-073.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-073.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-074.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-074.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-075.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-075.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-076.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-076.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-077.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-077.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-078.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-078.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-079.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-079.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-080.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-080.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-081.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-081.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-082.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-082.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-083.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-083.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-084.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-084.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-085.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-085.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-086.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-086.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-087.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-087.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-088.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-088.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-089-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-089.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-089.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-090.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-090.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-091.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-091.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-092.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-092.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-093.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-093.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-094.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-094.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-095.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-095.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-096.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-096.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-097.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-097.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-100.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-100.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-101.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-101.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-102.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-102.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-103.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-103.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-104.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-104.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-106.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-106.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-107.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-107.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-108.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-108.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-109.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-109.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-110-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-110.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-110.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-111.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-111.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-112.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-112.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-113.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-113.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-116.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-116.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-117.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-117.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-121.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-121.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-122.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-122.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-123.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-123.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-126.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-126.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-127.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-127.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-128.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-128.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-129.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-129.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-130.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-130.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-131.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-131.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-132.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-132.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-134.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-134.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-136.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-136.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-137.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-137.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-138.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-138.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-139.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-139.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-140.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-140.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-141-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-141.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-141.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-146.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-146.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-150.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-150.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-152.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-152.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-155.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-155.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-156.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-156.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-157.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-157.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-160.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-160.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-162.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-162.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-163.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-163.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-166.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-166.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-167.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-167.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-168.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-168.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-169.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-169.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-170.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-170.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-171.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-171.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-172.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-172.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-173.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-173.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-178.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-178.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-179.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-179.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-180.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-180.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-181.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-181.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-182.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-182.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-185.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-185.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-186.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-186.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-188.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-188.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-192.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-192.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-193.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-193.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-194.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-194.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-197-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-197.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-197.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-198-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-198.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-198.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-199-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-199.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-199.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-201.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-201.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-203.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-203.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-205-amd64.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-205.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Expected-205.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/LongConditions.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/LongConditions.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/LongMacro.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/LongMacro.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/MissingPathElement.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/MissingPathElement.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/RelevantKeyEvents2.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/RelevantKeyEvents2.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/RelevantkeyEvents.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/RelevantkeyEvents.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6259.cxx.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6259.cxx.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6282.cxx.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6282.cxx.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6306.cxx.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6306.cxx.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6316.cxx.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/Standardc6316.cxx.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS260613.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS260613.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS348783.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS348783.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS370524.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS370524.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS372959.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS372959.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS373273.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS373273.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS375867.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS375867.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS378661.cpp.xml.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/PREfast/TFS378661.cpp.xml.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Pylint/Pylint-01.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/Pylint/Pylint-01.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/EmbeddedLocations.csv.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/EmbeddedLocations.csv.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/Simple.csv.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/Simple.csv.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/results.csv.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/SemmleQL/results.csv.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/cancelspinlock_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkadddevice_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkdriverunload_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/checkirpmjpnp_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/dispatchroutine_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/iocompletion_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/iodpcroutine_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/StaticDriverVerifier/isrroutine_bug1.tt.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-03.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-03.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-04.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-04.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-05.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-05.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-07.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-07.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-08.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-08.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-09.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-09.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-10.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-10.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-11.json.sarif
+++ b/src/Test.FunctionalTests.Sarif/v2/ConverterTestData/TSLint/TSLint-11.json.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/ExpectedOutputs/RunWithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/ExpectedOutputs/RunWithArtifacts.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/Inputs/RunWithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif.Multitool/TestData/RebaseUriCommand/Inputs/RunWithArtifacts.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -143,6 +143,7 @@
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\WithExternalPropertyFiles.01-24.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\WithSuppressions.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\ThreadFlowLocationWithKind.sarif" />
+    <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\ExpectedOutputs\ExercisesSchemaRtm5Changes.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\ArtifactsWithRoles.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\ComprehensiveFileProperties.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\OneRunWithBasicInvocation.sarif" />
@@ -161,15 +162,16 @@
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\ToolWithLanguage.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\WithSuppressions.sarif" />
     <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\ThreadFlowLocationWithKind.sarif" />
+    <EmbeddedResource Include="TestData\PrereleaseCompatibilityTransformer\Inputs\ExercisesSchemaRtm5Changes.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\Minimum.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\MinimumWithTwoRuns.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\NotificationExceptionWithStack.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithAutomationDetails.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithBasicInvocation.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithFiles.sarif" />
+    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithLogicalLocations.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithNotificationTime.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithInvocationAndNotifications.sarif" />
-    <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithLogicalLocations.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\OneRunWithRules.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\Regions.sarif" />
     <EmbeddedResource Include="TestData\SarifCurrentToVersionOneVisitor\ExpectedOutputs\RestoreFromPropertyBag.sarif" />

--- a/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestCurrent.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestCurrent.sarif
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4.json",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestPrevious.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestPrevious.sarif
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4.json",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Absolute_TextFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Absolute_TextFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_ComprehensiveRegionProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_ComprehensiveRegionProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_ContextRegionSnippets.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_ContextRegionSnippets.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_FlattenedMessages.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_FlattenedMessages.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes+TextFiles+ComprehensiveRegionProperties+RegionSnippets+ContextRegionSnippets+FlattenedMessages.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes+TextFiles+ComprehensiveRegionProperties+RegionSnippets+ContextRegionSnippets+FlattenedMessages.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes+TextFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes+TextFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_Hashes.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_RegionSnippets.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_RegionSnippets.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_TextFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/CoreTests-Relative_TextFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/TopLevelOriginalUriBaseIdUriMissing_ContextRegionSnippets.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/ExpectedOutputs/TopLevelOriginalUriBaseIdUriMissing_ContextRegionSnippets.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/CoreTests-Absolute.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/CoreTests-Absolute.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/CoreTests-Relative.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/CoreTests-Relative.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/TopLevelOriginalUriBaseIdUriMissing.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/InsertOptionalDataVisitor/Inputs/TopLevelOriginalUriBaseIdUriMissing.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ArtifactsWithRoles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ArtifactsWithRoles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveFileProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveFileProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.01-24.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.01-24.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ComprehensiveToolProperties.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ExercisesSchemaRtm5Changes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ExercisesSchemaRtm5Changes.sarif
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "fullName": "CodeScanner 1.1 for Unix (en-US)",
+          "rules": [
+            {
+              "id": "C2001",
+              "shortDescription": {
+                "text": "A variable was used without being initialized."
+              },
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Variable \"one\" was used without being initialized."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///home/buildAgent/src/collections/list.h"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              }
+            }
+          ],
+          "suppressions": [
+            {
+              "kind": "external",
+              "status": "accepted"
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/LocationWithId.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/LocationWithId.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/MultiformatMessageStrings.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/MultiformatMessageStrings.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithBasicInvocation.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithBasicInvocation.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithInvocationExitCode.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithInvocationExitCode.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithRedactionToken.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/OneRunWithRedactionToken.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RuleIdCollisions.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RuleIdCollisions.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RunResources.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/RunResources.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ThreadFlowLocationWithKind.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ThreadFlowLocationWithKind.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ToolWithLanguage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/ToolWithLanguage.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/V1.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/V1.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithExternalPropertyFiles.01-24.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithExternalPropertyFiles.01-24.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithSuppressions.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/ExpectedOutputs/WithSuppressions.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/Inputs/ExercisesSchemaRtm5Changes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/Inputs/ExercisesSchemaRtm5Changes.sarif
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "fullName": "CodeScanner 1.1 for Unix (en-US)",
+          "rules": [
+            {
+              "id": "C2001",
+              "shortDescription": {
+                "text": "A variable was used without being initialized."
+              },
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Variable \"one\" was used without being initialized."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///home/buildAgent/src/collections/list.h"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              }
+            }
+          ],
+          "suppressions": [		  
+            {
+              "kind": "external",
+              "state": "accepted"
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/Inputs/RegressionTests.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/PrereleaseCompatibilityTransformer/Inputs/RegressionTests.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/OneRunWithAutomationDetails.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/OneRunWithAutomationDetails.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithOnePartialFingerprint.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithOnePartialFingerprint.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithTwoPartialFingerprints.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifCurrentToVersionOneVisitor/Inputs/ResultWithTwoPartialFingerprints.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifLogger/SimpleExample.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifLogger/SimpleExample.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/BasicResult.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/CodeFlows.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/CodeFlows.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/Minimum.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/Minimum.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithLanguage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithLanguage.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithPropertiesAndTags.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithPropertiesAndTags.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithTwoRuns.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/MinimumWithTwoRuns.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NestedInnerExceptionsInNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NonDottedQuadFileVersion.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NonDottedQuadFileVersion.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NotificationExceptionWithStack.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/NotificationExceptionWithStack.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithAllReportingDescriptors.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithAllReportingDescriptors.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithBasicInvocation.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithBasicInvocation.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithFiles.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithFiles.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithInvocationAndNotifications.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithInvocationAndNotifications.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithLogicalLocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithLogicalLocations.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithNotificationsButNoInvocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithNotificationsButNoInvocations.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithRules.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/OneRunWithRules.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/RestoreFromPropertyBag.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/RestoreFromPropertyBag.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/ResultLocationsAsEmptyArray.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/ResultLocationsAsEmptyArray.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/TwoResultsWithFixes.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/TwoResultsWithFixes.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/UriBaseId.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/SarifVersionOneToCurrentVisitor/ExpectedOutputs/UriBaseId.sarif
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
   "version": "2.1.0",
   "runs": [
     {

--- a/src/Test.UnitTests.Sarif/Writers/PrereleaseCompatibilityTransformerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/PrereleaseCompatibilityTransformerTests.cs
@@ -161,5 +161,13 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             // is in place.
             RunTest("V1.sarif");
         }
+
+        [Fact]
+        [Trait(TestTraits.Bug, "https://github.com/oasis-tcs/sarif-spec/issues/449")]
+        [Trait(TestTraits.Bug, "https://github.com/microsoft/sarif-sdk/issues/1785")]
+        public void PrereleaseCompatibilityTransformer_TransformsRtm4Correctly()
+        {
+            RunTest("ExercisesSchemaRtm5Changes.sarif");
+        }
     }
 }

--- a/src/build.props
+++ b/src/build.props
@@ -24,11 +24,11 @@
       NOTE: Version in scripts/BuildMultitoolForNpm.ps1 also has to be updated for each release
       until it adopts the same versions as the SDK itself.
     -->
-    <VersionPrefix>2.1.25</VersionPrefix>
-    <PreviousVersionPrefix>2.1.24</PreviousVersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
+    <PreviousVersionPrefix>2.1.25</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
-    <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.4</SchemaVersionAsPublishedToSchemaStoreOrg>
+    <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>
       
     <!-- The stable Version of SARIF Specifications. -->
     <StableSarifVersion>2.1.0</StableSarifVersion>


### PR DESCRIPTION
Resolves #1785. Rename `suppression.state` to `suppression.status`. Additional unit test 'ExercisesRtm5Changes.sarif' in prerelease transformer tests covers the new case. [FYI code flow isn't showing all changed files on my machine, including this one.]

@lgolding 
@nickmarston @chinarosesz FYI in case you'd like to see what it looks like to make a schema change (though honestly this could very well be the last one for 2.1)