### PR TITLE
creating results tag if results is empty

### DIFF
--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -258,8 +258,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 if ((_writeConditions & Conditions.ResultsInitialized) != Conditions.ResultsInitialized)
                 {
                     OpenResults();
-                    CloseResults();
                 }
+
+                CloseResults();
             }            
         }
 

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -255,7 +255,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
             }
             else
             {
-                OpenResults();
+                if ((_writeConditions & Conditions.ResultsInitialized) != Conditions.ResultsInitialized)
+                {
+                    OpenResults();
+                }
 
                 CloseResults();
             }            

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.Writers
@@ -245,10 +246,19 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 throw new ArgumentNullException(nameof(results));
             }
 
-            foreach (Result result in results)
+            if (results.Any())
             {
-                WriteResult(result);
+                foreach (Result result in results)
+                {
+                    WriteResult(result);
+                }
             }
+            else
+            {
+                OpenResults();
+
+                CloseResults();
+            }            
         }
 
         public void CloseResults()

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -258,9 +258,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 if ((_writeConditions & Conditions.ResultsInitialized) != Conditions.ResultsInitialized)
                 {
                     OpenResults();
+                    CloseResults();
                 }
-
-                CloseResults();
             }            
         }
 

--- a/src/Sarif/Writers/ResultLogJsonWriter.cs
+++ b/src/Sarif/Writers/ResultLogJsonWriter.cs
@@ -259,8 +259,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 {
                     OpenResults();
                 }
-
-                CloseResults();
             }            
         }
 

--- a/src/Test.UnitTests.Sarif/JsonTests.cs
+++ b/src/Test.UnitTests.Sarif/JsonTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             return result.ToString();
         }
 
-        protected static SarifLog CreateCurrentV2SarifLog(int resultCount = 0)
+        protected static SarifLog CreateCurrentV2SarifLog(int resultCount = 0, bool createResultsTag = false)
         {
             var sarifLog = new SarifLog
             {
@@ -50,9 +50,13 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
             };
 
+            if (createResultsTag || resultCount > 0)
+            {
+                sarifLog.Runs[0].Results = new List<Result>();
+            }
+
             for (int i = 0; i < resultCount; i++)
             {
-                sarifLog.Runs[0].Results = sarifLog.Runs[0].Results ?? new List<Result>();
                 var result = new Result
                 {
                     Message = new Message
@@ -66,9 +70,9 @@ namespace Microsoft.CodeAnalysis.Sarif
             return sarifLog;
         }
 
-        protected static string CreateCurrentV2SarifLogText(int resultCount = 0, Action<SarifLog> sarifLogAction = null)
+        protected static string CreateCurrentV2SarifLogText(int resultCount = 0, Action<SarifLog> sarifLogAction = null, bool createResultsTag = false)
         {
-            SarifLog sarifLog = CreateCurrentV2SarifLog(resultCount);
+            SarifLog sarifLog = CreateCurrentV2SarifLog(resultCount, createResultsTag);
 
             sarifLogAction?.Invoke(sarifLog);
 

--- a/src/Test.UnitTests.Sarif/Writers/ResultLogJsonWriterTests.cs
+++ b/src/Test.UnitTests.Sarif/Writers/ResultLogJsonWriterTests.cs
@@ -29,6 +29,21 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
         }
 
         [Fact]
+        public void ResultLogJsonWriter_AcceptsEmptyResultList()
+        {
+            string expected = CreateCurrentV2SarifLogText(resultCount: 0, null, true);
+
+            string actual = GetJson(uut =>
+            {
+                var run = new Run() { Tool = DefaultTool };
+                uut.Initialize(run);
+                uut.WriteResults(new Result[0]);
+            });
+
+            actual.Should().BeCrossPlatformEquivalent<SarifLog>(expected);
+        }
+
+        [Fact]
         public void ResultLogJsonWriter_DoNotInitializeMoreThanOnce()
         {
             Assert.Throws<InvalidOperationException>(() =>


### PR DESCRIPTION
Refs #1821

- created new unit test to test empty result if empty result list is written
- changed `CreateCurrentV2SarifLog` method to enable the creation when we pass a boolean or if we have count > 0