### PR TITLE
Loosen timing restrictions on regions caching test.

### DIFF
--- a/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
+++ b/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
 
             // Runtime should be way under 100ms if caching, and much longer otherwise
             w.Stop();
-            Assert.True(w.ElapsedMilliseconds < 100);
+            Assert.True(w.ElapsedMilliseconds < 150, $"Time observed was {w.ElapsedMilliseconds}. Expected < 150 ms.");
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
+++ b/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
@@ -478,9 +478,11 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
                 Region populated = fileRegionsCache.PopulateTextRegionProperties(copy, uri, populateSnippet: true);
             }
 
+            int timeThreshold = 150;
+
             // Runtime should be way under 100ms if caching, and much longer otherwise
             w.Stop();
-            Assert.True(w.ElapsedMilliseconds < 150, $"Time observed was {w.ElapsedMilliseconds}. Expected < 150 ms.");
+            Assert.True(w.ElapsedMilliseconds < timeThreshold, $"Time observed was {w.ElapsedMilliseconds}. Expected < {timeThreshold} ms.");
         }
 
         [Fact]

--- a/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
+++ b/src/Test.UnitTests.Sarif/FileRegionsCacheTests.cs
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis.Sarif.UnitTests
                 Region populated = fileRegionsCache.PopulateTextRegionProperties(copy, uri, populateSnippet: true);
             }
 
-            int timeThreshold = 150;
+            int const timeThreshold = 150;
 
             // Runtime should be way under 100ms if caching, and much longer otherwise
             w.Stop();


### PR DESCRIPTION
@ScottLouvau.  This is failing non-deterministically in some agent environments. I've loosened the timing window and we now emit the actual timing observed in log file.

@lgolding @rtaket @nickmarston @cfaucon 

Could use a review on this. The test that's modified is causing random pipeline failures, so good to resolve asap.