### PR TITLE
In SARIF1018, also require a trailing slash.

### DIFF
--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In this artifactLocation object contained in run.originalUriBaseIds, the uri property &apos;{0}&apos; does not end with a slash..
+        ///   Looks up a localized string similar to {0}: The URI &apos;{1}&apos; belonging to the &apos;{2}&apos; element of run.originalUriBaseIds does not end with a slash..
         /// </summary>
         internal static string SARIF1018_LacksTrailingSlash {
             get {
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property &apos;{0}&apos; is not an absolute URI..
+        ///   Looks up a localized string similar to {0}: The URI &apos;{1}&apos; belonging to the &apos;{2}&apos; element of run.originalUriBaseIds is not an absolute URI..
         /// </summary>
         internal static string SARIF1018_NotAbsolute {
             get {

--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -286,20 +286,29 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but uri is &apos;{0}&apos;, which is a relative URI..
-        /// </summary>
-        internal static string SARIF1018_Default {
-            get {
-                return ResourceManager.GetString("SARIF1018_Default", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent..
+        ///   Looks up a localized string similar to In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent. Also, uri must end with a slash, so that it can safely be combined with the relative URIs in artifactLocation objects elsewhere in the log file..
         /// </summary>
         internal static string SARIF1018_InvalidUriInOriginalUriBaseIds {
             get {
                 return ResourceManager.GetString("SARIF1018_InvalidUriInOriginalUriBaseIds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this artifactLocation object contained in run.originalUriBaseIds, the uri property &apos;{0}&apos; does not end with a slash..
+        /// </summary>
+        internal static string SARIF1018_LacksTrailingSlash {
+            get {
+                return ResourceManager.GetString("SARIF1018_LacksTrailingSlash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property &apos;{0}&apos; is not an absolute URI..
+        /// </summary>
+        internal static string SARIF1018_NotAbsolute {
+            get {
+                return ResourceManager.GetString("SARIF1018_NotAbsolute", resourceCulture);
             }
         }
     }

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -196,9 +196,9 @@
     <value>In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent. Also, uri must end with a slash, so that it can safely be combined with the relative URIs in artifactLocation objects elsewhere in the log file.</value>
   </data>
   <data name="SARIF1018_LacksTrailingSlash" xml:space="preserve">
-    <value>In this artifactLocation object contained in run.originalUriBaseIds, the uri property '{0}' does not end with a slash.</value>
+    <value>{0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds does not end with a slash.</value>
   </data>
   <data name="SARIF1018_NotAbsolute" xml:space="preserve">
-    <value>In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property '{0}' is not an absolute URI.</value>
+    <value>{0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds is not an absolute URI.</value>
   </data>
 </root>

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -192,10 +192,13 @@
   <data name="SARIF1017_InvalidIndex" xml:space="preserve">
     <value>If an object contains a property that is used as an array index, then that array must be present and must contain at least "index + 1" elements.</value>
   </data>
-  <data name="SARIF1018_Default" xml:space="preserve">
-    <value>In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but uri is '{0}', which is a relative URI.</value>
-  </data>
   <data name="SARIF1018_InvalidUriInOriginalUriBaseIds" xml:space="preserve">
-    <value>In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent.</value>
+    <value>In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent. Also, uri must end with a slash, so that it can safely be combined with the relative URIs in artifactLocation objects elsewhere in the log file.</value>
+  </data>
+  <data name="SARIF1018_LacksTrailingSlash" xml:space="preserve">
+    <value>In this artifactLocation object contained in run.originalUriBaseIds, the uri property '{0}' does not end with a slash.</value>
+  </data>
+  <data name="SARIF1018_NotAbsolute" xml:space="preserve">
+    <value>In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property '{0}' is not an absolute URI.</value>
   </data>
 </root>

--- a/src/Sarif.Multitool/Rules/SARIF1008.MessagesShouldEndWithPeriod.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1008.MessagesShouldEndWithPeriod.cs
@@ -36,13 +36,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected override void Analyze(ReportingDescriptor reportingDescriptor, string reportingDescriptorPointer)
         {
-            AnalyzeMessageStrings(reportingDescriptor.MessageStrings, reportingDescriptorPointer, SarifPropertyName.MessageStrings);
+            AnalyzeMessageStrings(reportingDescriptor.MessageStrings, reportingDescriptorPointer);
         }
 
         private void AnalyzeMessageStrings(
             IDictionary<string, MultiformatMessageString> messageStrings,
-            string reportingDescriptorPointer,
-            string propertyName)
+            string reportingDescriptorPointer)
         {
             if (messageStrings != null)
             {
@@ -55,7 +54,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                     string messageStringPointer = messageStringsPointer.AtProperty(key);
 
                     AnalyzeMessageString(messageString.Text, messageStringPointer, SarifPropertyName.Text);
-                    AnalyzeMessageString(messageString.Markdown, messageStringPointer, SarifPropertyName.Markdown);
                 }
             }
         }
@@ -63,13 +61,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         protected override void Analyze(MultiformatMessageString multiformatMessageString, string multiformatMessageStringPointer)
         {
             AnalyzeMessageString(multiformatMessageString.Text, multiformatMessageStringPointer, SarifPropertyName.Text);
-            AnalyzeMessageString(multiformatMessageString.Markdown, multiformatMessageStringPointer, SarifPropertyName.Markdown);
         }
 
         protected override void Analyze(Message message, string messagePointer)
         {
             AnalyzeMessageString(message.Text, messagePointer, SarifPropertyName.Text);
-            AnalyzeMessageString(message.Markdown, messagePointer, SarifPropertyName.Markdown);
         }
 
         private void AnalyzeMessageString(

--- a/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
@@ -35,14 +35,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             {
                 string originalUriBaseIdsPointer = runPointer.AtProperty(SarifPropertyName.OriginalUriBaseIds);
 
-                foreach (string key in run.OriginalUriBaseIds.Keys)
+                foreach (string uriBaseId in run.OriginalUriBaseIds.Keys)
                 {
-                    AnalyzeOriginalUriBaseIdsEntry(run.OriginalUriBaseIds[key], originalUriBaseIdsPointer.AtProperty(key));
+                    AnalyzeOriginalUriBaseIdsEntry(uriBaseId, run.OriginalUriBaseIds[uriBaseId], originalUriBaseIdsPointer.AtProperty(uriBaseId));
                 }
             }
         }
 
-        private void AnalyzeOriginalUriBaseIdsEntry(ArtifactLocation artifactLocation, string pointer)
+        private void AnalyzeOriginalUriBaseIdsEntry(string uriBaseId, ArtifactLocation artifactLocation, string pointer)
         {
             // If uriBaseId is present, the uri must be relative. But this is true for _all_
             // artifactLocation objects, not just the ones in run.originalUriBaseIds, so we
@@ -69,12 +69,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 Uri uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri)
                 {
-                    LogResult(pointer, nameof(RuleResources.SARIF1018_NotAbsolute), uriString);
+                    LogResult(pointer, nameof(RuleResources.SARIF1018_NotAbsolute), uriString, uriBaseId);
                 }
 
                 if (!uriString.EndsWith("/"))
                 {
-                    LogResult(pointer, nameof(RuleResources.SARIF1018_LacksTrailingSlash), uriString);
+                    LogResult(pointer, nameof(RuleResources.SARIF1018_LacksTrailingSlash), uriString, uriBaseId);
                 }
             }
         }

--- a/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             string uriString = artifactLocation.Uri.OriginalString;
             if (uriString != null && Uri.IsWellFormedUriString(uriString, UriKind.RelativeOrAbsolute))
             {
-                // Ok, it's a well-formed URI of some kind. If it's not absolute or it it doesn not
+                // Ok, it's a well-formed URI of some kind. If it's not absolute or if it does not
                 // end with a slash, _now_ we can report it.
                 Uri uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri)

--- a/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1018.InvalidUriInOriginalUriBaseIds.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         protected override IEnumerable<string> MessageResourceNames => new string[]
         {
-            nameof(RuleResources.SARIF1018_Default)
+            nameof(RuleResources.SARIF1018_NotAbsolute),
+            nameof(RuleResources.SARIF1018_LacksTrailingSlash)
         };
 
         protected override void Analyze(Run run, string runPointer)
@@ -63,12 +64,17 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             string uriString = artifactLocation.Uri.OriginalString;
             if (uriString != null && Uri.IsWellFormedUriString(uriString, UriKind.RelativeOrAbsolute))
             {
-                // Ok, it's a well-formed URI of some kind. If it's not absolute, _now_ we
-                // can report it.
+                // Ok, it's a well-formed URI of some kind. If it's not absolute or it it doesn not
+                // end with a slash, _now_ we can report it.
                 Uri uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
                 if (!uri.IsAbsoluteUri)
                 {
-                    LogResult(pointer, nameof(RuleResources.SARIF1018_Default), uriString);
+                    LogResult(pointer, nameof(RuleResources.SARIF1018_NotAbsolute), uriString);
+                }
+
+                if (!uriString.EndsWith("/"))
+                {
+                    LogResult(pointer, nameof(RuleResources.SARIF1018_LacksTrailingSlash), uriString);
                 }
             }
         }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1008.MessagesShouldEndWithPeriod_Invalid.sarif
@@ -70,30 +70,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].attachments[0].description.markdown",
-              "_Rich_ attachment description without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 137,
-                  "startColumn": 74
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].results[0].attachments[0].rectangles[0].message.text",
               "rectangle message without period"
             ]
@@ -107,30 +83,6 @@
                 "region": {
                   "startLine": 147,
                   "startColumn": 62
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].results[0].attachments[0].rectangles[0].message.markdown",
-              "_Rich_ rectangle message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 148,
-                  "startColumn": 73
                 }
               }
             }
@@ -166,30 +118,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].locations[0].message.markdown",
-              "_Rich_ location message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 76,
-                  "startColumn": 68
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].results[0].locations[0].physicalLocation.region.message.text",
               "region message without period"
             ]
@@ -203,30 +131,6 @@
                 "region": {
                   "startLine": 69,
                   "startColumn": 59
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].results[0].locations[0].physicalLocation.region.message.markdown",
-              "_Rich_ region message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 70,
-                  "startColumn": 70
                 }
               }
             }
@@ -262,30 +166,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].codeFlows[0].message.markdown",
-              "_Rich_ codeFlow message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 102,
-                  "startColumn": 68
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].results[0].codeFlows[0].threadFlows[0].message.text",
               "threadFlow message without period"
             ]
@@ -299,30 +179,6 @@
                 "region": {
                   "startLine": 107,
                   "startColumn": 63
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].results[0].codeFlows[0].threadFlows[0].message.markdown",
-              "_Rich_ threadFlow message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 108,
-                  "startColumn": 74
                 }
               }
             }
@@ -358,30 +214,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].codeFlows[0].threadFlows[0].locations[0].location.message.markdown",
-              "_Rich_ ThreadFlow location message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 124,
-                  "startColumn": 89
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].results[0].message.text",
               "result message without period"
             ]
@@ -395,30 +227,6 @@
                 "region": {
                   "startLine": 57,
                   "startColumn": 51
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].results[0].message.markdown",
-              "_Rich_ result message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 58,
-                  "startColumn": 62
                 }
               }
             }
@@ -454,30 +262,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].stacks[0].frames[0].location.message.markdown",
-              "_Rich_ frame message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 91,
-                  "startColumn": 71
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].results[0].stacks[0].message.text",
               "stack message without period"
             ]
@@ -491,30 +275,6 @@
                 "region": {
                   "startLine": 83,
                   "startColumn": 54
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].results[0].stacks[0].message.markdown",
-              "_Rich_ stack message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 84,
-                  "startColumn": 65
                 }
               }
             }
@@ -550,30 +310,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].results[0].fixes[0].description.markdown",
-              "_Rich_ fix description without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 158,
-                  "startColumn": 67
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].invocations[0].toolExecutionNotifications[0].message.text",
               "toolNotification message without period"
             ]
@@ -587,30 +323,6 @@
                 "region": {
                   "startLine": 35,
                   "startColumn": 65
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].invocations[0].toolExecutionNotifications[0].message.markdown",
-              "_Rich_ toolNotification message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 36,
-                  "startColumn": 76
                 }
               }
             }
@@ -646,30 +358,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].invocations[0].toolConfigurationNotifications[0].message.markdown",
-              "_Rich_ configuratioNotification message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 44,
-                  "startColumn": 84
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].tool.driver.rules[0].messageStrings.Default.text",
               "rule message without period"
             ]
@@ -683,30 +371,6 @@
                 "region": {
                   "startLine": 22,
                   "startColumn": 55
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].tool.driver.rules[0].messageStrings.Default.markdown",
-              "_Rich_ rule message without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 23,
-                  "startColumn": 66
                 }
               }
             }
@@ -742,30 +406,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "runs[0].tool.driver.rules[0].shortDescription.markdown",
-              "_Rich_ short rule description without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 14,
-                  "startColumn": 74
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
               "runs[0].tool.driver.rules[0].fullDescription.text",
               "Short full rule description without period"
             ]
@@ -779,30 +419,6 @@
                 "region": {
                   "startLine": 17,
                   "startColumn": 68
-                }
-              }
-            }
-          ]
-        },
-        {
-          "ruleId": "SARIF1008",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "runs[0].tool.driver.rules[0].fullDescription.markdown",
-              "_Rich_ full rule description without period"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "index": 0
-                },
-                "region": {
-                  "startLine": 18,
-                  "startColumn": 73
                 }
               }
             }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -14,11 +14,14 @@
                 "text": "In the artifactLocation objects contained in run."
               },
               "fullDescription": {
-                "text": "In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent."
+                "text": "In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent. Also, uri must end with a slash, so that it can safely be combined with the relative URIs in artifactLocation objects elsewhere in the log file."
               },
               "messageStrings": {
-                "Default": {
-                  "text": "In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but uri is '{0}', which is a relative URI."
+                "NotAbsolute": {
+                  "text": "In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property '{0}' is not an absolute URI."
+                },
+                "LacksTrailingSlash": {
+                  "text": "In this artifactLocation object contained in run.originalUriBaseIds, the uri property '{0}' does not end with a slash."
                 }
               },
               "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html"
@@ -45,10 +48,35 @@
           "ruleIndex": 0,
           "level": "error",
           "message": {
-            "id": "Default",
+            "id": "NotAbsolute",
             "arguments": [
               "runs[0].originalUriBaseIds.PROJECT_ROOT",
-              "project/"
+              "project"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 12,
+                  "startColumn": 25
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1018",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "LacksTrailingSlash",
+            "arguments": [
+              "runs[0].originalUriBaseIds.PROJECT_ROOT",
+              "project"
             ]
           },
           "locations": [

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -18,10 +18,10 @@
               },
               "messageStrings": {
                 "NotAbsolute": {
-                  "text": "In this artifactLocation object contained in run.originalUriBaseIds, uriBaseId is absent, but the uri property '{0}' is not an absolute URI."
+                  "text": "{0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds is not an absolute URI."
                 },
                 "LacksTrailingSlash": {
-                  "text": "In this artifactLocation object contained in run.originalUriBaseIds, the uri property '{0}' does not end with a slash."
+                  "text": "{0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds does not end with a slash."
                 }
               },
               "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html"
@@ -51,7 +51,8 @@
             "id": "NotAbsolute",
             "arguments": [
               "runs[0].originalUriBaseIds.PROJECT_ROOT",
-              "project"
+              "project",
+              "PROJECT_ROOT"
             ]
           },
           "locations": [
@@ -76,7 +77,8 @@
             "id": "LacksTrailingSlash",
             "arguments": [
               "runs[0].originalUriBaseIds.PROJECT_ROOT",
-              "project"
+              "project",
+              "PROJECT_ROOT"
             ]
           },
           "locations": [

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1003.UrisMustBeValid_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1003.UrisMustBeValid_Valid.sarif
@@ -28,7 +28,7 @@
         }
       },
       "originalUriBaseIds": {
-        "SRCROOT": "file:///c:/Code/sarif-sdk/src"
+        "SRCROOT": "file:///c:/Code/sarif-sdk/src/"
       },
       "resources": {
         "rules": {

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -11,9 +11,9 @@
       "originalUriBaseIds": {
         "PROJECT_ROOT": {
           "description": {
-            "text": "This artifactLocation has no uriBaseId, so its uri, if present, must be absolute. But it isn't."
+            "text": "This artifactLocation has no uriBaseId, so its uri, if present, must be absolute. But it isn't. It also doesn't end with a slash."
           },
-          "uri": "project/"
+          "uri": "project"
         }
       },
       "results": [],


### PR DESCRIPTION
Also:
- Fix #1860: Don't require Markdown messages to end with a period.