### PR TITLE
Improving GitHub issue creation

### DIFF
--- a/src/WorkItems/GitHubClientWrapper.cs
+++ b/src/WorkItems/GitHubClientWrapper.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
-using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
-using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
 using Octokit;
 
 namespace Microsoft.WorkItems
 {
     internal class GitHubClientWrapper : IGitHubClientWrapper
     {
-        private GitHubClient gitHubClient;
+        private readonly GitHubClient gitHubClient;
 
         public GitHubClientWrapper(GitHubClient gitHubClient)
         {
@@ -36,6 +31,5 @@ namespace Microsoft.WorkItems
         {
             return this.gitHubClient.Issue.Update(organization, repository, issueNumber, issueUpdate);
         }
-
     }
 }

--- a/src/WorkItems/GitHubFilingClient.cs
+++ b/src/WorkItems/GitHubFilingClient.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Services.WebApi;
 using Octokit;
-using Octokit.Internal;
 
 namespace Microsoft.WorkItems
 {
@@ -31,33 +29,21 @@ namespace Microsoft.WorkItems
             {
                 var newIssue = new NewIssue(workItemModel.Title)
                 {
-                    Body = workItemModel.BodyOrDescription,
+                    Body = workItemModel.BodyOrDescription
                 };
+
+                if (workItemModel.LabelsOrTags?.Count != 0)
+                {
+                    foreach (string tag in workItemModel.LabelsOrTags)
+                    {
+                        newIssue.Labels.Add(tag);
+                    }
+                }
 
                 Issue issue = await _gitHubClient.CreateWorkItemAsync(
                     this.AccountOrOrganization,
                     this.ProjectOrRepository,
                     newIssue);
-
-                // TODO: Can we collapse GH issue creation to a single operation?
-                // 
-                // https://github.com/microsoft/sarif-sdk/issues/1790
-
-                if (workItemModel.LabelsOrTags?.Count != 0)
-                {
-                    var issueUpdate = new IssueUpdate();
-
-                    foreach (string tag in workItemModel.LabelsOrTags)
-                    {
-                        issueUpdate.AddLabel(tag);
-                    }
-
-                    await _gitHubClient.UpdateWorkItemAsync(
-                        this.AccountOrOrganization,
-                        this.ProjectOrRepository,
-                        issue.Number,
-                        issueUpdate);
-                }
 
                 workItemModel.Uri = new Uri(issue.Url, UriKind.Absolute);
                 workItemModel.HtmlUri = new Uri(issue.HtmlUrl, UriKind.Absolute);


### PR DESCRIPTION
Closes #1790 

Changes:
- changing modifier and cleaning unused namespaces
- changing logic to make only one request to create issue with labels