### PR TITLE
validation rule sarif1004

### DIFF
--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -124,6 +124,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: &apos;{1}&apos; &apos;{2}&apos; Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text.
+        /// </summary>
+        internal static string SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text {
+            get {
+                return ResourceManager.GetString("SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegm" +
+                        "ent_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: &apos;{1}&apos; &apos;{2}&apos; Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text.
+        /// </summary>
+        internal static string SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text {
+            get {
+                return ResourceManager.GetString("SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFra" +
+                        "gment_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Placeholder_SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text.
         /// </summary>
         internal static string SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text {

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -227,4 +227,10 @@ If the validator reports that 'contextRegion' is not a proper superset of 'regio
   <data name="SARIF2005_ProvideHelpfulToolInformation_Warning_UseNumericToolVersions_Text" xml:space="preserve">
     <value>{0}: Placeholder '{1}'</value>
   </data>
+  <data name="SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text" xml:space="preserve">
+    <value>{0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text</value>
+  </data>
+  <data name="SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text" xml:space="preserve">
+    <value>{0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text</value>
+  </data>
 </root>

--- a/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
@@ -9,26 +9,31 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 {
     public class ExpressUriBaseIdsCorrectly : SarifValidationSkimmerBase
     {
-        public override MultiformatMessageString FullDescription => new MultiformatMessageString
-        {
-            Text = RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text
-        };
+        /// <summary>
+        /// SARIF1004
+        /// </summary>
+        public override string Id => RuleId.ExpressUriBaseIdsCorrectly;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override MultiformatMessageString FullDescription => new MultiformatMessageString { Text = RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text };
+
+        protected override IEnumerable<string> MessageResourceNames => new string[] {
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdRequiresRelativeUri_Text),
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_TopLevelUriBaseIdMustBeAbsolute_Text),
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text)
+                };
 
         public override FailureLevel DefaultLevel => FailureLevel.Error;
 
-        public override string Id => RuleId.ExpressUriBaseIdsCorrectly;
-
-        protected override IEnumerable<string> MessageResourceNames => new string[]
-        {
-            nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdRequiresRelativeUri_Text),
-            nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_TopLevelUriBaseIdMustBeAbsolute_Text),
-            nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text)
-        };
-
         protected override void Analyze(ArtifactLocation fileLocation, string fileLocationPointer)
         {
+            // UriBaseIdRequiresRelativeUri: The 'uri' property of 'fileLocation' must be a relative uri, since 'uriBaseId' is present.
             if (fileLocation.UriBaseId != null && fileLocation.Uri.IsAbsoluteUri)
             {
+                // {0}: This fileLocation object contains a "uriBaseId" property, which means that the value
+                // of the "uri" property must be a relative URI reference, but "{1}" is an absolute URI reference.
                 LogResult(
                     fileLocationPointer.AtProperty(SarifPropertyName.Uri),
                     nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdRequiresRelativeUri_Text),
@@ -63,14 +68,26 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             {
                 var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
 
+                // TopLevelUriBaseIdMustBeAbsolute: TODO
                 if (artifactLocation.UriBaseId == null && !uri.IsAbsoluteUri)
                 {
-                    LogResult(pointer, nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_TopLevelUriBaseIdMustBeAbsolute_Text), uriString, uriBaseId);
+                    // {0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds is not an absolute URI.
+                    LogResult(
+                        pointer,
+                        nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_TopLevelUriBaseIdMustBeAbsolute_Text),
+                        uriString,
+                        uriBaseId);
                 }
 
+                // UriBaseIdValueMustEndWithSlash: TODO
                 if (!uriString.EndsWith("/"))
                 {
-                    LogResult(pointer, nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text), uriString, uriBaseId);
+                    // {0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds does not end with a slash.
+                    LogResult(
+                        pointer,
+                        nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text),
+                        uriString,
+                        uriBaseId);
                 }
             }
         }

--- a/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 }
 
                 // UriBaseIdValueMustNotContainDotDotSegment: uriBaseIds must not contain `..` segment(s).
-                if (uriString.Split("/").Any( x => x.Equals("..")))
+                if (uriString.Split("/").Any(x => x.Equals("..")))
                 {
                     // {0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text
                     LogResult(

--- a/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
 using Microsoft.Json.Pointer;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
@@ -15,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.ExpressUriBaseIdsCorrectly;
 
         /// <summary>
-        /// 
+        /// Placeholder_SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text
         /// </summary>
         public override MultiformatMessageString FullDescription => new MultiformatMessageString { Text = RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_FullDescription_Text };
 
@@ -93,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 }
 
                 // UriBaseIdValueMustNotContainDotDotSegment: uriBaseIds must not contain `..` segment(s).
-                if (uriString.Contains(".."))
+                if (uriString.Split("/").Any( x => x.Equals("..")))
                 {
                     // {0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text
                     LogResult(

--- a/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         protected override IEnumerable<string> MessageResourceNames => new string[] {
                     nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdRequiresRelativeUri_Text),
                     nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_TopLevelUriBaseIdMustBeAbsolute_Text),
-                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text)
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text),
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text),
+                    nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text)
                 };
 
         public override FailureLevel DefaultLevel => FailureLevel.Error;
@@ -68,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
             {
                 var uri = new Uri(uriString, UriKind.RelativeOrAbsolute);
 
-                // TopLevelUriBaseIdMustBeAbsolute: TODO
+                // TopLevelUriBaseIdMustBeAbsolute: Top level uriBaseId must be absolute.
                 if (artifactLocation.UriBaseId == null && !uri.IsAbsoluteUri)
                 {
                     // {0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds is not an absolute URI.
@@ -79,13 +81,35 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                         uriBaseId);
                 }
 
-                // UriBaseIdValueMustEndWithSlash: TODO
+                // UriBaseIdValueMustEndWithSlash: uriBaseIds must end with a slash.
                 if (!uriString.EndsWith("/"))
                 {
                     // {0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds does not end with a slash.
                     LogResult(
                         pointer,
                         nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustEndWithSlash_Text),
+                        uriString,
+                        uriBaseId);
+                }
+
+                // UriBaseIdValueMustNotContainDotDotSegment: uriBaseIds must not contain `..` segment(s).
+                if (uriString.Contains(".."))
+                {
+                    // {0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text
+                    LogResult(
+                        pointer,
+                        nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text),
+                        uriString,
+                        uriBaseId);
+                }
+
+                // UriBaseIdValueMustNotContainQueryOrFragment: uriBaseIds must not contain any query or fragments.
+                if (uri.IsAbsoluteUri && (!string.IsNullOrEmpty(uri.Fragment) || !string.IsNullOrEmpty(uri.Query)))
+                {
+                    // {0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text
+                    LogResult(
+                        pointer,
+                        nameof(RuleResources.SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text),
                         uriString,
                         uriBaseId);
                 }

--- a/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
+++ b/src/Sarif.Multitool/Rules/SARIF1004.ExpressUriBaseIdsCorrectly.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 }
 
                 // UriBaseIdValueMustNotContainDotDotSegment: uriBaseIds must not contain `..` segment(s).
-                if (uriString.Split("/").Any(x => x.Equals("..")))
+                if (uriString.Split('/').Any(x => x.Equals("..")))
                 {
                     // {0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text
                     LogResult(

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1004.ExpressUriBaseIdsCorrectly_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1004.ExpressUriBaseIdsCorrectly_Invalid.sarif
@@ -25,6 +25,12 @@
                 },
                 "Error_UriBaseIdValueMustEndWithSlash": {
                   "text": "{0}: The URI '{1}' belonging to the '{2}' element of run.originalUriBaseIds does not end with a slash."
+                },
+                "Error_UriBaseIdValueMustNotContainDotDotSegment": {
+                  "text": "{0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text"
+                },
+                "Error_UriBaseIdValueMustNotContainQueryOrFragment": {
+                  "text": "{0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainQueryOrFragment_Text"
                 }
               },
               "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html"
@@ -129,6 +135,136 @@
           "ruleIndex": 0,
           "level": "error",
           "message": {
+            "id": "Error_UriBaseIdValueMustNotContainDotDotSegment",
+            "arguments": [
+              "runs[0].originalUriBaseIds.BAD_URI_CONTAINING_DOTDOT",
+              "file:///C:/rules/dir1/dir2/../",
+              "BAD_URI_CONTAINING_DOTDOT"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 114,
+                  "startColumn": 38
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1004",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_UriBaseIdValueMustEndWithSlash",
+            "arguments": [
+              "runs[0].originalUriBaseIds.BAD_URI_CONTAINING_QUERY",
+              "http://www.contoso.com/catalog/shownew.htm?date=today",
+              "BAD_URI_CONTAINING_QUERY"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 120,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1004",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_UriBaseIdValueMustNotContainQueryOrFragment",
+            "arguments": [
+              "runs[0].originalUriBaseIds.BAD_URI_CONTAINING_QUERY",
+              "http://www.contoso.com/catalog/shownew.htm?date=today",
+              "BAD_URI_CONTAINING_QUERY"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 120,
+                  "startColumn": 37
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1004",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_UriBaseIdValueMustEndWithSlash",
+            "arguments": [
+              "runs[0].originalUriBaseIds.BAD_URI_CONTAINING_FRAGMENT",
+              "http://www.contoso.com/index.htm#search",
+              "BAD_URI_CONTAINING_FRAGMENT"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 126,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1004",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_UriBaseIdValueMustNotContainQueryOrFragment",
+            "arguments": [
+              "runs[0].originalUriBaseIds.BAD_URI_CONTAINING_FRAGMENT",
+              "http://www.contoso.com/index.htm#search",
+              "BAD_URI_CONTAINING_FRAGMENT"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 126,
+                  "startColumn": 40
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1004",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
             "id": "Error_UriBaseIdRequiresRelativeUri",
             "arguments": [
               "runs[0].conversion.analysisToolLogFiles[0].uri",
@@ -167,7 +303,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 131,
+                  "startLine": 149,
                   "startColumn": 42
                 }
               }
@@ -192,7 +328,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 193,
+                  "startLine": 211,
                   "startColumn": 46
                 }
               }
@@ -217,7 +353,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 138,
+                  "startLine": 156,
                   "startColumn": 48
                 }
               }
@@ -242,7 +378,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 169,
+                  "startLine": 187,
                   "startColumn": 58
                 }
               }
@@ -267,7 +403,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 202,
+                  "startLine": 220,
                   "startColumn": 48
                 }
               }
@@ -292,7 +428,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 151,
+                  "startLine": 169,
                   "startColumn": 54
                 }
               }
@@ -317,7 +453,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 184,
+                  "startLine": 202,
                   "startColumn": 48
                 }
               }
@@ -342,7 +478,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 213,
+                  "startLine": 231,
                   "startColumn": 50
                 }
               }
@@ -367,7 +503,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 118,
+                  "startLine": 136,
                   "startColumn": 42
                 }
               }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1004.ExpressUriBaseIdsCorrectly_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1004.ExpressUriBaseIdsCorrectly_Invalid.sarif
@@ -22,6 +22,24 @@
           "description": {
             "text": "This is a regression test for Bug #1862, where we were not checking for a trailing slash on relative URIs."
           }
+        },
+        "BAD_URI_CONTAINING_DOTDOT": {
+          "uri": "file:///C:/rules/dir1/dir2/../",
+          "description": {
+            "text": "Uri contains dot dot segment."
+          }
+        },
+        "BAD_URI_CONTAINING_QUERY": {
+          "uri": "http://www.contoso.com/catalog/shownew.htm?date=today",
+          "description": {
+            "text": "Uri contains a query."
+          }
+        },
+        "BAD_URI_CONTAINING_FRAGMENT": {
+          "uri": "http://www.contoso.com/index.htm#search",
+          "description": {
+            "text": "URI contains a fragment."
+          }
         }
       },
       "invocations": [


### PR DESCRIPTION
Over all todo list:
[ ] Rules yet to be written (see table below).
[ ] all user messages need to be updated/verified.
[ ] introduce taxa.
[ ] follow formatting convention in all rules.

Status 		|RuleID		|RuleName					|Level		|MessageId
---|---|---|---|---|
[done]		|SARIF1001	|RuleIdentifiersMustBeValid			|error		|Default
[done] 		|SARIF1002	|UrisMustBeValid				|error		|UrisMustConformToRfc3986
[    ]		|SARIF1002	|UrisMustBeValid				|error		|FileUrisMustConformToRfc8089
[    ] 		|SARIF1002	|UrisMustBeValid				|error		|FileUrisMustNotIncludeDotDotSegments
[    ]		|SARIF1003	|UrisShouldUseConventionalForm			|warning	|Default
[done]		|SARIF1004	|ExpressUriBaseIdsCorrectly			|error		|UriBaseIdRequiresRelativeUri
[done]		|SARIF1004	|ExpressUriBaseIdsCorrectly			|error		|TopLevelUriBaseIdMustBeAbsolute
[done]		|SARIF1004	|ExpressUriBaseIdsCorrectly			|error		|UriBaseIdValueMustEndWithSlash
**[ PR ]**		|SARIF1004	|ExpressUriBaseIdsCorrectly			|error		|UriBaseIdValueMustNotContainDotDotSegment
**[ PR ]**		|SARIF1004	|ExpressUriBaseIdsCorrectly			|error		|UriBaseIdValueMustNotContainQueryOrFragment
[done]		|SARIF1005	|UriMustBeAbsolute				|error		|Default
[done]		|SARIF1006	|InvocationPropertiesMustBeConsistent		|error		|EndTimeMustNotPrecedeStartTime
[done]		|SARIF1007	|RegionPropertiesMustBeConsistent		|error		|EndLineMustNotPrecedeStartLine
[done]		|SARIF1007	|RegionPropertiesMustBeConsistent		|error		|EndColumnMustNotPrecedeStartColumn
[done]		|SARIF1007	|RegionPropertiesMustBeConsistent		|error		|RegionStartPropertyMustBePresent
[done]		|SARIF1008	|PhysicalLocationPropertiesMustBeConsistent	|error		|ContextRegionRequiresRegion
[done]		|SARIF1008	|PhysicalLocationPropertiesMustBeConsistent	|error		|ContextRegionMustBeProperSupersetOfRegion
[done]		|SARIF1009	|IndexPropertiesMustBeConsistentWithArrays	|error		|TargetArrayMustExist
[done]		|SARIF1009	|IndexPropertiesMustBeConsistentWithArrays	|error		|TargetArrayMustBeLongEnough
[done]		|SARIF1010	|RuleIdMustBeConsistent				|error		|ResultMustSpecifyRuleId
[done]		|SARIF1010	|RuleIdMustBeConsistent				|error		|ResultRuleIdMustBeConsistent
[done]		|SARIF1011	|ReferenceFinalSchema				|error		|Default
[    ]		|SARIF1012	|MessagesPropertiesMustBeConsistent		|error		|CorrectNumberOfArguments
[    ]		|SARIF2001	|AuthorHighQualityMessages			|warning	|IncludeDynamicContent
[    ]		|SARIF2001	|AuthorHighQualityMessages			|warning	|EnquoteDynamicContent
[done]		|SARIF2001	|AuthorHighQualityMessages			|warning	|TerminateWithPeriod
[    ]		|SARIF2002	|UseMessageArguments				|warning	|Default
[    ]		|SARIF2003	|ProduceEnrichedSarif				|note		|ProvideVersionControlProvenance
[    ]		|SARIF2003	|ProduceEnrichedSarif				|note		|ProvideCodeSnippets
[    ]		|SARIF2003	|ProduceEnrichedSarif				|note		|ProvideContextRegion
[    ]		|SARIF2003	|ProduceEnrichedSarif				|note		|ProvideHelpUris
[    ]		|SARIF2003	|ProduceEnrichedSarif				|note		|EmbedFileContent
[    ]		|SARIF2004	|OptimizeFileSize				|warning	|EliminateLocationOnlyArtifacts
[    ]		|SARIF2004	|OptimizeFileSize				|warning	|DoNotIncludeExtraIndexedObjectProperties
[done]		|SARIF2005	|ProvideHelpfulToolInformation			|warning	|ProvideConciseToolName
[done]		|SARIF2005	|ProvideHelpfulToolInformation			|warning	|ProvideToolVersion
[done]		|SARIF2005	|ProvideHelpfulToolInformation			|warning	|UseNumericToolVersions
[    ]		|SARIF2006	|UrisShouldBeReachable				|warning	|Default
[    ]		|SARIF2007	|ExpressPathsRelativeToRepoRoot			|warning 	|Default
[done]		|SARIF2008	|ProvideSchema					|warning	|SchemaPropertyShouldBePresent
