### PR TITLE
Add new eventids for work item success metrics

### DIFF
--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -47,15 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             this.FilingClient = FilingClientFactory.Create(this.FilingContext.HostUri);
 
             this.Logger = ServiceProviderFactory.ServiceProvider.GetService<ILogger<FilingClient>>();
-
-            Assembly currentAssembly = Assembly.GetExecutingAssembly();
-            AssemblyName assemblyName = currentAssembly.GetName();
-            FileInfo assemblyFileInfo = new FileInfo(currentAssembly.Location);
-            Dictionary<string, object> assemblyMetrics = new Dictionary<string, object>();
-            assemblyMetrics.Add("Name", assemblyName.Name);
-            assemblyMetrics.Add("Version", assemblyName.Version);
-            assemblyMetrics.Add("CreationTime", assemblyFileInfo.CreationTime.ToUniversalTime().ToString());
-            this.Logger.LogMetrics(EventIds.AssemblyVersion, assemblyMetrics);
+            Assembly.GetExecutingAssembly().LogIdentity();
         }
 
         public FilingClient FilingClient { get; set; }
@@ -237,12 +229,11 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 //
                 UpdateLogWithWorkItemDetails(sarifLog, sarifWorkItemModel.HtmlUri, sarifWorkItemModel.Uri);
 
-                LogMetricsForProcessedModel(sarifLog, sarifWorkItemModel, FilingResult.Succeeded, null);
+                LogMetricsForProcessedModel(sarifLog, sarifWorkItemModel, FilingResult.Succeeded);
             }
             catch (Exception ex)
             {
                 this.Logger.LogError(ex, "An exception was raised filing log '{logGuid}'.", logGuid);
-                Console.Error.WriteLine(ex);
 
                 Dictionary<string, object> customDimentions = new Dictionary<string, object>();
                 customDimentions.Add("ExceptionType", ex.GetType().FullName);
@@ -273,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             }
         }
 
-        private void LogMetricsForProcessedModel(SarifLog sarifLog, SarifWorkItemModel sarifWorkItemModel, FilingResult filingResult, Dictionary<string, object> additionalCustomDimensions)
+        private void LogMetricsForProcessedModel(SarifLog sarifLog, SarifWorkItemModel sarifWorkItemModel, FilingResult filingResult, Dictionary<string, object> additionalCustomDimensions = null)
         {
             additionalCustomDimensions ??= new Dictionary<string, object>();
 

--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             var workItemMetrics = new Dictionary<string, object>
                 {
                     { "LogGuid", logGuid },
-                    { "WorkItemModelId", sarifWorkItemModel.Id },
+                    { "WorkItemModelGuid", sarifWorkItemModel.Guid },
                     { nameof(sarifWorkItemModel.Area), sarifWorkItemModel.Area },
                     { nameof(sarifWorkItemModel.BodyOrDescription), sarifWorkItemModel.BodyOrDescription },
                     { "FilingResult", filingResult.ToString() },
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 var workItemDetailMetrics = new Dictionary<string, object>
                 {
                     { "LogGuid", logGuid },
-                    { "WorkItemModelId", sarifWorkItemModel.Id },
+                    { "WorkItemModelGuid", sarifWorkItemModel.Guid },
                     { nameof(ruleMetrics.Tool), ruleMetrics.Tool },
                     { nameof(ruleMetrics.RuleId), ruleMetrics.RuleId },
                     { nameof(ruleMetrics.ErrorCount), ruleMetrics.ErrorCount },

--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -287,21 +287,21 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
             var workItemMetrics = new Dictionary<string, object>
                 {
-                    { "logGuid", logGuid },
-                    { "workItemGuid", sarifWorkItemModel.Id },
-                    { "area", sarifWorkItemModel.Area },
-                    { "bodyOrDescription", sarifWorkItemModel.BodyOrDescription },
-                    { "filingResult", filingResult.ToString() },
-                    { "commentOrDiscussion", sarifWorkItemModel.CommentOrDiscussion },
-                    { "htmlUri", sarifWorkItemModel.HtmlUri },
-                    { "iteration", sarifWorkItemModel.Iteration },
-                    { "labelsOrTags", tags },
-                    { "locationUri", uris },
-                    { "milestone", sarifWorkItemModel.Milestone },
-                    { "ownerOrAccount", sarifWorkItemModel.OwnerOrAccount },
-                    { "repositoryOrProject", sarifWorkItemModel.RepositoryOrProject },
-                    { "title", sarifWorkItemModel.Title },
-                    { "uri", sarifWorkItemModel.Uri },
+                    { "LogGuid", logGuid },
+                    { "WorkItemModelId", sarifWorkItemModel.Id },
+                    { "Area", sarifWorkItemModel.Area },
+                    { "BodyOrDescription", sarifWorkItemModel.BodyOrDescription },
+                    { "FilingResult", filingResult.ToString() },
+                    { "CommentOrDiscussion", sarifWorkItemModel.CommentOrDiscussion },
+                    { "HtmlUri", sarifWorkItemModel.HtmlUri },
+                    { "Iteration", sarifWorkItemModel.Iteration },
+                    { "LabelsOrTags", tags },
+                    { "LocationUri", uris },
+                    { "Milestone", sarifWorkItemModel.Milestone },
+                    { "OwnerOrAccount", sarifWorkItemModel.OwnerOrAccount },
+                    { "RepositoryOrProject", sarifWorkItemModel.RepositoryOrProject },
+                    { "Title", sarifWorkItemModel.Title },
+                    { "Uri", sarifWorkItemModel.Uri },
                 };
 
             foreach (string key in additionalCustomDimensions.Keys)
@@ -333,16 +333,16 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
                 var workItemDetailMetrics = new Dictionary<string, object>
                 {
-                    { "logGuid", logGuid },
-                    { "workItemGuid", sarifWorkItemModel.Id },
-                    { "tool", ruleMetrics.Tool },
-                    { "ruleId", ruleMetrics.RuleId },
-                    { "errorCount", ruleMetrics.ErrorCount },
-                    { "warningCount", ruleMetrics.WarningCount },
-                    { "noteCount", ruleMetrics.NoteCount },
-                    { "openCount", ruleMetrics.OpenCount },
-                    { "reviewCount", ruleMetrics.ReviewCount },
-                    { "suppressedByTransformerCount", ruleMetrics.SuppressedByTransformerCount }
+                    { "LogGuid", logGuid },
+                    { "WorkItemModelId", sarifWorkItemModel.Id },
+                    { "Tool", ruleMetrics.Tool },
+                    { "RuleId", ruleMetrics.RuleId },
+                    { "ErrorCount", ruleMetrics.ErrorCount },
+                    { "WarningCount", ruleMetrics.WarningCount },
+                    { "NoteCount", ruleMetrics.NoteCount },
+                    { "OpenCount", ruleMetrics.OpenCount },
+                    { "ReviewCount", ruleMetrics.ReviewCount },
+                    { "SuppressedByTransformerCount", ruleMetrics.SuppressedByTransformerCount }
                 };
 
                 this.Logger.LogMetrics(EventIds.WorkItemFiledDetailMetrics, workItemMetrics);

--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -208,17 +208,19 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
                 foreach (SarifWorkItemModelTransformer transformer in sarifWorkItemModel.Context.Transformers)
                 {
-                    sarifWorkItemModel = transformer.Transform(sarifWorkItemModel);
+                    SarifWorkItemModel updatedSarifWorkItemModel = transformer.Transform(sarifWorkItemModel);
 
                     // If a transformer has set the model to null, that indicates 
                     // it should be pulled from the work flow (i.e., not filed).
-                    if (sarifWorkItemModel == null) 
+                    if (updatedSarifWorkItemModel == null)
                     {
                         Dictionary<string, object> customDimentions = new Dictionary<string, object>();
                         customDimentions.Add("TransformerType", transformer.GetType().FullName);
                         LogMetricsForProcessedModel(sarifLog, sarifWorkItemModel, FilingResult.Canceled, customDimentions);
                         return;
                     }
+
+                    sarifWorkItemModel = updatedSarifWorkItemModel;
                 }
 
                 Task<IEnumerable<WorkItemModel>> task = filingClient.FileWorkItems(new[] { sarifWorkItemModel });

--- a/src/Sarif.WorkItems/SarifWorkItemFiler.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemFiler.cs
@@ -280,19 +280,19 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 {
                     { "LogGuid", logGuid },
                     { "WorkItemModelId", sarifWorkItemModel.Id },
-                    { "Area", sarifWorkItemModel.Area },
-                    { "BodyOrDescription", sarifWorkItemModel.BodyOrDescription },
+                    { nameof(sarifWorkItemModel.Area), sarifWorkItemModel.Area },
+                    { nameof(sarifWorkItemModel.BodyOrDescription), sarifWorkItemModel.BodyOrDescription },
                     { "FilingResult", filingResult.ToString() },
-                    { "CommentOrDiscussion", sarifWorkItemModel.CommentOrDiscussion },
-                    { "HtmlUri", sarifWorkItemModel.HtmlUri },
-                    { "Iteration", sarifWorkItemModel.Iteration },
+                    { nameof(sarifWorkItemModel.CommentOrDiscussion), sarifWorkItemModel.CommentOrDiscussion },
+                    { nameof(sarifWorkItemModel.HtmlUri), sarifWorkItemModel.HtmlUri },
+                    { nameof(sarifWorkItemModel.Iteration), sarifWorkItemModel.Iteration },
                     { "LabelsOrTags", tags },
                     { "LocationUri", uris },
-                    { "Milestone", sarifWorkItemModel.Milestone },
-                    { "OwnerOrAccount", sarifWorkItemModel.OwnerOrAccount },
-                    { "RepositoryOrProject", sarifWorkItemModel.RepositoryOrProject },
-                    { "Title", sarifWorkItemModel.Title },
-                    { "Uri", sarifWorkItemModel.Uri },
+                    { nameof(sarifWorkItemModel.Milestone), sarifWorkItemModel.Milestone },
+                    { nameof(sarifWorkItemModel.OwnerOrAccount), sarifWorkItemModel.OwnerOrAccount },
+                    { nameof(sarifWorkItemModel.RepositoryOrProject), sarifWorkItemModel.RepositoryOrProject },
+                    { nameof(sarifWorkItemModel.Title), sarifWorkItemModel.Title },
+                    { nameof(sarifWorkItemModel.Uri), sarifWorkItemModel.Uri },
                 };
 
             foreach (string key in additionalCustomDimensions.Keys)
@@ -326,14 +326,14 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
                 {
                     { "LogGuid", logGuid },
                     { "WorkItemModelId", sarifWorkItemModel.Id },
-                    { "Tool", ruleMetrics.Tool },
-                    { "RuleId", ruleMetrics.RuleId },
-                    { "ErrorCount", ruleMetrics.ErrorCount },
-                    { "WarningCount", ruleMetrics.WarningCount },
-                    { "NoteCount", ruleMetrics.NoteCount },
-                    { "OpenCount", ruleMetrics.OpenCount },
-                    { "ReviewCount", ruleMetrics.ReviewCount },
-                    { "SuppressedByTransformerCount", ruleMetrics.SuppressedByTransformerCount }
+                    { nameof(ruleMetrics.Tool), ruleMetrics.Tool },
+                    { nameof(ruleMetrics.RuleId), ruleMetrics.RuleId },
+                    { nameof(ruleMetrics.ErrorCount), ruleMetrics.ErrorCount },
+                    { nameof(ruleMetrics.WarningCount), ruleMetrics.WarningCount },
+                    { nameof(ruleMetrics.NoteCount), ruleMetrics.NoteCount },
+                    { nameof(ruleMetrics.OpenCount), ruleMetrics.OpenCount },
+                    { nameof(ruleMetrics.ReviewCount), ruleMetrics.ReviewCount },
+                    { nameof(ruleMetrics.SuppressedByTransformerCount), ruleMetrics.SuppressedByTransformerCount }
                 };
 
                 this.Logger.LogMetrics(EventIds.WorkItemFiledDetailMetrics, workItemMetrics);

--- a/src/Sarif.WorkItems/SarifWorkItemModel.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
         public IList<Uri> LocationUris { get; private set; }
 
-        public Guid Id { get; }
+        public Guid Guid { get; }
 
         // The sarifLog parameter contains exactly a set of results that are intended to be filed as a single work item 
         // and this log will be attached to the work item.
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
             this.SarifLog = sarifLog;
             this.Context = context ?? new SarifWorkItemContext();
 
-            this.Id = (id == default(Guid)) ? Guid.NewGuid() : id;
+            this.Guid = (id == default(Guid)) ? Guid.NewGuid() : id;
 
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitSarifLog(sarifLog);

--- a/src/Sarif.WorkItems/SarifWorkItemModel.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemModel.cs
@@ -20,14 +20,14 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
 
         // The sarifLog parameter contains exactly a set of results that are intended to be filed as a single work item 
         // and this log will be attached to the work item.
-        public SarifWorkItemModel(SarifLog sarifLog, SarifWorkItemContext context = null, Guid id = default(Guid))
+        public SarifWorkItemModel(SarifLog sarifLog, SarifWorkItemContext context = null, Guid guid = default(Guid))
         {
             if (sarifLog == null) { throw new ArgumentNullException(nameof(sarifLog)); }
 
             this.SarifLog = sarifLog;
             this.Context = context ?? new SarifWorkItemContext();
 
-            this.Guid = (id == default(Guid)) ? Guid.NewGuid() : id;
+            this.Guid = (guid == default(Guid)) ? Guid.NewGuid() : guid;
 
             var visitor = new ExtractAllArtifactLocationsVisitor();
             visitor.VisitSarifLog(sarifLog);

--- a/src/Sarif.WorkItems/SarifWorkItemModelTransformer.cs
+++ b/src/Sarif.WorkItems/SarifWorkItemModelTransformer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Sarif.WorkItems
     {
         public SarifWorkItemModelTransformer()
         {
-            this.Logger = ServiceProviderFactory.ServiceProvider.GetService<ILogger<ILogger>>();
+            this.Logger = ServiceProviderFactory.ServiceProvider.GetService<ILogger<FilingClient>>();
         }
 
         protected ILogger Logger { get; }

--- a/src/WorkItems/Logging/AssemblyExtensions.cs
+++ b/src/WorkItems/Logging/AssemblyExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.WorkItems.Logging
+{
+    public static class AssemblyExtensions
+    {
+        public static void LogIdentity(this Assembly assembly, EventId customEventId = default(EventId), IDictionary<string, object> customDimensions = null)
+        {
+            ILogger logger = ServiceProviderFactory.ServiceProvider.GetService<ILogger<FilingClient>>();
+
+            EventId eventId = (customEventId == default(EventId)) ? EventIds.AssemblyVersion : customEventId;
+            customDimensions ??= new Dictionary<string, object>();
+
+            AssemblyName assemblyName = assembly.GetName();
+            FileInfo assemblyFileInfo = new FileInfo(assembly.Location);
+            Dictionary<string, object> assemblyMetrics = new Dictionary<string, object>(customDimensions);
+            assemblyMetrics.Add("Name", assemblyName.Name);
+            assemblyMetrics.Add("Version", assemblyName.Version);
+            assemblyMetrics.Add("CreationTime", assemblyFileInfo.CreationTime.ToUniversalTime().ToString());
+
+            logger.LogMetrics(eventId, assemblyMetrics);
+        }
+    }
+}

--- a/src/WorkItems/Logging/EventIds.cs
+++ b/src/WorkItems/Logging/EventIds.cs
@@ -7,8 +7,15 @@ namespace Microsoft.WorkItems.Logging
 {
     public static class EventIds
     {
-        public static EventId LogsToProcessMetrics => new EventId(9001, nameof(LogsToProcessMetrics));
-        public static EventId WorkItemFiledCoreMetrics => new EventId(9002, nameof(WorkItemFiledCoreMetrics));
-        public static EventId WorkItemFiledDetailMetrics => new EventId(9003, nameof(WorkItemFiledDetailMetrics));
+        public static EventId AssemblyVersion => new EventId(1001, nameof(AssemblyVersion));
+
+        public static EventId LogsToProcessMetrics => new EventId(8001, nameof(LogsToProcessMetrics));
+
+        // EventIds 9000-9009 are reserved for work item filing status
+        public static EventId WorkItemFiledCoreMetrics => new EventId(9001, nameof(WorkItemFiledCoreMetrics));
+        public static EventId WorkItemCanceledCoreMetrics => new EventId(9002, nameof(WorkItemCanceledCoreMetrics));
+        public static EventId WorkItemExceptionCoreMetrics => new EventId(9003, nameof(WorkItemExceptionCoreMetrics));
+
+        public static EventId WorkItemFiledDetailMetrics => new EventId(9010, nameof(WorkItemFiledDetailMetrics));
     }
 }


### PR DESCRIPTION
Note that the existing EventIds have changed.

Here's a query that contains most of the new EventIds. It does not contain 9002 because there's currently no transformer that can return null.

traces
| where operation_Id == "ebcc7f10-5525-415f-affa-51827c373f98"
| order by timestamp asc
