### PR TITLE
updating shouldSerializeText return

### DIFF
--- a/src/Sarif/Core/ReportingDescriptor.cs
+++ b/src/Sarif/Core/ReportingDescriptor.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return this.DeprecatedNames.HasAtLeastOneNonNullValue();
         }
 
+        public bool ShouldSerializeFullDescription()
+        {
+            return this.FullDescription.HasAtLeastOneNonNullEmptyValue();
+        }
+
         public bool ShouldSerializeRelationships()
         {
             return this.Relationships.HasAtLeastOneNonDefaultValue(ReportingDescriptorRelationship.ValueComparer);

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -40,6 +40,11 @@ namespace Microsoft.CodeAnalysis.Sarif
             return collection != null && collection.Any((m) => m != null);
         }
 
+        public static bool HasAtLeastOneNonNullEmptyValue(this MultiformatMessageString multiformatMessageString)
+        {
+            return !string.IsNullOrEmpty(multiformatMessageString?.Text);
+        }
+
         public static bool HasAtLeastOneNonDefaultValue<T>(this IEnumerable<T> collection, IEqualityComparer<T> comparer) where T : new()
         {
             var defaultInstance = new T();

--- a/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
+++ b/src/Test.FunctionalTests.Sarif/SarifConverterTests.cs
@@ -2,6 +2,7 @@
 // license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -88,6 +89,45 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         public void PyLintConverter_EndToEnd()
         {
             BatchRunConverter(ToolFormat.Pylint, "*.json");
+        }
+
+        [Fact]
+        public void JsonConvert_EndToEnd()
+        {
+            var sarifLog = new SarifLog
+            {
+                Runs = new List<Run>
+                {
+                    new Run
+                    {
+                        Tool = new Tool
+                        {
+                            Driver = new ToolComponent
+                            {
+                                Name = "DefaultTool",
+                                Rules = new List<ReportingDescriptor>
+                                {
+                                    new ReportingDescriptor
+                                    {
+                                        FullDescription = new MultiformatMessageString
+                                        {
+                                            Text = null
+                                        }
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            };
+
+            string jsonSarifLog = JsonConvert.SerializeObject(sarifLog);
+
+            SarifLog newSarifLog = JsonConvert.DeserializeObject<SarifLog>(jsonSarifLog);
+
+            string newJsonSarifLog = JsonConvert.SerializeObject(newSarifLog);
+
+            Assert.Equal(jsonSarifLog, newJsonSarifLog);
         }
 
         private readonly ToolFormatConverter converter = new ToolFormatConverter();


### PR DESCRIPTION
Refs #1740

- updating ShouldSerializeText so we could be able to Deserialize and Serialize sarifLog without problem if FullDescription.text is null

@lgolding , i thought in create a new test getting a default sariflog that we have in the repository, setting the FullDescription.Text to null -> serialize -> desserialize -> serialize again.
The expect would be to work. The question is: where should I create that file?