### PR TITLE
Move to .NET Core 3.0 build

### DIFF
--- a/BuildPackagesFromLayoutDirectory.cmd
+++ b/BuildPackagesFromLayoutDirectory.cmd
@@ -41,7 +41,7 @@ goto :Exit
 xcopy /Y %LayoutForSigningDirectory%\net452\%1 %BinaryOutputDirectory%\net452\
 
 :: For .NET core, .exes are renamed to .dlls due to packaging conventions
-xcopy /Y %LayoutForSigningDirectory%\netcoreapp2.1\%~n1.dll %BinaryOutputDirectory%\netcoreapp2.1\
+xcopy /Y %LayoutForSigningDirectory%\netcoreapp3.0\%~n1.dll %BinaryOutputDirectory%\netcoreapp3.0\
 xcopy /Y %LayoutForSigningDirectory%\netstandard2.1\%~n1.dll %BinaryOutputDirectory%\netstandard2.1\
 
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed.)

--- a/BuildPackagesFromLayoutDirectory.cmd
+++ b/BuildPackagesFromLayoutDirectory.cmd
@@ -41,7 +41,7 @@ goto :Exit
 xcopy /Y %LayoutForSigningDirectory%\net452\%1 %BinaryOutputDirectory%\net452\
 
 :: For .NET core, .exes are renamed to .dlls due to packaging conventions
-xcopy /Y %LayoutForSigningDirectory%\netcoreapp3.0\%~n1.dll %BinaryOutputDirectory%\netcoreapp3.0\
+xcopy /Y %LayoutForSigningDirectory%\netcoreapp3.1\%~n1.dll %BinaryOutputDirectory%\netcoreapp3.1\
 xcopy /Y %LayoutForSigningDirectory%\netstandard2.1\%~n1.dll %BinaryOutputDirectory%\netstandard2.1\
 
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed.)

--- a/RunTests.cmd
+++ b/RunTests.cmd
@@ -25,15 +25,15 @@ echo Unrecognized option "%1" && goto :ExitFailed
 
 call SetBuildEnvVars.cmd
 
-set Frameworks=netcoreapp2.1 net461
+set Frameworks=netcoreapp3.0 net461
 set TestRunnerRootPath=%ThisFileDirectory%src\packages\xunit.runner.console\2.3.1\tools\
 
 for %%p in (%NewTestProjects%) do (
     for %%f in (%Frameworks%) do (
         echo Running tests for %%p: %%f
         pushd %ThisFileDirectory%bld\bin\%%p\AnyCPU_%Configuration%\%%f
-        if "%%f" EQU "netcoreapp2.1" (
-            dotnet %TestRunnerRootPath%netcoreapp2.1\xunit.console.dll %%p.dll %ReporterOption%
+        if "%%f" EQU "netcoreapp3.0" (
+            dotnet %TestRunnerRootPath%netcoreapp3.0\xunit.console.dll %%p.dll %ReporterOption%
         ) else (
             %TestRunnerRootPath%net452\xunit.console.exe %%p.dll %ReporterOption%
         )

--- a/RunTests.cmd
+++ b/RunTests.cmd
@@ -25,15 +25,15 @@ echo Unrecognized option "%1" && goto :ExitFailed
 
 call SetBuildEnvVars.cmd
 
-set Frameworks=netcoreapp3.0 net461
+set Frameworks=netcoreapp3.1 net461
 set TestRunnerRootPath=%ThisFileDirectory%src\packages\xunit.runner.console\2.3.1\tools\
 
 for %%p in (%NewTestProjects%) do (
     for %%f in (%Frameworks%) do (
         echo Running tests for %%p: %%f
         pushd %ThisFileDirectory%bld\bin\%%p\AnyCPU_%Configuration%\%%f
-        if "%%f" EQU "netcoreapp3.0" (
-            dotnet %TestRunnerRootPath%netcoreapp3.0\xunit.console.dll %%p.dll %ReporterOption%
+        if "%%f" EQU "netcoreapp3.1" (
+            dotnet %TestRunnerRootPath%netcoreapp3.1\xunit.console.dll %%p.dll %ReporterOption%
         ) else (
             %TestRunnerRootPath%net452\xunit.console.exe %%p.dll %ReporterOption%
         )

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -38,15 +38,15 @@ $npmBuildFolder = "$BuildRoot\Publish\npm"
 if (-not $SkipBuild) {
     Write-Information "Building Sarif.Multitool for Windows, Linux, and MacOS..."
     foreach ($runtime in "win-x64", "linux-x64", "osx-x64") {
-        dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.0 -r $runtime
+        dotnet publish $SourceRoot\$project\$project.csproj -c $Configuration -f netcoreapp3.1 -r $runtime
     }
 
     Write-Information "Merging binaries [$projectBinDirectory] and NPM configuration [$npmSourceFolder]..."
     New-DirectorySafely $npmBuildFolder\
     Copy-Item -Force -Container -Recurse -Path $npmSourceFolder\* -Destination $npmBuildFolder\
-    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32\
-    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux\
-    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.0\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin\
+    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.1\win-x64\* -Destination $npmBuildFolder\sarif-multitool-win32\
+    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.1\linux-x64\* -Destination $npmBuildFolder\sarif-multitool-linux\
+    Copy-Item -Force -Container -Recurse -Path $projectBinDirectory\Publish\netcoreapp3.1\osx-x64\* -Destination $npmBuildFolder\sarif-multitool-darwin\
 }
 
 # Match SARIF SDK version (from 2.2.1 forward).
@@ -67,10 +67,10 @@ foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {
 
 # After merging outputs, delete the other 250MB copies of the Multitool single file exes (saving only the bld\Publish\npm copy)
 if (-not $NoPostClean) {
-    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\win-x64
-    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\linux-x64
-    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\osx-x64
-    Remove-DirectorySafely $projectBinDirectory\Publish\netcoreapp3.0
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.1\win-x64
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.1\linux-x64
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.1\osx-x64
+    Remove-DirectorySafely $projectBinDirectory\Publish\netcoreapp3.1
 }
 
 Write-Information "$ScriptName SUCCEEDED."

--- a/scripts/BuildMultitoolForNpm.ps1
+++ b/scripts/BuildMultitoolForNpm.ps1
@@ -67,7 +67,9 @@ foreach ($package in (Get-ChildItem $npmBuildFolder).FullName) {
 
 # After merging outputs, delete the other 250MB copies of the Multitool single file exes (saving only the bld\Publish\npm copy)
 if (-not $NoPostClean) {
-    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\win-x64
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\linux-x64
+    Remove-DirectorySafely $projectBinDirectory\netcoreapp3.0\osx-x64
     Remove-DirectorySafely $projectBinDirectory\Publish\netcoreapp3.0
 }
 

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -16,7 +16,7 @@ $Frameworks.NetFx = @("net461")
 $Frameworks.Library = @("netstandard2.1") + $Frameworks.NetFx
 
 # Frameworks for which we build applications.
-$Frameworks.Application = @("netcoreapp3.0") + $Frameworks.NetFx
+$Frameworks.Application = @("netcoreapp3.1") + $Frameworks.NetFx
 
 $Frameworks.All = ($Frameworks.Library + $Frameworks.Application | Select -Unique)
 

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -16,7 +16,7 @@ $Frameworks.NetFx = @("net461")
 $Frameworks.Library = @("netstandard2.1") + $Frameworks.NetFx
 
 # Frameworks for which we build applications.
-$Frameworks.Application = @("netcoreapp2.1") + $Frameworks.NetFx
+$Frameworks.Application = @("netcoreapp3.0") + $Frameworks.NetFx
 
 $Frameworks.All = ($Frameworks.Library + $Frameworks.Application | Select -Unique)
 

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -38,7 +38,7 @@ $failedTestProjects = @()
 foreach ($project in $Projects.Tests) {
     foreach ($framework in $Frameworks.Application) {
 
-        if ((-not $AppVeyor) -and ($framework -ne "netcoreapp2.1")) { continue; }
+        if ((-not $AppVeyor) -and ($framework -ne "netcoreapp3.0")) { continue; }
 
         Write-Information "Running tests in ${project}: $framework..."
         Push-Location $SourceRoot\$project

--- a/scripts/Run-Tests.ps1
+++ b/scripts/Run-Tests.ps1
@@ -38,7 +38,7 @@ $failedTestProjects = @()
 foreach ($project in $Projects.Tests) {
     foreach ($framework in $Frameworks.Application) {
 
-        if ((-not $AppVeyor) -and ($framework -ne "netcoreapp3.0")) { continue; }
+        if ((-not $AppVeyor) -and ($framework -ne "netcoreapp3.1")) { continue; }
 
         Write-Information "Running tests in ${project}: $framework..."
         Push-Location $SourceRoot\$project

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -20,7 +20,7 @@
   </metadata>
   <files>
     <!-- The subfolder layout for the different TargetFrameworks is intentionally inconsistent -->
-    <!-- net461 and netcoreapp2.1 pack to tools\TargetFramework\* for backcompat -->
+    <!-- net461 and netcoreapp3.0 pack to tools\TargetFramework\* for backcompat -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net461\Sarif.Multitool.exe.config"
           target="tools\net461"
           />
@@ -32,27 +32,27 @@
           target="tools\net461"
           />
 
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\**"
-          target="tools\netcoreapp2.1"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\Sarif*.dll"
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\**"
+          target="tools\netcoreapp3.0"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\Sarif*.dll"
           />
-    <file src="bld\bin\Signing\netcoreapp2.1\**"
-          target="tools\netcoreapp2.1"
+    <file src="bld\bin\Signing\netcoreapp3.0\**"
+          target="tools\netcoreapp3.0"
           />
     <file src="bld\bin\Signing\netstandard2.1\**"
-          target="tools\netcoreapp2.1"
+          target="tools\netcoreapp3.0"
           />
 
-    <!-- netcoreapp2.1 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\**"
-          target="tools\netcoreapp2.1\any"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\Sarif*.dll"
+    <!-- netcoreapp3.0 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\**"
+          target="tools\netcoreapp3.0\any"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\Sarif*.dll"
           />
-    <file src="bld\bin\Signing\netcoreapp2.1\**"
-          target="tools\netcoreapp2.1\any"
+    <file src="bld\bin\Signing\netcoreapp3.0\**"
+          target="tools\netcoreapp3.0\any"
           />
     <file src="bld\bin\Signing\netstandard2.1**"
-          target="tools\netcoreapp2.1\any"
+          target="tools\netcoreapp3.0\any"
           />
 
     <file src="src\ReleaseHistory.md" />        

--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -20,7 +20,7 @@
   </metadata>
   <files>
     <!-- The subfolder layout for the different TargetFrameworks is intentionally inconsistent -->
-    <!-- net461 and netcoreapp3.0 pack to tools\TargetFramework\* for backcompat -->
+    <!-- net461 and netcoreapp3.1 pack to tools\TargetFramework\* for backcompat -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\net461\Sarif.Multitool.exe.config"
           target="tools\net461"
           />
@@ -32,27 +32,27 @@
           target="tools\net461"
           />
 
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\**"
-          target="tools\netcoreapp3.0"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\Sarif*.dll"
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.1\**"
+          target="tools\netcoreapp3.1"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.1\Sarif*.dll"
           />
-    <file src="bld\bin\Signing\netcoreapp3.0\**"
-          target="tools\netcoreapp3.0"
+    <file src="bld\bin\Signing\netcoreapp3.1\**"
+          target="tools\netcoreapp3.1"
           />
     <file src="bld\bin\Signing\netstandard2.1\**"
-          target="tools\netcoreapp3.0"
+          target="tools\netcoreapp3.1"
           />
 
-    <!-- netcoreapp3.0 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
-    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\**"
-          target="tools\netcoreapp3.0\any"
-          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.0\Sarif*.dll"
+    <!-- netcoreapp3.1 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
+    <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.1\**"
+          target="tools\netcoreapp3.1\any"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp3.1\Sarif*.dll"
           />
-    <file src="bld\bin\Signing\netcoreapp3.0\**"
-          target="tools\netcoreapp3.0\any"
+    <file src="bld\bin\Signing\netcoreapp3.1\**"
+          target="tools\netcoreapp3.1\any"
           />
     <file src="bld\bin\Signing\netstandard2.1**"
-          target="tools\netcoreapp3.0\any"
+          target="tools\netcoreapp3.1\any"
           />
 
     <file src="src\ReleaseHistory.md" />        

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -4,23 +4,23 @@
     <OutputType>Exe</OutputType>
 
     <!-- To Publish single-file exes, run: 
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r win-x64
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r linux-x64
-      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.0 -r osx-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.1 -r win-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.1 -r linux-x64
+      dotnet publish Sarif.Multitool.csproj -c Release -f netcoreapp3.1 -r osx-x64
 
       We use [Condition="'$(RuntimeIdentifier)' != ''"] to identify settings used only for these builds.      
     -->
 
     <!-- Publish trimmed single-file exe -->
-    <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
-    <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
 
-    <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
+    <!-- Publish trimmed in per-platform builds, and 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
+    <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 
   <!-- PackAsTool is supported/recommended for .NET Core -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -11,11 +11,11 @@
       We use [Condition="'$(RuntimeIdentifier)' != ''"] to identify settings used only for these builds.      
     -->
 
-    <!-- Publish trimmed single-file exe -->
-    <PublishSingleFile>true</PublishSingleFile>
-
-    <!-- Publish trimmed in per-platform builds, and 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
+    <!-- Publish trimmed single-file exe in platform-specific builds (not supported in agnostic builds) -->
+    <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
     <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
+
+    <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -19,8 +19,8 @@
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 
-  <!-- PackAsTool is supported/recommended for .NET Core >= 2.1 -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <!-- PackAsTool is supported/recommended for .NET Core -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 

--- a/src/Test.Plugins/Test.Plugins.csproj
+++ b/src/Test.Plugins/Test.Plugins.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Test.Plugins/Test.Plugins.csproj
+++ b/src/Test.Plugins/Test.Plugins.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/build.props
+++ b/src/build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/build.props
+++ b/src/build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Per Mike, this change updates SARIF framework targets to netcoreapp3.0;net461. This is needed to unblock our NPM build, which must be .NET Core 3.0 and used a trick to not disturb the normal project files which no longer works.

Targetting .NET Core 3.0 also improves our build and release time, as the same target will be in our NuGet packages and our NPM release.