### PR TITLE
NPM Non-Trimmed, DeferredList fix

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,6 +2,8 @@
 
 ## **v2.2.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.4)
 * BUGFIX: Validation rule SARIF1018 was not checking for a trailing slash on `uri` properties in `originalUriBaseIds` if `uriBaseId` was present.
+* BUGFIX: Build Sarif.Multitool NPM package non-trimmed to avoid more assembly load problems.
+* FEATURE: DeferredList will cache last item returned and won't throw if same instance written. (SarifRewritingVisitor + Deferred OM usable)
 
 ## **v2.2.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.3)
 * FEATURE: Introduce `SarifConstants.SarifFileExtension` with value `".sarif"`.

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -11,10 +11,11 @@
       We use [Condition="'$(RuntimeIdentifier)' != ''"] to identify settings used only for these builds.      
     -->
 
-    <!-- Publish trimmed single-file exe -->
+    <!-- Publish single-file exe -->
+    <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
+
     <!-- Seeing assembly load failures with trimmed exe, but not without. On some machines, for some commands. :/ -->
     <!-- <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed> -->
-    <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
 
     <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -12,7 +12,8 @@
     -->
 
     <!-- Publish trimmed single-file exe -->
-    <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed>
+    <!-- Seeing assembly load failures with trimmed exe, but not without. On some machines, for some commands. :/ -->
+    <!-- <PublishTrimmed Condition="'$(RuntimeIdentifier)' != ''">true</PublishTrimmed> -->
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
 
     <!-- Publish 'ready-to-run' on Windows (Linux/Mac not yet supported) -->


### PR DESCRIPTION
An NPM build configuration fix to try to unblock Gabriel for a demo, and a small fix to DeferredList to make it work with SarifRewritingVisitor. (Feature request: Generate a parallel visitor for non-mutating traversal of the log. VisitX would return void and the generated calling methods would not try to set instances to any new values).