### PR TITLE
updating method to create correct short description

### DIFF
--- a/src/Sarif.Driver/Sdk/Skimmer.cs
+++ b/src/Sarif.Driver/Sdk/Skimmer.cs
@@ -13,15 +13,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
         {
             this.Options = new Dictionary<string, string>();
         }
+
         private IDictionary<string, MultiformatMessageString> multiformatMessageStrings;
 
-        virtual protected ResourceManager ResourceManager => null;
+        protected virtual ResourceManager ResourceManager => null;
 
-        virtual protected IEnumerable<string> MessageResourceNames => throw new NotImplementedException();
+        protected virtual IEnumerable<string> MessageResourceNames => throw new NotImplementedException();
 
         virtual public FailureLevel DefaultLevel { get { return FailureLevel.Warning; } }
 
-        override public IDictionary<string, MultiformatMessageString> MessageStrings
+        public override IDictionary<string, MultiformatMessageString> MessageStrings
         {
             get
             {
@@ -43,38 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
         public override MultiformatMessageString FullDescription => throw new InvalidOperationException($"The {nameof(FullDescription)} property must be overridden in the SkimmerBase-derived class.");
 
-        public override MultiformatMessageString ShortDescription
-        {
-            get { return new MultiformatMessageString { Text = FirstSentence(FullDescription.Text) }; }
-        }
-
-        internal static string FirstSentence(string fullDescription)
-        {
-            int charCount = 0;
-            bool withinApostrophe = false;
-
-            foreach (char ch in fullDescription)
-            {
-                charCount++;
-                switch (ch)
-                {
-                    case '\'':
-                    {
-                        withinApostrophe = !withinApostrophe;
-                        continue;
-                    }
-
-                    case '.':
-                    {
-                        if (withinApostrophe) { continue; }
-                        return fullDescription.Substring(0, charCount);
-                    }
-                }
-            }
-            int length = Math.Min(fullDescription.Length, 80);
-            bool truncated = length < fullDescription.Length;
-            return fullDescription.Substring(0, length) + (truncated ? "..." : "");
-        }
+        public override MultiformatMessageString ShortDescription => new MultiformatMessageString { Text = ExtensionMethods.GetFirstSentence(FullDescription.Text) };
 
         public override string Name => this.GetType().Name;
 

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1001.DoNotUseFriendlyNameAsRuleId_Invalid.sarif
@@ -11,7 +11,7 @@
               "id": "SARIF1001",
               "name": "DoNotUseFriendlyNameAsRuleId",
               "shortDescription": {
-                "text": "Do not use the same string for a rule's id and name properties. The id property ..."
+                "text": "Do not use the same string for a rule's id and name properties."
               },
               "fullDescription": {
                 "text": "Do not use the same string for a rule's id and name properties. The id property must be a stable, opaque identifer such as \"SARIF1001\". The name property should be a string that is understandable to an end user, such as \"DoNotUserFriendlyNameAsRuleId\"."

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1018.InvalidUriInOriginalUriBaseIds_Invalid.sarif
@@ -11,7 +11,7 @@
               "id": "SARIF1018",
               "name": "InvalidUriInOriginalUriBaseIds",
               "shortDescription": {
-                "text": "In the artifactLocation objects contained in run."
+                "text": "In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent."
               },
               "fullDescription": {
                 "text": "In the artifactLocation objects contained in run.originalUriBaseIds, if uriBaseId is absent, then uri must either be an absolute URI or it must be absent. Also, uri must end with a slash, so that it can safely be combined with the relative URIs in artifactLocation objects elsewhere in the log file."

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1019.RuleIdMustBePresentAndConsistent_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1019.RuleIdMustBePresentAndConsistent_Invalid.sarif
@@ -11,7 +11,7 @@
               "id": "SARIF1019",
               "name": "RuleIdMustBePresentAndConsistent",
               "shortDescription": {
-                "text": "In every result, at least one of the properties result."
+                "text": "In every result, at least one of the properties result.ruleId and result.rule.id must be present."
               },
               "fullDescription": {
                 "text": "In every result, at least one of the properties result.ruleId and result.rule.id must be present. If both are present, they must be equal."

--- a/src/Test.UnitTests.Sarif/ExtensionsTests.cs
+++ b/src/Test.UnitTests.Sarif/ExtensionsTests.cs
@@ -401,6 +401,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         [InlineData("Abbreviations such as approx. don't fool us.", "Abbreviations such as approx. don't fool us.")]
         // Expected bad output cases
         [InlineData("no space after period.cannot return good sentence.", "no space after period.cannot return good sentence.")]
+        [InlineData("In every result, at least one of the properties result.ruleId and result.rule.id must be present. If both are present, they must be equal.", "In every result, at least one of the properties result.ruleId and result.rule.id must be present.")]
         public void Extensions_ExtractsFirstSentenceProperly(string input, string expected)
         {
             string actual = ExtensionMethods.GetFirstSentence(input);


### PR DESCRIPTION
Refs #1887

Changes:
- updating Skimmer to `GetFirstSentence` based on ExtensionMethods
- adding a new test to `GetFirstSentence` to double check the result
- updating output results to be correct based on the new `GetFirstSentence` method
- removing unused method
- updating some patterns and spacing in Skimmer file