### PR TITLE
Serialization Consistency fixes

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **v2.3.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.1)
+* BUGFIX: Ensure all DateTimes on object model are using DateTimeConverter consistently.
+* BUGFIX: Fix DateTime roundtripping in properties collections to follow normal DateTime output format.
+* FEATURE: Properties serialization performance improved (~20% faster load when Results use Properties).
+
 ## **v2.3.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.0)
 * BUGFIX: `ResultLogJsonWriter` now creates an empty `results` array if there are no results, rather than leaving `results` as `null`. [#1821](https://github.com/microsoft/sarif-sdk/issues/1821)
 * BUGFIX: In validation rules, `shortDescription` is now calculated by `GetFirstSentence` method, fixing a bug in sentence breaking. [#1887](https://github.com/microsoft/sarif-sdk/issues/1887)

--- a/src/Sarif/Autogenerated/ResultProvenance.cs
+++ b/src/Sarif/Autogenerated/ResultProvenance.cs
@@ -38,12 +38,14 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The Coordinated Universal Time (UTC) date and time at which the result was first detected. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "firstDetectionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
+        [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
         public virtual DateTime FirstDetectionTimeUtc { get; set; }
 
         /// <summary>
         /// The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See "Date/time properties" in the SARIF spec for the required format.
         /// </summary>
         [DataMember(Name = "lastDetectionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
+        [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
         public virtual DateTime LastDetectionTimeUtc { get; set; }
 
         /// <summary>

--- a/src/Sarif/Autogenerated/ThreadFlowLocation.cs
+++ b/src/Sarif/Autogenerated/ThreadFlowLocation.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// The Coordinated Universal Time (UTC) date and time at which this location was executed.
         /// </summary>
         [DataMember(Name = "executionTimeUtc", IsRequired = false, EmitDefaultValue = false)]
+        [JsonConverter(typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter))]
         public virtual DateTime ExecutionTimeUtc { get; set; }
 
         /// <summary>

--- a/src/Sarif/CodeGenHints.json
+++ b/src/Sarif/CodeGenHints.json
@@ -731,6 +731,26 @@
       }
     }
   ],
+  "ResultProvenance.FirstDetectionTimeUtc": [
+    {
+      "kind": "AttributeHint",
+      "arguments": {
+        "namespaceName": "Newtonsoft.Json",
+        "typeName": "JsonConverter",
+        "arguments": [ "typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter)" ]
+      }
+    }
+  ],
+  "ResultProvenance.LastDetectionTimeUtc": [
+    {
+      "kind": "AttributeHint",
+      "arguments": {
+        "namespaceName": "Newtonsoft.Json",
+        "typeName": "JsonConverter",
+        "arguments": [ "typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter)" ]
+      }
+    }
+  ],
   "run": [
     {
       "kind": "BaseTypeHint",
@@ -936,6 +956,16 @@
         "baseTypeNames": [
           "PropertyBagHolder"
         ]
+      }
+    }
+  ],
+  "ThreadFlowLocation.ExecutionTimeUtc": [
+    {
+      "kind": "AttributeHint",
+      "arguments": {
+        "namespaceName": "Newtonsoft.Json",
+        "typeName": "JsonConverter",
+        "arguments": [ "typeof(Microsoft.CodeAnalysis.Sarif.Readers.DateTimeConverter)" ]
       }
     }
   ],

--- a/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/RoundTripping/RoundTripping.sarif
@@ -23,31 +23,12 @@
             "true": true,
             "false": false,
             "null": null,
-            "dateTimeArray": [
-  "2019-09-26T15:52:02",
-  "2019-09-26T15:54",
-  "2019-09-26T15:55:05.1234567"
-],
-            "stringArray": [
-  "Thing One",
-  "Thing Two"
-],
-            "intArray": [
-  54,
-  -54
-],
-            "boolArray": [
-  true,
-  false
-],
-            "nullArray": [
-  null,
-  null
-],
-            "customObject": {
-  "DateTime": "1776-07-04T12:00",
-  "String": "The 4th"
-}
+            "dateTimeArray": ["2019-09-26T15:52:02","2019-09-26T15:54","2019-09-26T15:55:05.1234567"],
+            "stringArray": ["Thing One","Thing Two"],
+            "intArray": [54,-54],
+            "boolArray": [true,false],
+            "nullArray": [null,null],
+            "customObject": {"DateTime":"1776-07-04T12:00","String":"The 4th"}
           }
         }
       ],

--- a/src/build.props
+++ b/src/build.props
@@ -20,8 +20,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.3.0</VersionPrefix>
-    <PreviousVersionPrefix>2.2.5</PreviousVersionPrefix>
+    <VersionPrefix>2.3.2</VersionPrefix>
+    <PreviousVersionPrefix>2.3.0</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>

--- a/src/build.props
+++ b/src/build.props
@@ -20,7 +20,7 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.3.2</VersionPrefix>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <PreviousVersionPrefix>2.3.0</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->


### PR DESCRIPTION
Serialization improvements to make SDK serialization more consistent.
 - Add CodeGenHints and regenerate OM to ensure all DateTime properties use DateTimeConverter.
 - Fix properties serialization to keep DateTime format when roundtripped.
 - Consistently load and emit properties without indentation (saves memory when loaded, consistent output, and 20% faster overall log load when Results have properties).