### PR TITLE
BaselineE2E improvements

### DIFF
--- a/src/Test.EndToEnd.Baselining/BaseliningDetailEnricher.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningDetailEnricher.cs
@@ -94,12 +94,12 @@ namespace Test.EndToEnd.Baselining
         // (There are too many to include all of them all the time)
         private string DetailsHeading()
         {
-            return $"{PadTo(17, "RID")} | RuleID    | {PadTo(40, "Uri+Region")} | Hash     | Snippet";
+            return $"{PadTo(17, "RID")} | RuleID    | {PadTo(70, "Uri+Region")} | {PadTo(8, "Hash")} | {PadTo(60, "Snippet")}";
         }
 
         private string Details(Result result)
         {
-            return $" | {result.ResolvedRuleId(result.Run)} | {PadTo(40, result.FirstLocation())} | {result.PartialFingerprint("SecretHash/v1", 8)} | {result.Snippet(16)}";
+            return $" | {result.ResolvedRuleId(result.Run)} | {PadTo(70, result.FirstLocation())} | {result.FirstPartialFingerprint(8)} | {result.Snippet(60)}";
         }
 
         private string PadTo(int length, string value)

--- a/src/Test.EndToEnd.Baselining/BaseliningDetailLogger.cs
+++ b/src/Test.EndToEnd.Baselining/BaseliningDetailLogger.cs
@@ -45,7 +45,7 @@ namespace Test.EndToEnd.Baselining
             }
         }
 
-        public void Write(SarifLog newBaselineLog, SarifLog baselineLog, SarifLog currentLog, BaseliningSummary summary)
+        public void Write(SarifLog newBaselineLog, SarifLog baselineLog, BaseliningSummary summary)
         {
             Dictionary<string, Result> baselineResultsByGuid = new Dictionary<string, Result>();
             foreach(Result result in baselineLog.EnumerateResults())

--- a/src/Test.EndToEnd.Baselining/Extensions/ResultTextFormatter.cs
+++ b/src/Test.EndToEnd.Baselining/Extensions/ResultTextFormatter.cs
@@ -24,6 +24,20 @@ namespace Test.EndToEnd.Baselining
             return value;
         }
 
+        public static string FirstPartialFingerprint(this Result result, int lengthLimit = -1)
+        {
+            string value = result?.PartialFingerprints?.Values?.FirstOrDefault() ?? "";
+            if (lengthLimit > 0 && value.Length > lengthLimit) { value = value.Substring(0, lengthLimit); }
+            return value;
+        }
+
+        public static string FirstFingerprint(this Result result, int lengthLimit = -1)
+        {
+            string value = result?.Fingerprints?.Values?.FirstOrDefault() ?? "";
+            if (lengthLimit > 0 && value.Length > lengthLimit) { value = value.Substring(0, lengthLimit); }
+            return value;
+        }
+
         public static string Snippet(this Result result, int lengthLimit = -1)
         {
             string value = result?.EnumeratePhysicalLocations().FirstOrDefault()?.Region?.Snippet?.Text ?? "";

--- a/src/Test.EndToEnd.Baselining/Program.cs
+++ b/src/Test.EndToEnd.Baselining/Program.cs
@@ -104,19 +104,14 @@ namespace Test.EndToEnd.Baselining
         {
             BaseliningTester tester = new BaseliningTester();
             BaseliningSummary overallSummary = tester.RunAll(options.TestRootPath);
-            Console.WriteLine(overallSummary);
             
-            Console.WriteLine();
-            Console.WriteLine($"REVIEW: windiff \"{Path.GetFullPath(Path.Combine(options.TestRootPath, BaseliningTester.ExpectedDebugFolderName))}\" \"{Path.GetFullPath(Path.Combine(options.TestRootPath, BaseliningTester.OutputDebugFolderName))}\"");
-            Console.WriteLine($"ACCEPT: robocopy /MIR \"{Path.GetFullPath(Path.Combine(options.TestRootPath, BaseliningTester.OutputFolderName))}\" \"{Path.GetFullPath(Path.Combine(options.TestRootPath, BaseliningTester.ExpectedFolderName))}\"");
-
             return 0;
         }
 
         private static int Debug(DebugOptions options)
         {
             BaseliningTester tester = new BaseliningTester();
-            tester.RunSeries(Path.Combine(options.TestRootPath, BaseliningTester.InputFolderName, options.DebugSeriesPath), options.DebugLogIndex, options.DebugResultIndex);
+            tester.RunSeries(Path.Combine(options.TestRootPath, BaseliningTester.InputFolderName, options.DebugSeriesPath), options.DebugSeriesPath, options.DebugLogIndex, options.DebugResultIndex);
 
             return 0;
         }


### PR DESCRIPTION
- SarifToCsv: Support specific Fingerprint/PartialFingerprint.
- SarifToCsv: Handle properties which aren't "string-like" correctly

BaselineE2E:
  - Write relative series path (not as "wall of text"-y)'
  - Fix analysis warning (remove unused param)
  - Pad URIs and expand snippets for CodeAsData examples
  - Add outputters for Finderprint and non-name-specific PartialFingerprint