### PR TITLE
WebScout fixes

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,15 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.2.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.3)
+* BUGFIX: Result.GetRule will look up by RuleId if RuleIndex not present.
+* BUGFIX: Baselining will properly persist Run.Tool.Driver.Rules if Results reference by RuleId.
+* BUGFIX: DeferredOM will properly load files with a BOM. (LineMappingStreamReader fix)
+
 ## **v2.2.2** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.2) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.2) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.2) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.2)
 * BUGFIX: `dotnet tool install` command for Multitool now produces a working installation rather than reporting missing `Sarif.Converters` binary.
+* BUGFIX: Result.GetRule will look up by RuleId if RuleIndex not present.
+* BUGFIX: Baselining will properly persist Run.Tool.Driver.Rules if Results reference by RuleId.
+* BUGFIX: DeferredOM will properly load files with a BOM. (LineMappingStreamReader fix)
 
 ## **v2.2.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.1)
 * FEATURE: Multitool `remove` option now supports `Guids` value to remove `Result.Guid`.

--- a/src/Samples/SarifToCsv/App.config
+++ b/src/Samples/SarifToCsv/App.config
@@ -7,6 +7,9 @@
     <!-- Set RemoveNewlines to true to remove newlines from string values, for easier use in Excel and other tools which interpret newlines in quotes as a row separator -->
     <add key="RemoveNewlines" value="true" />
     
+    <!-- If Deferred OM loading is causing issues, uncomment to disable it in SarifToCsv. -->
+    <!--<add key="LoadDeferred" value="false" />-->
+    
     <!-- List the columns you wish included in output. Run SarifToCsv without arguments for available column names. -->
     <add key="ColumnNames" value="Run.Tool.Name, RuleId, BaselineState, Location.Region.Snippet.Text, Location.Region.StartLine, Location.Region.StartColumn, Location.Uri, Message, Fingerprints, RunIndex, ResultIndex" />
   </appSettings>

--- a/src/Samples/SarifToCsv/Program.cs
+++ b/src/Samples/SarifToCsv/Program.cs
@@ -40,6 +40,7 @@ namespace SarifToCsv
                 string csvFilePath = (args.Length > 1 ? args[1] : Path.ChangeExtension(args[0], ".csv"));
                 IEnumerable<string> columnNames = (args.Length > 2 ? args[2] : ConfigurationManager.AppSettings["ColumnNames"]).Split(',').Select((value) => value.Trim());
                 bool removeNewlines = bool.Parse(ValueOrDefault(ConfigurationManager.AppSettings["RemoveNewlines"], "false"));
+                bool loadDeferred = bool.Parse(ValueOrDefault(ConfigurationManager.AppSettings["LoadDeferred"], "true"));
 
                 IEnumerable<Action<WriteContext>> selectedWriters = columnNames.Select((name) => SarifCsvColumnWriters.GetWriter(name)).ToArray();
 
@@ -47,7 +48,10 @@ namespace SarifToCsv
                 Stopwatch w = Stopwatch.StartNew();
 
                 JsonSerializer serializer = new JsonSerializer();
-                serializer.ContractResolver = new SarifDeferredContractResolver();
+                if (loadDeferred)
+                {
+                    serializer.ContractResolver = new SarifDeferredContractResolver();
+                }
 
                 using (CsvWriter writer = new CsvWriter(csvFilePath))
                 {

--- a/src/Samples/SarifToCsv/SarifToCsv.csproj
+++ b/src/Samples/SarifToCsv/SarifToCsv.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Samples/SarifToCsv/packages.config
+++ b/src/Samples/SarifToCsv/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
 </packages>

--- a/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 
             var indexRemappingVisitor = new RemapIndicesVisitor(currentArtifacts: null, currentLogicalLocations: null);
 
-            properties = properties ?? new Dictionary<string, SerializedPropertyInfo>();
+            properties ??= new Dictionary<string, SerializedPropertyInfo>();
 
             List<Result> newRunResults = new List<Result>();
             foreach (MatchedResults resultPair in results)
@@ -274,18 +274,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
                     if (reportingDescriptors.TryGetValue(ruleId, out int ruleIndex))
                     {
                         result.RuleIndex = ruleIndex;
-                        result.RuleId = ruleId;
                     }
                     else
                     {
                         ReportingDescriptor rule = result.GetRule(resultPair.Run);
+                        int newIndex = reportingDescriptors.Count;
 
-                        result.RuleIndex = reportingDescriptors.Count;
-                        reportingDescriptors[ruleId] = reportingDescriptors.Count;
+                        reportingDescriptors[ruleId] = newIndex;
 
-                        run.Tool.Driver.Rules = run.Tool.Driver.Rules ?? new List<ReportingDescriptor>();
+                        run.Tool.Driver.Rules ??= new List<ReportingDescriptor>();
                         run.Tool.Driver.Rules.Add(rule);
+
+                        result.RuleIndex = newIndex;
                     }
+
+                    result.RuleId = ruleId;
                 }
 
                 newRunResults.Add(result);

--- a/src/Sarif/Core/Result.cs
+++ b/src/Sarif/Core/Result.cs
@@ -73,18 +73,21 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return GetRuleByIndex(rules, this.Rule.Index);
                 }
 
-                // Look up by this.RuleDescriptor, Guid, if present
-                if (!string.IsNullOrEmpty(this.Rule?.Guid))
+                // Look up by this.RuleDescriptor.Guid, if present
+                if (!string.IsNullOrEmpty(this.Rule?.Guid) && rules != null)
                 {
-                    if (rules != null)
-                    {
-                        foreach (ReportingDescriptor rule in rules)
-                        {
-                            if (rule.Guid == this.Rule.Guid) { return rule; }
-                        }
+                    ReportingDescriptor rule = component.GetRuleByGuid(this.Rule.Guid);
+                    if (rule != null) { return rule; }
+                    throw new ArgumentException($"ReportingDescriptorReference referred to Guid {this.Rule.Guid}, which was not found in toolComponent.Rules.");
+                }
 
-                        throw new ArgumentException($"ReportingDescriptorReference referred to Guid {this.Rule.Guid}, which was not found in toolComponent.Rules.");
-                    }
+                // Look up by RuleId, if present
+                string ruleId = this.RuleId ?? this.Rule?.Id;
+                if (ruleId != null && rules != null)
+                {
+                    ReportingDescriptor rule = component.GetRuleById(ruleId);
+                    if (rule != null) { return rule; }
+                    throw new ArgumentException($"ReportingDescriptorReference referred to RuleId {ruleId}, which was not found in toolComponent.Rules.");
                 }
             }
 

--- a/src/Sarif/Core/Result.cs
+++ b/src/Sarif/Core/Result.cs
@@ -67,27 +67,25 @@ namespace Microsoft.CodeAnalysis.Sarif
                     return GetRuleByIndex(rules, this.RuleIndex);
                 }
 
-                // Look up by this.RuleDescriptor.Index, if present
+                // Look up by this.Rule.Index, if present
                 if (this.Rule?.Index >= 0)
                 {
                     return GetRuleByIndex(rules, this.Rule.Index);
                 }
 
-                // Look up by this.RuleDescriptor.Guid, if present
+                // Look up by this.Rule.Guid, if present
                 if (!string.IsNullOrEmpty(this.Rule?.Guid) && rules != null)
                 {
                     ReportingDescriptor rule = component.GetRuleByGuid(this.Rule.Guid);
                     if (rule != null) { return rule; }
-                    throw new ArgumentException($"ReportingDescriptorReference referred to Guid {this.Rule.Guid}, which was not found in toolComponent.Rules.");
                 }
 
-                // Look up by RuleId, if present
+                // Look up by this.RuleId or this.Rule.Id, if present
                 string ruleId = this.RuleId ?? this.Rule?.Id;
                 if (ruleId != null && rules != null)
                 {
                     ReportingDescriptor rule = component.GetRuleById(ruleId);
                     if (rule != null) { return rule; }
-                    throw new ArgumentException($"ReportingDescriptorReference referred to RuleId {ruleId}, which was not found in toolComponent.Rules.");
                 }
             }
 

--- a/src/Sarif/Core/ToolComponent.cs
+++ b/src/Sarif/Core/ToolComponent.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             ReportingDescriptor rule = null;
 
             // Build lookup if not built or possibly out-of-date
-            if (_cachedRulesByGuid == null || !_cachedRulesByGuid.TryGetValue(ruleGuid, out rule))
+            if (_cachedRulesByGuid?.TryGetValue(ruleGuid, out rule) != true)
             {
                 BuildRuleCaches();
                 _cachedRulesByGuid.TryGetValue(ruleGuid, out rule);

--- a/src/Sarif/Core/ToolComponent.cs
+++ b/src/Sarif/Core/ToolComponent.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.CodeAnalysis.Sarif
 {
     /// <summary>
@@ -8,6 +12,49 @@ namespace Microsoft.CodeAnalysis.Sarif
     /// </summary>
     public partial class ToolComponent
     {
+        private Dictionary<string, ReportingDescriptor> _cachedRulesById;
+        private Dictionary<string, ReportingDescriptor> _cachedRulesByGuid;
+
+        private void BuildRuleCaches()
+        {
+            _cachedRulesById = new Dictionary<string, ReportingDescriptor>();
+            _cachedRulesByGuid = new Dictionary<string, ReportingDescriptor>();
+
+            foreach (ReportingDescriptor r in this.Rules ?? Enumerable.Empty<ReportingDescriptor>())
+            {
+                if (r.Id != null) { _cachedRulesById[r.Id] = r; }
+                if (r.Guid != null) { _cachedRulesByGuid[r.Guid] = r; }
+            }
+        }
+
+        public ReportingDescriptor GetRuleById(string ruleId)
+        {
+            ReportingDescriptor rule = null;
+
+            // Build lookup if not built or possibly out-of-date
+            if (_cachedRulesById == null || !_cachedRulesById.TryGetValue(ruleId, out rule))
+            {
+                BuildRuleCaches();
+                _cachedRulesById.TryGetValue(ruleId, out rule);
+            }
+
+            return rule;
+        }
+
+        public ReportingDescriptor GetRuleByGuid(string ruleGuid)
+        {
+            ReportingDescriptor rule = null;
+
+            // Build lookup if not built or possibly out-of-date
+            if (_cachedRulesByGuid == null || !_cachedRulesByGuid.TryGetValue(ruleGuid, out rule))
+            {
+                BuildRuleCaches();
+                _cachedRulesByGuid.TryGetValue(ruleGuid, out rule);
+            }
+
+            return rule;
+        }
+
         public bool ShouldSerializeRules()
         {
             return this.Rules.HasAtLeastOneNonNullValue();

--- a/src/Sarif/Readers/LineMappingStreamReader.cs
+++ b/src/Sarif/Readers/LineMappingStreamReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
     ///  in the part of the file currently read. This allows it to map a line and char back to a byte offset
     ///  to allow consumers to seek back to the position later.
     /// </summary>
-    public class LineMappingStreamReader : StreamReader
+    internal class LineMappingStreamReader : StreamReader
     {
         // Track bytes read before the current read (to return absolute line offsets) and in the current read
         private long _bytesReadPreviously;

--- a/src/Sarif/Readers/LineMappingStreamReader.cs
+++ b/src/Sarif/Readers/LineMappingStreamReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
     ///  in the part of the file currently read. This allows it to map a line and char back to a byte offset
     ///  to allow consumers to seek back to the position later.
     /// </summary>
-    internal class LineMappingStreamReader : StreamReader
+    public class LineMappingStreamReader : StreamReader
     {
         // Track bytes read before the current read (to return absolute line offsets) and in the current read
         private long _bytesReadPreviously;
@@ -41,13 +41,53 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
         // Track and attempt to correct for it.
         private readonly OverflowCorrector _overflowCorrector;
 
-        public LineMappingStreamReader(Stream stream) : base(stream)
+        public LineMappingStreamReader(Stream stream) : base(FindBomWidth(stream, out int bomWidth))
         {
+            // Record the width of any BOM, so that byte offsets we return are correct (base StreamReader will read and hide BOM)
+            _bytesReadPreviously = bomWidth;
+
             // (1, 1) is the 0th byte, so the line number before the read is 1 and there is one character (the newline before the first line) before the first read.
             _firstLineNumber = 1;
             _firstLineCharsBeforeBuffer = 1;
 
             _overflowCorrector = new OverflowCorrector();
+        }
+
+        private static Stream FindBomWidth(Stream stream, out int bomWidth)
+        {
+            long previousPosition = stream.Position;
+
+            // Read four bytes
+            byte[] buffer = new byte[4];
+            stream.Seek(0, SeekOrigin.Begin);
+            int countRead = stream.Read(buffer, 0, 4);
+
+            // Check for BOMs and record byte count
+            if (buffer[0] == 0xFE && buffer[1] == 0xFF)
+            {
+                bomWidth = 2;
+            }
+            else if(buffer[0] == 0xFF && buffer[1] == 0xFE)
+            {
+                bomWidth = 2;
+            }
+            else if(buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+            {
+                bomWidth = 3;
+            }
+            else if(buffer[0] == 0x00 && buffer[1] == 0x00 && buffer[2] == 0xFE && buffer[3] == 0xFF)
+            {
+                bomWidth = 4;
+            }
+            else
+            {
+                bomWidth = 0;
+            }
+
+            // Restore the stream to the prior position
+            stream.Seek(previousPosition, SeekOrigin.Begin);
+
+            return stream;
         }
 
         public long LineAndCharToOffset(int line, long charInLine)

--- a/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif.WorkItems/SarifWorkItemExtensionsTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
         public void SarifWorkItemExtensions_CreateWorkItemTitle_LongTitleFromUrl()
         {
             string ruleId = "TestRuleId";
-            string expected = ":Warning]: TestRuleId (in alaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)";
+            string expected = ":Warning]: TestRuleId: Test Rule (in alaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...)";
 
             Result result = new Result();
             ArtifactLocation artifactLocation = new ArtifactLocation(new Uri("al" + new string('a', 1024), UriKind.Relative), string.Empty, 0, new Message(), new Dictionary<string, SerializedPropertyInfo>());
@@ -91,19 +91,19 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             run.Results.Add(result);
 
             // A logical location longer than 128 char is truncated with ellipses
-            string expected = ":Warning]: TestRuleId (in 'llbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...')";
+            string expected = ":Warning]: TestRuleId: Test Rule (in 'llbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb...')";
             result.Locations[0].LogicalLocation.FullyQualifiedName = "ll" + new string('b', 1024);
             string title = sarifLog.Runs[0].CreateWorkItemTitle();
             title.Should().EndWith(expected);
 
             // A logical location that's a path is truncated to it's file name
-            expected = ":Warning]: TestRuleId (in '0123456789')";
+            expected = ":Warning]: TestRuleId: Test Rule (in '0123456789')";
             result.Locations[0].LogicalLocation.FullyQualifiedName = "ll" + new string('b', 1024) + "\\0123456789";
             title = sarifLog.Runs[0].CreateWorkItemTitle();
             title.Should().EndWith(expected);
 
             // A logical location that's a path is truncated using its full path
-            expected = ":Warning]: TestRuleId (in 'll0123456789\\cccccccccccccccccccccccccccccccccccccccccccccc...')";
+            expected = ":Warning]: TestRuleId: Test Rule (in 'll0123456789\\ccccccccccccccccccccccccccccccccccc...')";
             result.Locations[0].LogicalLocation.FullyQualifiedName = "ll0123456789\\" + new string('c', 1024);
             title = sarifLog.Runs[0].CreateWorkItemTitle();
             title.Should().EndWith(expected);

--- a/src/Test.UnitTests.Sarif/Readers/LineMappingStreamReaderTests.cs
+++ b/src/Test.UnitTests.Sarif/Readers/LineMappingStreamReaderTests.cs
@@ -107,5 +107,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Readers
                 return (JObject)serializer.Deserialize(jsonReader);
             }
         }
+
+        [Fact]
+        public void LineMappingStreamReader_BomHandling()
+        {
+            string sampleFilePath = "elfie-arriba-utf8-bom.sarif";
+            ResourceExtractor extractor = new ResourceExtractor(typeof(LineMappingStreamReaderTests));
+            File.WriteAllBytes(sampleFilePath, extractor.GetResourceBytes("elfie-arriba-utf8-bom.sarif"));
+
+            // Read the Json with a LineMappingStreamReader
+            using (LineMappingStreamReader streamReader = new LineMappingStreamReader(File.OpenRead(sampleFilePath)))
+            using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+            {
+                // Get into the top object
+                jsonReader.Read();
+
+                // Root element - index 3 (due to three BOM bytes)
+                long position = streamReader.LineAndCharToOffset(jsonReader.LineNumber, jsonReader.LinePosition);
+
+                Assert.Equal(3, position);
+            }
+        }
     }
 }

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestData\Readers\elfie-arriba-utf8-bom.sarif" />
     <EmbeddedResource Include="TestData\Baseline\elfie-arriba.sarif" />
     <EmbeddedResource Include="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <EmbeddedResource Include="TestData\Baseline\SuppressionTestPrevious.sarif" />

--- a/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestCurrent.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/Baseline/SuppressionTestCurrent.sarif
@@ -5,7 +5,26 @@
     {
       "tool": {
         "driver": {
-          "name": "CodeScanner"
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "TST0001",
+              "fullDescription": { "text": "Rule 001" }
+            },
+            {
+              "id": "TST0002",
+              "fullDescription": { "text": "Rule 002" }
+            },
+            {
+              "id": "TST0003",
+              "fullDescription": { "text": "Rule 003" }
+            },
+            {
+              "id": "TST0004",
+              "fullDescription": { "text": "Rule 004" }
+            }
+
+          ]
         }
       },
       "results": [

--- a/src/Test.UnitTests.Sarif/TestData/Readers/elfie-arriba-utf8-bom.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/Readers/elfie-arriba-utf8-bom.sarif
@@ -1,0 +1,236 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "results": [
+        {
+          "ruleId": "CSCAN0050/0",
+          "ruleIndex": 0,
+          "message": {
+            "text": "An apparent PFX certificate file was found in 'server.key'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/node-gyp/test/fixtures/server.key",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 20,
+                  "charOffset": 0,
+                  "charLength": 20,
+                  "snippet": {
+                    "text": "-----BEGIN PRIVATE K"
+                  }
+                }
+              }
+            }
+          ],
+          "guid": "d0e26f09-c783-4abf-a195-e634778c59c3",
+          "partialFingerprints": {
+            "SecretHash/v1": "ZpQcXkWWtAe4lPc64hZnbn+1O+Uv2v3o/7iZojeBd5o=",
+            "SecretHash/v2": "187bc5ee853e84fae5764c5abbf3c170d0ce417465d7b3817fea30908be3fc82"
+          }
+        },
+        {
+          "ruleId": "CSCAN0060/0",
+          "ruleIndex": 1,
+          "message": {
+            "text": "An apparent PEM certificate file with private key was found in 'key.pem'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/eventsource/test/key.pem",
+                  "index": 1
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 31,
+                  "charOffset": 0,
+                  "charLength": 31,
+                  "snippet": {
+                    "text": "-----BEGIN RSA PRIVATE KEY-----"
+                  }
+                }
+              }
+            }
+          ],
+          "guid": "e3d5c8f3-fddf-414a-874a-590e52ccd46e",
+          "partialFingerprints": {
+            "SecretHash/v1": "fdZwTjfxyQHIYf+BmyPXyLEOqdG4U2NLBuFNLckqc/s=",
+            "SecretHash/v2": "31a9d2ebe99fda6bb960be39abf9219b38ddfacb7d790f3e968b86da13f51a34"
+          }
+        },
+        {
+          "ruleId": "CSCAN0060/0",
+          "ruleIndex": 1,
+          "message": {
+            "text": "An apparent PEM certificate file with private key was found in 'test_key.pem'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_key.pem",
+                  "index": 2
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 31,
+                  "charOffset": 0,
+                  "charLength": 31,
+                  "snippet": {
+                    "text": "-----BEGIN RSA PRIVATE KEY-----"
+                  }
+                }
+              }
+            }
+          ],
+          "guid": "42a15196-8657-4735-abfe-d029fef1d54c",
+          "partialFingerprints": {
+            "SecretHash/v1": "fdZwTjfxyQHIYf+BmyPXyLEOqdG4U2NLBuFNLckqc/s=",
+            "SecretHash/v2": "31a9d2ebe99fda6bb960be39abf9219b38ddfacb7d790f3e968b86da13f51a34"
+          }
+        },
+        {
+          "ruleId": "CSCAN0060/0",
+          "ruleIndex": 1,
+          "message": {
+            "text": "An apparent PEM certificate file with private key was found in 'test_rsa_privkey.pem'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_rsa_privkey.pem",
+                  "index": 3
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 31,
+                  "charOffset": 0,
+                  "charLength": 31,
+                  "snippet": {
+                    "text": "-----BEGIN RSA PRIVATE KEY-----"
+                  }
+                }
+              }
+            }
+          ],
+          "guid": "cca22fc9-7f58-4656-9947-563dc85fadfc",
+          "partialFingerprints": {
+            "SecretHash/v1": "fdZwTjfxyQHIYf+BmyPXyLEOqdG4U2NLBuFNLckqc/s=",
+            "SecretHash/v2": "31a9d2ebe99fda6bb960be39abf9219b38ddfacb7d790f3e968b86da13f51a34"
+          }
+        },
+        {
+          "ruleId": "CSCAN0060/0",
+          "ruleIndex": 1,
+          "message": {
+            "text": "An apparent PEM certificate file with private key was found in 'test_rsa_privkey_encrypted.pem'."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_rsa_privkey_encrypted.pem",
+                  "index": 4
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 31,
+                  "charOffset": 0,
+                  "charLength": 31,
+                  "snippet": {
+                    "text": "-----BEGIN RSA PRIVATE KEY-----"
+                  }
+                }
+              }
+            }
+          ],
+          "guid": "5fa3d8b7-9762-483e-a455-8b529ae8b0cb",
+          "partialFingerprints": {
+            "SecretHash/v1": "fdZwTjfxyQHIYf+BmyPXyLEOqdG4U2NLBuFNLckqc/s=",
+            "SecretHash/v2": "31a9d2ebe99fda6bb960be39abf9219b38ddfacb7d790f3e968b86da13f51a34"
+          }
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "Spam",
+          "fullName": "Spam 1.2.23.0",
+          "version": "1.2.23.0",
+          "semanticVersion": "1.2.23",
+          "rules": [
+            {
+              "id": "CSCAN0050",
+              "name": "PfxFile"
+            },
+            {
+              "id": "CSCAN0060",
+              "name": "PemFile"
+            }
+          ],
+          "properties": {
+            "CompanyName": "Microsoft",
+            "ProductName": "Spam"
+          }
+        }
+      },
+      "invocations": [
+        {
+          "commandLine": "C:\\Code\\spam\\src\\bin\\Debug\\netcoreapp2.1\\win-x64\\Spam.dll C:\\Code\\elfie-arriba C:\\Code\\elfie-arriba.sarif",
+          "startTimeUtc": "2020-03-04T22:18:23.634Z",
+          "endTimeUtc": "2020-03-04T22:18:23.837Z",
+          "executionSuccessful": true,
+          "workingDirectory": {
+            "uri": "file:///C:/Code/spam/src/bin/Debug/netcoreapp2.1/win-x64"
+          }
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/node-gyp/test/fixtures/server.key"
+          }
+        },
+        {
+          "location": {
+            "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/eventsource/test/key.pem"
+          }
+        },
+        {
+          "location": {
+            "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_key.pem"
+          }
+        },
+        {
+          "location": {
+            "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_rsa_privkey.pem"
+          }
+        },
+        {
+          "location": {
+            "uri": "file:///C:/Code/elfie-arriba/XForm/XForm.Web/node_modules/public-encrypt/test/test_rsa_privkey_encrypted.pem"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/SarifLoggerTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 string commandLine = Environment.CommandLine;
                 string lowerCaseCommandLine = commandLine.ToLower();
 
-                if (lowerCaseCommandLine.Contains("testhost.dll") || lowerCaseCommandLine.Contains("\\xunit.console") || lowerCaseCommandLine.Contains("testhost.x86.exe"))
+                if (lowerCaseCommandLine.Contains("testhost.") || lowerCaseCommandLine.Contains("\\xunit.console"))
                 {
                     int index = commandLine.LastIndexOf("\\");
                     string argumentToRedact = commandLine.Substring(0, index + 1);

--- a/src/build.props
+++ b/src/build.props
@@ -24,8 +24,8 @@
       NOTE: Version in scripts/BuildMultitoolForNpm.ps1 also has to be updated for each release
       until it adopts the same versions as the SDK itself.
     -->
-    <VersionPrefix>2.2.2</VersionPrefix>
-    <PreviousVersionPrefix>2.2.1</PreviousVersionPrefix>
+    <VersionPrefix>2.2.3</VersionPrefix>
+    <PreviousVersionPrefix>2.2.2</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
- Result.GetRule now looks up by RuleId (after RuleIndex or Guid)
- ToolComponent builds lookup cache by RuleId and Guid to prevent performance problems looking up every Result's Rule.
- Baselining now persists Run.Tool.Driver.Rules referenced by Results via RuleId properly.
- SarifToCsv: Match Sarif SDK Newtonsoft version.
- SarifToCsv: Make use of DeferredOM configurable, as workaround if needed.
- Fix Deferred OM to detect and handle files with BOMs.
- Fix broken unit tests (unrelated to these changes)