### PR TITLE
Update release history and version number.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.2.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.6)
+* BUGFIX: `ResultLogJsonWriter` now creates an empty `results` array if there are no results, rather than leaving `results` as `null`. [#1821](https://github.com/microsoft/sarif-sdk/issues/1821)
+
 ## **v2.2.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.5)
 * BUGFIX: Fix SDK doubling Uris with certain escaped characters (ex: '-' and '_') on every Load/Save cycle (cause: https://github.com/dotnet/runtime/issues/36288)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,8 +2,8 @@
 
 ## **v2.2.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.6)
 * BUGFIX: `ResultLogJsonWriter` now creates an empty `results` array if there are no results, rather than leaving `results` as `null`. [#1821](https://github.com/microsoft/sarif-sdk/issues/1821)
-* BUGFIX: Run.Tool.Driver.Rules shotDescription now uses GetFirstSentence method [#1887](https://github.com/microsoft/sarif-sdk/issues/1887)
-* FEATURE: Add validation rule SARIF1019, which will require that n every result, at least one of the properties result.ruleId and result.rule.id must be present. If both are present, they must be equal. [#1880](https://github.com/microsoft/sarif-sdk/issues/1880)
+* BUGFIX: In validation rules, `shortDescription` is now calculated by `GetFirstSentence` method, fixing a bug in sentence breaking. [#1887](https://github.com/microsoft/sarif-sdk/issues/1887)
+* FEATURE: Add validation rule `SARIF1019`, which requires every result to have at least one of `result.ruleId` and `result.rule.id`. If both are present, they must be equal. [#1880](https://github.com/microsoft/sarif-sdk/issues/1880)
 
 ## **v2.2.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.5)
 * BUGFIX: Fix SDK doubling Uris with certain escaped characters (ex: '-' and '_') on every Load/Save cycle (cause: https://github.com/dotnet/runtime/issues/36288)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -2,6 +2,8 @@
 
 ## **v2.2.6** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.6) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.6) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.6) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.6)
 * BUGFIX: `ResultLogJsonWriter` now creates an empty `results` array if there are no results, rather than leaving `results` as `null`. [#1821](https://github.com/microsoft/sarif-sdk/issues/1821)
+* BUGFIX: Run.Tool.Driver.Rules shotDescription now uses GetFirstSentence method [#1887](https://github.com/microsoft/sarif-sdk/issues/1887)
+* FEATURE: Add validation rule SARIF1019, which will require that n every result, at least one of the properties result.ruleId and result.rule.id must be present. If both are present, they must be equal. [#1880](https://github.com/microsoft/sarif-sdk/issues/1880)
 
 ## **v2.2.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.5)
 * BUGFIX: Fix SDK doubling Uris with certain escaped characters (ex: '-' and '_') on every Load/Save cycle (cause: https://github.com/dotnet/runtime/issues/36288)

--- a/src/build.props
+++ b/src/build.props
@@ -20,12 +20,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <!-- 
-      NOTE: Version in scripts/BuildMultitoolForNpm.ps1 also has to be updated for each release
-      until it adopts the same versions as the SDK itself.
-    -->
-    <VersionPrefix>2.2.5</VersionPrefix>
-    <PreviousVersionPrefix>2.2.4</PreviousVersionPrefix>
+    <VersionPrefix>2.2.6</VersionPrefix>
+    <PreviousVersionPrefix>2.2.5</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
Update release history for change made by @eddynaka, and bump the version number.

Also:
- Remove an obsolete comment in build props. The script BuildMultitoolForNpm.ps1 now [automatically tracks](https://github.com/microsoft/sarif-sdk/blob/75592fc8346809f36e093f79fc66bb84f4bb28cd/scripts/BuildMultitoolForNpm.ps1#L52) the SDK version number.