### PR TITLE
Load transformer assemblies from the SARIF SDK path

### DIFF
--- a/src/Sarif.WorkItems/SarifWorkItemContext.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemContext.cs
@@ -87,10 +87,17 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 this.workItemModelTransformers = new List<SarifWorkItemModelTransformer>();
 
                 var loadedAssemblies = new Dictionary<string, Assembly>();
+                var thisAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
                 foreach (string assemblyLocation in this.GetProperty(PluginAssemblyLocations))
                 {
-                    Assembly a = Assembly.LoadFrom(assemblyLocation);
+                    string assemblyPath = assemblyLocation;
+                    if (!Path.IsPathRooted(assemblyLocation))
+                    {
+                        assemblyPath = Path.GetFullPath(Path.Combine(thisAssemblyDirectory, assemblyLocation));
+                    }
+
+                    Assembly a = Assembly.LoadFrom(assemblyPath);
                     loadedAssemblies.Add(a.FullName, a);
                     this.AssemblyLocationMap.Add(a.FullName, Path.GetDirectoryName(Path.GetFullPath(a.Location)));
                 }


### PR DESCRIPTION
If the transformer assembly path is a relative path, it used to be loaded relative to the current directory. It's probably more intuitive if they're loaded relative to the multitool path.