### PR TITLE
Prevent crashing on null and empty URIs

### DIFF
--- a/src/Sarif/Readers/UriConverter.cs
+++ b/src/Sarif/Readers/UriConverter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
             }
 
             var uri = value as Uri;
-            if (uri != null)
+            if (uri != null && !string.IsNullOrWhiteSpace(uri.OriginalString))
             {
                 string path = uri.OriginalString;
                 string validUri = UriHelper.MakeValidUri(path);


### PR DESCRIPTION
The URI object itself can be non-null, but the string contained within it can still be null, or simply whitespace. If it is, the converter currently crashes instead of skipping the URI.

All of the unit-tests have passed, there is work in progress to port it to the sarif-viewer extension