### PR TITLE
Adding ExtractAllLocationUri's visitor

### DIFF
--- a/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
+++ b/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT        
+// license. See LICENSE file in the project root for full license information. 
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif.Visitors
+{
+
+    public class ExtractAllArtifactLocationsVisitor : SarifRewritingVisitor
+    {
+        private Run _currentRun;
+        public HashSet<ArtifactLocation> allArtifactLocations { get; private set; }
+
+        public ExtractAllArtifactLocationsVisitor()
+        {
+            allArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
+        }
+
+        public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
+        {
+            if (node.Uri == null)
+            {
+                return node;
+            }
+            allArtifactLocations.Add(node.Resolve(_currentRun));
+            return node;
+        }
+
+        public override Run VisitRun(Run node)
+        {
+            _currentRun = base.VisitRun(node);
+            return node;
+        }
+    }
+}

--- a/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
+++ b/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
@@ -11,12 +11,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     /// This will extract every location present in the log file, which may then need to be filtered by a
     /// downstream consumer.
     /// 
-    /// May optionally be based a run at contsruction, which allows the visitor to later visit only specific parts of
-    /// the sarif log where location data aggregation is desired.
+    /// User may optionally set a specific run before invoking, in order to only fetch artifact locations
+    /// from a subset on an entire SARIF file.
     /// </summary>
     public class ExtractAllArtifactLocationsVisitor : SarifRewritingVisitor
     {
-        private Run _currentRun;
+        private Run CurrentRun { get; set; }
         public HashSet<ArtifactLocation> AllArtifactLocations { get; private set; }
 
         public ExtractAllArtifactLocationsVisitor()
@@ -24,25 +24,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             AllArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
         }
 
-        public ExtractAllArtifactLocationsVisitor(Run node)
-        {
-            AllArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
-            _currentRun = node;
-        }
-
         public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
         {
-            if (node.Uri == null)
-            {
-                return node;
-            }
-            AllArtifactLocations.Add(node.Resolve(_currentRun));
+            AllArtifactLocations.Add(node.Resolve(CurrentRun));
             return node;
         }
 
         public override Run VisitRun(Run node)
         {
-            _currentRun = base.VisitRun(node);
+            CurrentRun = node;
+            CurrentRun = base.VisitRun(node);
             return node;
         }
     }

--- a/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
+++ b/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
@@ -10,6 +10,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     /// A visitor that examines a specified SARIF log to extract all artifact locations for later processing.
     /// This will extract every location present in the log file, which may then need to be filtered by a
     /// downstream consumer.
+    /// 
+    /// May optionally be based a run at contsruction, which allows the visitor to later visit only specific parts of
+    /// the sarif log where location data aggregation is desired.
     /// </summary>
     public class ExtractAllArtifactLocationsVisitor : SarifRewritingVisitor
     {
@@ -19,6 +22,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         public ExtractAllArtifactLocationsVisitor()
         {
             AllArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
+        }
+
+        public ExtractAllArtifactLocationsVisitor(Run node)
+        {
+            AllArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
+            _currentRun = node;
         }
 
         public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)

--- a/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
+++ b/src/Sarif/Visitors/ExtractAllArtifactLocationsVisitor.cs
@@ -6,15 +6,19 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Sarif.Visitors
 {
-
+    /// <summary>
+    /// A visitor that examines a specified SARIF log to extract all artifact locations for later processing.
+    /// This will extract every location present in the log file, which may then need to be filtered by a
+    /// downstream consumer.
+    /// </summary>
     public class ExtractAllArtifactLocationsVisitor : SarifRewritingVisitor
     {
         private Run _currentRun;
-        public HashSet<ArtifactLocation> allArtifactLocations { get; private set; }
+        public HashSet<ArtifactLocation> AllArtifactLocations { get; private set; }
 
         public ExtractAllArtifactLocationsVisitor()
         {
-            allArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
+            AllArtifactLocations = new HashSet<ArtifactLocation>(ArtifactLocation.ValueComparer);
         }
 
         public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
@@ -23,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 return node;
             }
-            allArtifactLocations.Add(node.Resolve(_currentRun));
+            AllArtifactLocations.Add(node.Resolve(_currentRun));
             return node;
         }
 

--- a/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitSarifLog(sarifLog);
+            visitor.AllArtifactLocations.Count.Should().Be(3);
 
             foreach (Result result in sarifLog.Runs[0].Results)
             {
@@ -155,10 +156,70 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitSarifLog(sarifLog);
+            visitor.AllArtifactLocations.Count.Should().Be(3);
 
-            foreach (Location location in sarifLog.Runs[0].Results[0].Locations)
+            foreach (Result result in sarifLog.Runs[0].Results)
             {
-                visitor.AllArtifactLocations.Contains(location.PhysicalLocation.ArtifactLocation).Should().BeTrue();
+                visitor.AllArtifactLocations.Contains(result.Locations[0].PhysicalLocation.ArtifactLocation).Should().BeTrue();
+            }
+        }
+
+             [Fact]
+        public void ExtractAllArtifactLocationsVisitor_FetchesIndexedLocations()
+        {
+            var sarifLog = new SarifLog
+            {
+                Runs = new[]
+                {
+                    new Run
+                    {
+                        Artifacts = new List<Artifact>
+                        {
+                            new Artifact{ Location = new ArtifactLocation{  Uri = new Uri(TestConstants.FileLocations.Location1), }, Contents = new ArtifactContent { Text = "New" } },
+                            new Artifact{ Location = new ArtifactLocation{  Uri = new Uri(TestConstants.FileLocations.Location2), }, Contents = new ArtifactContent { Text = "Child of new" } },
+                        },
+                        Results = new[]
+                        {
+                            new Result
+                            {
+                                RuleId = TestConstants.RuleIds.Rule1,
+                                BaselineState = BaselineState.New,
+                                Locations = new []
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Index = 0,
+                                             }
+                                        }
+                                    },
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Index = 1,
+                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var visitor = new ExtractAllArtifactLocationsVisitor();
+            visitor.VisitSarifLog(sarifLog);
+            visitor.AllArtifactLocations.Count.Should().Be(2);
+
+            foreach (Artifact artifact in sarifLog.Runs[0].Artifacts)
+            {
+                visitor.AllArtifactLocations.Contains(artifact.Location).Should().BeTrue();
             }
         }
     }

--- a/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     public class ExtractAllArtifactLocationsVisitorTests
     {
         [Fact]
-        public void PerRunPerRuleSplittingVisitor_EmptyLog()
+        public void ExtractAllArtifactLocationsVisitor_EmptyLog()
         {
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitRun(new Run());
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         }
 
         [Fact]
-        public void PerRunPerRuleSplittingVisitor_ExtractsMultipleLocations()
+        public void ExtractAllArtifactLocationsVisitor_ExtractsMultipleLocations()
         {
             var sarifLog = new SarifLog
             {
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         }
 
         [Fact]
-        public void PerRunPerRuleSplittingVisitor_ExtractsMultipleLocationsSingleResult()
+        public void ExtractAllArtifactLocationsVisitor_ExtractsMultipleLocationsSingleResult()
         {
             var sarifLog = new SarifLog
             {

--- a/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.CodeAnalysis.Test.Utilities.Sarif;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.Visitors
+{
+    public class ExtractAllArtifactLocationsVisitorTests
+    {
+        [Fact]
+        public void PerRunPerRuleSplittingVisitor_EmptyLog()
+        {
+            var visitor = new ExtractAllArtifactLocationsVisitor();
+            visitor.VisitRun(new Run());
+            visitor.allArtifactLocations.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void PerRunPerRuleSplittingVisitor_ExtractsMultipleLocations()
+        {
+            var sarifLog = new SarifLog
+            {
+                Runs = new[]
+                {
+                    new Run
+                    {
+                        Results = new[]
+                        {
+                            new Result
+                            {
+                                RuleId = TestConstants.RuleIds.Rule1,
+                                BaselineState = BaselineState.New,
+                                Locations = new []
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location1),
+                                             }
+                                        }
+                                    }
+                                }
+                            },
+
+                            new Result
+                            {
+                                RuleId = TestConstants.RuleIds.Rule2,
+                                BaselineState = BaselineState.Updated,
+                                Locations = new []
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location2),
+                                             }
+                                        }
+                                    }
+                                }
+                            },
+
+                            new Result
+                            {
+                                RuleId = TestConstants.RuleIds.Rule2,
+                                BaselineState = BaselineState.New,
+                                Locations = new []
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location3),
+                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var visitor = new ExtractAllArtifactLocationsVisitor();
+            visitor.VisitSarifLog(sarifLog);
+
+            foreach (Result result in sarifLog.Runs[0].Results)
+            {
+                visitor.allArtifactLocations.Contains(result.Locations[0].PhysicalLocation.ArtifactLocation).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void PerRunPerRuleSplittingVisitor_ExtractsMultipleLocationsSingleResult()
+        {
+            var sarifLog = new SarifLog
+            {
+                Runs = new[]
+                {
+                    new Run
+                    {
+                        Results = new[]
+                        {
+                            new Result
+                            {
+                                RuleId = TestConstants.RuleIds.Rule1,
+                                BaselineState = BaselineState.New,
+                                Locations = new []
+                                {
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location1),
+                                             }
+                                        }
+                                    },
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location2),
+                                             }
+                                        }
+                                    },
+                                    new Location
+                                    {
+                                        PhysicalLocation = new PhysicalLocation
+                                        {
+                                             ArtifactLocation = new ArtifactLocation
+                                             {
+                                                Uri = new Uri(TestConstants.FileLocations.Location3),
+                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var visitor = new ExtractAllArtifactLocationsVisitor();
+            visitor.VisitSarifLog(sarifLog);
+
+            foreach (Location location in sarifLog.Runs[0].Results[0].Locations)
+            {
+                visitor.allArtifactLocations.Contains(location.PhysicalLocation.ArtifactLocation).Should().BeTrue();
+            }
+        }
+    }
+}

--- a/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/ExtractAllArtifactionLocationsVisitorTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         {
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitRun(new Run());
-            visitor.allArtifactLocations.Count.Should().Be(0);
+            visitor.AllArtifactLocations.Count.Should().Be(0);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             foreach (Result result in sarifLog.Runs[0].Results)
             {
-                visitor.allArtifactLocations.Contains(result.Locations[0].PhysicalLocation.ArtifactLocation).Should().BeTrue();
+                visitor.AllArtifactLocations.Contains(result.Locations[0].PhysicalLocation.ArtifactLocation).Should().BeTrue();
             }
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             foreach (Location location in sarifLog.Runs[0].Results[0].Locations)
             {
-                visitor.allArtifactLocations.Contains(location.PhysicalLocation.ArtifactLocation).Should().BeTrue();
+                visitor.AllArtifactLocations.Contains(location.PhysicalLocation.ArtifactLocation).Should().BeTrue();
             }
         }
     }

--- a/src/Test.Utilities.Sarif/TestConstants.cs
+++ b/src/Test.Utilities.Sarif/TestConstants.cs
@@ -28,6 +28,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.Sarif
             public const string Rule10 = "TST0010";
         }
 
+        public static class FileLocations
+        {
+            public const string Location1 = "C:\\Test\\Data\\File1.sarif";
+            public const string Location2 = "C:\\Test\\Data\\File2.sarif";
+            public const string Location3 = "C:\\Test\\Data\\File3.sarif";
+            public const string Location4 = "C:\\Test\\Data\\File4.sarif";
+        }
+
         public static class TaxonIds
         {
             public const string Taxon1 = "TAX0001";

--- a/src/Test.Utilities.Sarif/TestConstants.cs
+++ b/src/Test.Utilities.Sarif/TestConstants.cs
@@ -30,10 +30,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.Sarif
 
         public static class FileLocations
         {
-            public const string Location1 = "C:\\Test\\Data\\File1.sarif";
-            public const string Location2 = "C:\\Test\\Data\\File2.sarif";
-            public const string Location3 = "C:\\Test\\Data\\File3.sarif";
-            public const string Location4 = "C:\\Test\\Data\\File4.sarif";
+            public const string Location1 = @"C:\Test\Data\File1.sarif";
+            public const string Location2 = @"C:\Test\Data\File2.sarif";
+            public const string Location3 = @"C:\Test\Data\File3.sarif";
+            public const string Location4 = @"C:\Test\Data\File4.sarif";
         }
 
         public static class TaxonIds


### PR DESCRIPTION
Adds a visitor to create a HashSet of every ArtifactLocation that is present in a SARIF file and resolves those URIs to their index location.

This will be needed for bug filing, where the URIs in a SARIF location will be used as the key to indexing services.  I will next be looking at the best place to transform this artifact location list into a list of unique URIs, normalized, which I can then pass to the needed service.