### PR TITLE
Resilient references

### DIFF
--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -75,7 +75,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include=".\DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" Link="sarif.2.1.0.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -75,7 +75,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include=".\DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" Link="sarif.2.1.0.json" CopyToOutputDirectory="PreserveNewest"/>
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" Link="sarif-2.1.0.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -74,9 +74,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="$(SolutionDir)\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include=".\DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="..\Sarif\Schemata\sarif-2.1.0-rtm.5.json" Link="sarif-2.1.0.json" />
+    <EmbeddedResource Include="$(MsBuildThisFileDirectory)..\Sarif\Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sarif.Multitool/ValidateCommand.cs
+++ b/src/Sarif.Multitool/ValidateCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
             else
             {
-                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool-sarif.2.1.0.json";
+                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0.json";
 
                 using (Stream stream = this.GetType().Assembly.GetManifestResourceStream(schemaResource))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/Sarif.Multitool/ValidateCommand.cs
+++ b/src/Sarif.Multitool/ValidateCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
             else
             {
-                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif.2.1.0.json";
+                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool-sarif.2.1.0.json";
 
                 using (Stream stream = this.GetType().Assembly.GetManifestResourceStream(schemaResource))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/Sarif.Multitool/ValidateCommand.cs
+++ b/src/Sarif.Multitool/ValidateCommand.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
             }
             else
             {
-                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif-2.1.0-rtm.5.json";
+                string schemaResource = "Microsoft.CodeAnalysis.Sarif.Multitool.sarif.2.1.0.json";
 
                 using (Stream stream = this.GetType().Assembly.GetManifestResourceStream(schemaResource))
                 using (StreamReader reader = new StreamReader(stream))

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <JsonSchemaFile Include="Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json">
+    <JsonSchemaFile Include="$(MsBuildThisFileDirectory)Schemata\sarif-$(SchemaVersionAsPublishedToSchemaStoreOrg).json">
       <Namespace>$(RootNamespace)</Namespace>
       <RootClassName>SarifLog</RootClassName>
       <CopyrightFilePath>CopyrightNotice.txt</CopyrightFilePath>

--- a/src/build.props
+++ b/src/build.props
@@ -102,7 +102,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\triskelion.png" Pack="true" PackagePath="\"/>
+    <None Include="$(MsBuildThisFileDirectory)..\triskelion.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@rtaket 
This change allows us to indirectly reference schema files when SARIF SDK is compiled as a sub-module.