### PR TITLE
Fix #1791: ESLint formatter returns invalid SARIF in some cases

### DIFF
--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -61,11 +61,16 @@ module.exports = function (results, data) {
     const sarifResults = [];
     const embedFileContents = process.env.SARIF_ESLINT_EMBED === "true";
 
-    // Emit a tool execution notification with this id if ESLint emits a message with
+    // Emit a tool configuration notification with this id if ESLint emits a message with
     // no ruleId (which indicates an internal error in ESLint).
-    const internalErrorId = "ESL9999"
+    //
+    // It is not clear whether we should treat these messages tool configuration notifications,
+    // tool execution notifications, or a mixture of the two, based on the properties of the
+    // message. https://github.com/microsoft/sarif-sdk/issues/1798, "ESLint formatter can't
+    // distinguish between an internal error and a misconfiguration", tracks this issue.
+    const internalErrorId = "ESL0999"
 
-    const toolExecutionNotifications = [];
+    const toolConfigurationNotifications = [];
     let executionSuccessful = true;
 
     results.forEach(result => {
@@ -192,7 +197,7 @@ module.exports = function (results, data) {
                     if (message.ruleId) {
                         sarifResults.push(sarifRepresentation);
                     } else {
-                        toolExecutionNotifications.push(sarifRepresentation)
+                        toolConfigurationNotifications.push(sarifRepresentation)
                     }
                 });
             }
@@ -211,10 +216,10 @@ module.exports = function (results, data) {
     // This provides a positive indication that the run completed and no results were found.
     sarifLog.runs[0].results = sarifResults;
 
-    if (toolExecutionNotifications.length > 0) {
+    if (toolConfigurationNotifications.length > 0) {
         sarifLog.runs[0].invocations = [
             {
-                toolExecutionNotifications: toolExecutionNotifications,
+                toolConfigurationNotifications: toolConfigurationNotifications,
                 executionSuccessful: executionSuccessful
             }
         ]

--- a/src/ESLint.Formatter/test/sarif.js
+++ b/src/ESLint.Formatter/test/sarif.js
@@ -460,9 +460,9 @@ describe("formatter:sarif", () => {
             let invocation = run.invocations[0]
             assert.isFalse(invocation.executionSuccessful)
 
-            assert.lengthOf(invocation.toolExecutionNotifications, 1)
-            let notification = invocation.toolExecutionNotifications[0]
-            assert.strictEqual(notification.descriptor.id, "ESL9999");
+            assert.lengthOf(invocation.toolConfigurationNotifications, 1)
+            let notification = invocation.toolConfigurationNotifications[0]
+            assert.strictEqual(notification.descriptor.id, "ESL0999");
             assert.strictEqual(notification.level, "error");
             assert.strictEqual(notification.message.text, "Internal error.");
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,6 +6,7 @@
 * FEATURE: Multitool `insert` option now supports `Guids` value to populate `Result.Guid`.
 * API + SCHEMA BREAKING: Fix typo in schema: suppression.state should be suppression.status according to the spec. [#1785](https://github.com/microsoft/sarif-sdk/issues/1785)
 * BUGFIX: Multitool `rewrite` no longer throws when it encounters an invalid value (such as -1) for a region property.
+* BUGFIX: ESLint SARIF formatter no longer produces invalid SARIF when given an ESLint message with no rule id. It is treated as a `toolConfigurationNotification`. [#1791](https://github.com/microsoft/sarif-sdk/issues/1791)
 
 ## **v2.1.25** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.1.25) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.1.25) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.1.25) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.1.25)
 * FEATURE: The baseliner (available through the Multitool's `match-results-forward` command) now populates `result.provenance.firstDetectionTimeUtc` so you can now track the age of each issue. [#1737](https://github.com/microsoft/sarif-sdk/issues/1737)


### PR DESCRIPTION
At times, ESLint emits a message with no `ruleId`, indicating an internal error in ESLint. Represent this in SARIF as a `toolExecutionNotification` with `level: "error"`, rather than as a `result` with no `ruleId`, which is invalid.

This affects some unit tests, which now must always provide a `ruleId`.

Also:
- Per the spec, emit `run.results` even if the array is empty, as a positive indicator that the tool found no results. This affects the unit test which previously expected `run.results` to be `undefined` in this case.