### PR TITLE
Incremental baselining fix

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,6 +6,8 @@
 * BUGFIX: `WorkItemFiler` now logs correctly the details for `LogMetricsForProcessedModel` method [#1896](https://github.com/microsoft/sarif-sdk/issues/1896)
 * FEATURE: Add validation rule `SARIF1019`, which requires every result to have at least one of `result.ruleId` and `result.rule.id`. If both are present, they must be equal. [#1880](https://github.com/microsoft/sarif-sdk/issues/1880)
 * FEATURE: Add validation rule `SARIF1020`, which requires that the $schema property should be present, and must refer to the final version of the SARIF 2.1.0 schema.  [#1890](https://github.com/microsoft/sarif-sdk/issues/1890)
+* FEATURE: Expose Run.MergeResultsFrom(Run) to merge Results from multiple Runs using code from result matching algorithm.
+* BREAKING: Rename 'RemapIndicesVisitor' to 'RunMergingVisitor' and redesign to control how much merging occurs internally.
 
 ## **v2.2.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.5)
 * BUGFIX: Fix SDK doubling Uris with certain escaped characters (ex: '-' and '_') on every Load/Save cycle (cause: https://github.com/dotnet/runtime/issues/36288)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,8 +6,8 @@
 * BUGFIX: `WorkItemFiler` now logs correctly the details for `LogMetricsForProcessedModel` method [#1896](https://github.com/microsoft/sarif-sdk/issues/1896)
 * FEATURE: Add validation rule `SARIF1019`, which requires every result to have at least one of `result.ruleId` and `result.rule.id`. If both are present, they must be equal. [#1880](https://github.com/microsoft/sarif-sdk/issues/1880)
 * FEATURE: Add validation rule `SARIF1020`, which requires that the $schema property should be present, and must refer to the final version of the SARIF 2.1.0 schema.  [#1890](https://github.com/microsoft/sarif-sdk/issues/1890)
-* FEATURE: Expose Run.MergeResultsFrom(Run) to merge Results from multiple Runs using code from result matching algorithm.
-* BREAKING: Rename 'RemapIndicesVisitor' to 'RunMergingVisitor' and redesign to control how much merging occurs internally.
+* FEATURE: Expose `Run.MergeResultsFrom(Run)` to merge Results from multiple Runs using code from result matching algorithm.
+* BREAKING: Rename `RemapIndicesVisitor` to `RunMergingVisitor` and redesign to control how much merging occurs internally.
 
 ## **v2.2.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.2.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.2.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.2.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.2.5)
 * BUGFIX: Fix SDK doubling Uris with certain escaped characters (ex: '-' and '_') on every Load/Save cycle (cause: https://github.com/dotnet/runtime/issues/36288)

--- a/src/Sarif/Core/Run.cs
+++ b/src/Sarif/Core/Run.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 
 using Microsoft.CodeAnalysis.Sarif.Readers;
+using Microsoft.CodeAnalysis.Sarif.Visitors;
 
 namespace Microsoft.CodeAnalysis.Sarif
 {
@@ -171,6 +172,17 @@ namespace Microsoft.CodeAnalysis.Sarif
                     }
                 }
             }
+        }
+
+        public void MergeResultsFrom(Run additional)
+        {
+            // Merge Results from the two Runs, building shared collections of result-referenced things
+            var visitor = new RunMergingVisitor();
+
+            visitor.VisitRun(this);
+            visitor.VisitRun(additional);
+
+            visitor.PopulateWithMerged(this);
         }
 
         public bool ShouldSerializeColumnKind()

--- a/src/Sarif/Visitors/RunMergingVisitor.cs
+++ b/src/Sarif/Visitors/RunMergingVisitor.cs
@@ -25,14 +25,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
     /// </remarks>
     public class RunMergingVisitor : SarifRewritingVisitor
     {
-        private List<Result> Results { get; set; }
-        private List<Artifact> Artifacts { get; set; }
-        private List<LogicalLocation> LogicalLocations { get; set; }
-        private List<ReportingDescriptor> Rules { get; set; }
+        private List<Result> Results { get; }
+        private List<Artifact> Artifacts { get; }
+        private List<LogicalLocation> LogicalLocations { get; }
+        private List<ReportingDescriptor> Rules { get; }
 
-        private Dictionary<string, int> RuleIdToIndex { get; set; }
-        private Dictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int> LogicalLocationToIndex { get; set; }
-        private Dictionary<OrderSensitiveValueComparisonList<Artifact>, int> ArtifactToIndex { get; set; }
+        private Dictionary<string, int> RuleIdToIndex { get; }
+        private Dictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int> LogicalLocationToIndex { get; }
+        private Dictionary<OrderSensitiveValueComparisonList<Artifact>, int> ArtifactToIndex { get; }
 
         public Run CurrentRun { get; set; }
 

--- a/src/Sarif/Visitors/RunMergingVisitor.cs
+++ b/src/Sarif/Visitors/RunMergingVisitor.cs
@@ -1,82 +1,113 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Sarif.Visitors
 {
     /// <summary>
-    /// This class is used to update indices for data that is merged for various
-    /// reasons, including result matching operations.
+    ///  RunMergingVisitor merges Results from multiple Runs. 
+    ///  It gathers things referenced by the Results, remaps indices in the Results to the merged collections,
+    ///  and then populates the desired run with the merged sets.
+    ///  
+    ///  Used by Baselining and Run.MergeResultFrom(Run).
     /// </summary>
-    public class RemapIndicesVisitor : SarifRewritingVisitor
+    /// <remarks>
+    ///  Usage:
+    ///   var visitor = new RunMergingVisitor();
+    ///   
+    ///   visitor.VisitRun(primary);
+    ///   visitor.VisitRun(additional);
+    ///   
+    ///   visitor.PopulateMergedRun(primary);
+    /// </remarks>
+    public class RunMergingVisitor : SarifRewritingVisitor
     {
-        public RemapIndicesVisitor(
-            IList<Artifact> currentArtifacts,
-            IList<LogicalLocation> currentLogicalLocations)
-        {
-            CurrentArtifacts = new List<Artifact>();
-            CurrentLogicalLocations = new List<LogicalLocation>();
+        private List<Result> Results { get; set; }
+        private List<Artifact> Artifacts { get; set; }
+        private List<LogicalLocation> LogicalLocations { get; set; }
+        private List<ReportingDescriptor> Rules { get; set; }
 
-            RemapCurrentArtifacts(currentArtifacts);
-            RemapCurrentLogicalLocations(currentLogicalLocations);
+        private Dictionary<string, int> RuleIdToIndex { get; set; }
+        private Dictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int> LogicalLocationToIndex { get; set; }
+        private Dictionary<OrderSensitiveValueComparisonList<Artifact>, int> ArtifactToIndex { get; set; }
+
+        public Run CurrentRun { get; set; }
+
+        public RunMergingVisitor()
+        {
+            Results = new List<Result>();
+            Artifacts = new List<Artifact>();
+            LogicalLocations = new List<LogicalLocation>();
+            Rules = new List<ReportingDescriptor>();
+
+            RuleIdToIndex = new Dictionary<string, int>();
+            LogicalLocationToIndex = new Dictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int>();
+            ArtifactToIndex = new Dictionary<OrderSensitiveValueComparisonList<Artifact>, int>();
         }
 
-        private void RemapCurrentArtifacts(IList<Artifact> currentArtifacts)
+        public void PopulateWithMerged(Run targetRun)
         {
-            RemappedArtifacts = new Dictionary<OrderSensitiveValueComparisonList<Artifact>, int>();
+            targetRun.Results = Results;
+            targetRun.Artifacts = Artifacts;
+            targetRun.LogicalLocations = LogicalLocations;
 
-            if (currentArtifacts != null)
-            {
-                foreach (Artifact artifact in currentArtifacts)
-                {
-                    CacheArtifact(artifact, currentArtifacts);
-                }
-            }
+            targetRun.Tool ??= new Tool();
+            targetRun.Tool.Driver ??= new ToolComponent();
+            targetRun.Tool.Driver.Rules = Rules;
         }
 
-        private void RemapCurrentLogicalLocations(IList<LogicalLocation> currentLogicalLocations)
+        public override Run VisitRun(Run node)
         {
-            RemappedLogicalLocations = new Dictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int>();
+            // Set CurrentRun, Visit Results, Clear Current Run
+            CurrentRun = node;
+            Run result = base.VisitRun(node);
+            CurrentRun = null;
 
-            if (currentLogicalLocations != null)
-            {
-                foreach (LogicalLocation logicalLocation in currentLogicalLocations)
-                {
-                    CacheLogicalLocation(logicalLocation, currentLogicalLocations);
-                }
-            }
+            return result;
         }
-
-        public IList<Artifact> CurrentArtifacts { get; set; }
-
-        public IList<LogicalLocation> CurrentLogicalLocations { get; set; }
-
-        public IList<Artifact> HistoricalFiles { get; set; }
-
-        public IList<LogicalLocation> HistoricalLogicalLocations { get; set; }
-
-        public IDictionary<OrderSensitiveValueComparisonList<LogicalLocation>, int> RemappedLogicalLocations { get; private set; }
-
-        public IDictionary<OrderSensitiveValueComparisonList<Artifact>, int> RemappedArtifacts { get; private set; }
 
         public override Result VisitResult(Result node)
         {
             // We suspend the visit if there's insufficient data to perform any work
-            if (HistoricalFiles == null && HistoricalLogicalLocations == null)
+            if (CurrentRun == null)
             {
-                return node;
+                throw new InvalidOperationException($"RemapIndicesVisitor requires CurrentRun to be set before Visiting Results.");
             }
 
-            return base.VisitResult(node);
+            // Cache RuleId and set Result.RuleIndex to the (new) index
+            string ruleId = node.ResolvedRuleId(CurrentRun);
+            if (!string.IsNullOrEmpty(ruleId))
+            {
+                if (RuleIdToIndex.TryGetValue(ruleId, out int ruleIndex))
+                {
+                    node.RuleIndex = ruleIndex;
+                }
+                else
+                {
+                    ReportingDescriptor rule = node.GetRule(CurrentRun);
+                    int newIndex = Rules.Count;
+                    Rules.Add(rule);
+
+                    RuleIdToIndex[ruleId] = newIndex;
+                    node.RuleIndex = newIndex;
+                }
+
+                node.RuleId = ruleId;
+            }
+
+            Result result = base.VisitResult(node);
+            Results.Add(result);
+            return result;
         }
 
         public override LogicalLocation VisitLogicalLocation(LogicalLocation node)
         {
-            if (node.Index != -1 && HistoricalLogicalLocations != null)
+            if (node.Index != -1 && CurrentRun.LogicalLocations != null)
             {
-                node.Index = CacheLogicalLocation(HistoricalLogicalLocations[node.Index], HistoricalLogicalLocations);
+                node.Index = CacheLogicalLocation(CurrentRun.LogicalLocations[node.Index], CurrentRun.LogicalLocations);
             }
 
             return base.VisitLogicalLocation(node);
@@ -93,15 +124,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 logicalLocation.ParentIndex = CacheLogicalLocation(currentLogicalLocations[parentIndex], currentLogicalLocations);
             }
 
-            OrderSensitiveValueComparisonList<LogicalLocation> logicalLocationChain = ConstructLogicalLocationsChain(logicalLocation, CurrentLogicalLocations);
+            OrderSensitiveValueComparisonList<LogicalLocation> logicalLocationChain = ConstructLogicalLocationsChain(logicalLocation, LogicalLocations);
 
-            if (!RemappedLogicalLocations.TryGetValue(logicalLocationChain, out int remappedIndex))
+            if (!LogicalLocationToIndex.TryGetValue(logicalLocationChain, out int remappedIndex))
             {
-                remappedIndex = RemappedLogicalLocations.Count;
+                remappedIndex = LogicalLocationToIndex.Count;
                 logicalLocation.Index = remappedIndex;
 
-                this.CurrentLogicalLocations.Add(logicalLocation);
-                RemappedLogicalLocations[logicalLocationChain] = remappedIndex;
+                this.LogicalLocations.Add(logicalLocation);
+                LogicalLocationToIndex[logicalLocationChain] = remappedIndex;
             }
 
             return remappedIndex;
@@ -109,9 +140,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
         public override ArtifactLocation VisitArtifactLocation(ArtifactLocation node)
         {
-            if (node.Index != -1 && HistoricalFiles != null)
+            if (node.Index != -1 && CurrentRun.Artifacts != null)
             {
-                node.Index = CacheArtifact(HistoricalFiles[node.Index], HistoricalFiles);
+                node.Index = CacheArtifact(CurrentRun.Artifacts[node.Index], CurrentRun.Artifacts);
             }
 
             return base.VisitArtifactLocation(node);
@@ -133,16 +164,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             // Equally important, the artifact chain is a specially constructed key that
             // operates against the newly constructed files array in CurrentArtifacts.
-            OrderSensitiveValueComparisonList<Artifact> artifactChain = ConstructArtifactsChain(artifact, CurrentArtifacts);
+            OrderSensitiveValueComparisonList<Artifact> artifactChain = ConstructArtifactsChain(artifact, Artifacts);
 
-            if (!RemappedArtifacts.TryGetValue(artifactChain, out int remappedIndex))
+            if (!ArtifactToIndex.TryGetValue(artifactChain, out int remappedIndex))
             {
-                remappedIndex = RemappedArtifacts.Count;
+                remappedIndex = ArtifactToIndex.Count;
 
-                this.CurrentArtifacts.Add(artifact);
-                RemappedArtifacts[artifactChain] = remappedIndex;
+                this.Artifacts.Add(artifact);
+                ArtifactToIndex[artifactChain] = remappedIndex;
 
-                Debug.Assert(RemappedArtifacts.Count == this.CurrentArtifacts.Count);
+                Debug.Assert(ArtifactToIndex.Count == this.Artifacts.Count);
 
                 if (artifact.Location != null)
                 {


### PR DESCRIPTION
With Jeremiah, added Run.MergeResultsFrom(Run), exposing the logic the baseliner uses to merge results. This will allow us to implement incremental run baselining in the SarifBaseliner service.

We've redesigned and renamed the RemapIndicesVisitor class to do this work. The class doesn't have any consumers in the Sarif SDK solution other than baselining, but it is a breaking change. The new name is RunMergingVisitor, which more clearly indicates the purpose, and it now takes a whole Run as the "historical / current" context and has a "Populate" method to add the merged collections to the output run. This will allow it to merge additional collections in the future without further design changes.

NOTE: We altered the baselining property merging behavior in this change. When baselining in "KeepOldest" property merging mode, the old logic would actually keep the old Artifact entirely. It makes sense to use old Result.Properties when merging, but using an old Artifact whole seems wrong. Rather than implementing Artifact property bag merging, we're assuming that behavior is not actually wanted. Please comment if that's not the case.