### PR TITLE
Provide messages for SARIF1005.ProvideHelpfulToolInformation

### DIFF
--- a/docs/Producing effective SARIF.md
+++ b/docs/Producing effective SARIF.md
@@ -315,7 +315,7 @@ The tool's 'name' property should be no more than three words long. This makes i
 
 The tool should provide either or both of the 'version' and 'semanticVersion' properties. This enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions.
 
-If 'version' is used, facilitate comparison between versions by specifying it with at least two dot-separated integer components, optionally followed by any desired characters.
+If 'version' is used, facilitate comparison between versions by specifying it either with an integer, or with at least two dot-separated integer components, optionally followed by any desired characters.
 
 #### Messages
 

--- a/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
+++ b/src/Sarif.Multitool/Rules/RuleResources.Designer.cs
@@ -344,7 +344,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Placeholder.
+        ///   Looks up a localized string similar to Provide information that makes it easy to identify the name and version of your tool.
+        ///
+        ///The tool&apos;s &apos;name&apos; property should be no more than three words long. This makes it easy to remember and allows it to fit into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the &apos;fullName&apos; property.
+        ///
+        ///The tool should provide either or both of the &apos;version&apos; and &apos;semanticVersion&apos; properties. This enables the log file consumer to determine whether the file was [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SARIF2005_ProvideHelpfulToolInformation_FullDescription_Text {
             get {
@@ -353,7 +357,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Placeholder &apos;{1}&apos; &apos;{2}&apos; &apos;{3}&apos;.
+        ///   Looks up a localized string similar to {0}: The tool name &apos;{1}&apos; contains {2} words, which is more than the recommended maximum of {3} words. A short tool name is easy to remember and fits into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the &apos;fullName&apos; property..
         /// </summary>
         internal static string SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideConciseToolName_Text {
             get {
@@ -362,7 +366,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Placeholder.
+        ///   Looks up a localized string similar to {0}: The tool &apos;{1}&apos; provides neither a &apos;version&apos; property nor a &apos;semanticVersion&apos; property. Providing a version enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions..
         /// </summary>
         internal static string SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideToolVersion_Text {
             get {
@@ -371,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Placeholder &apos;{1}&apos;.
+        ///   Looks up a localized string similar to {0}: The tool &apos;{1}&apos; contains the &apos;version&apos; property &apos;{2}&apos;, which is not numeric. To facilitate comparison between versions, specify a &apos;version&apos; that starts with at least two dot-separated integer components, optionally followed by any desired characters..
         /// </summary>
         internal static string SARIF2005_ProvideHelpfulToolInformation_Warning_UseNumericToolVersions_Text {
             get {

--- a/src/Sarif.Multitool/Rules/RuleResources.resx
+++ b/src/Sarif.Multitool/Rules/RuleResources.resx
@@ -216,16 +216,22 @@ If the validator reports that 'contextRegion' is not a proper superset of 'regio
     <value>{0}: This 'physicalLocation' object contains both a 'region' and a 'contextRegion' property, but 'contextRegion' is not a proper superset of 'region'. This is invalid because the purpose of 'contextRegion' is to provide a viewing context around the 'region' which is the location of the result. It's possible that the tool reversed 'region' and 'contextRegion'. If 'region' and 'contextRegion' are identical, the tool must omit 'contextRegion'.</value>
   </data>
   <data name="SARIF2005_ProvideHelpfulToolInformation_FullDescription_Text" xml:space="preserve">
-    <value>Placeholder</value>
+    <value>Provide information that makes it easy to identify the name and version of your tool.
+
+The tool's 'name' property should be no more than three words long. This makes it easy to remember and allows it to fit into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the 'fullName' property.
+
+The tool should provide either or both of the 'version' and 'semanticVersion' properties. This enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions.
+
+If 'version' is used, facilitate comparison between versions by specifying it either with an integer, or with at least two dot-separated integer components, optionally followed by any desired characters.</value>
   </data>
   <data name="SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideConciseToolName_Text" xml:space="preserve">
-    <value>{0}: Placeholder '{1}' '{2}' '{3}'</value>
+    <value>{0}: The tool name '{1}' contains {2} words, which is more than the recommended maximum of {3} words. A short tool name is easy to remember and fits into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the 'fullName' property.</value>
   </data>
   <data name="SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideToolVersion_Text" xml:space="preserve">
-    <value>{0}: Placeholder</value>
+    <value>{0}: The tool '{1}' provides neither a 'version' property nor a 'semanticVersion' property. Providing a version enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions.</value>
   </data>
   <data name="SARIF2005_ProvideHelpfulToolInformation_Warning_UseNumericToolVersions_Text" xml:space="preserve">
-    <value>{0}: Placeholder '{1}'</value>
+    <value>{0}: The tool '{1}' contains the 'version' property '{2}', which is not numeric. To facilitate comparison between versions, specify a 'version' that starts with at least two dot-separated integer components, optionally followed by any desired characters.</value>
   </data>
   <data name="SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text" xml:space="preserve">
     <value>{0}: '{1}' '{2}' Placeholder: SARIF1004_ExpressUriBaseIdsCorrectly_Error_UriBaseIdValueMustNotContainDotDotSegment_Text</value>

--- a/src/Sarif.Multitool/Rules/SARIF2005.ProvideHelpfulToolInformation.cs
+++ b/src/Sarif.Multitool/Rules/SARIF2005.ProvideHelpfulToolInformation.cs
@@ -17,7 +17,20 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
         public override string Id => RuleId.ProvideHelpfulToolInformation;
 
         /// <summary>
-        /// Placeholder (full description).
+        /// Provide information that makes it easy to identify the name and version of your tool.
+        ///
+        /// The tool's 'name' property should be no more than three words long. This makes it easy
+        /// to remember and allows it to fit into a narrow column when displaying a list of results.
+        /// If you need to provide more information about your tool, use the 'fullName' property.
+        ///
+        /// The tool should provide either or both of the 'version' and 'semanticVersion' properties.
+        /// This enables the log file consumer to determine whether the file was produced by an
+        /// up to date version, and to avoid accidentally comparing log files produced by different
+        /// tool versions.
+        ///
+        /// If 'version' is used, facilitate comparison between versions by specifying it with
+        /// at least two dot-separated integer components, optionally followed by any desired
+        /// characters.
         /// </summary>
         public override MultiformatMessageString FullDescription => new MultiformatMessageString { Text = RuleResources.SARIF2005_ProvideHelpfulToolInformation_FullDescription_Text };
 
@@ -29,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         public override FailureLevel DefaultLevel => FailureLevel.Warning;
 
-        private static readonly Regex s_versionRegex = new Regex(@"^\d+\.\d+.*", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex s_versionRegex = new Regex(@"^\d+.*", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         protected override void Analyze(Tool tool, string toolPointer)
         {
@@ -41,7 +54,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
 
         private void AnalyzeToolDriver(ToolComponent toolComponent, string toolDriverPointer)
         {
-            // ProvideConciseToolName: Ensure that tool.driver.name isn't more than 3 words long
             if (!string.IsNullOrEmpty(toolComponent.Name))
             {
                 const int MaxWords = 3;
@@ -50,7 +62,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 {
                     string driverNamePointer = toolDriverPointer.AtProperty(SarifPropertyName.Name);
 
-                    // {0}: Placeholder '{1}' '{2}' '{3}'
+                    // {0}: The tool name '{1}' contains {2} words, which is more than the recommended
+                    // maximum of {3} words. A short tool name is easy to remember and fits into a
+                    // narrow column when displaying a list of results. If you need to provide more
+                    // information about your tool, use the 'fullName' property.
                     LogResult(
                         driverNamePointer,
                         nameof(RuleResources.SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideConciseToolName_Text),
@@ -60,32 +75,38 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool.Rules
                 }
             }
 
-            // ProvideToolVersion: Either tool.driver.version or tool.driver.semanticVersion should be there.
             if (string.IsNullOrWhiteSpace(toolComponent.Version) && string.IsNullOrWhiteSpace(toolComponent.SemanticVersion))
             {
-                // {0}: Placeholder
+                // {0}: The tool '{1}' provides neither a 'version' property nor a 'semanticVersion'
+                // property. Providing a version enables the log file consumer to determine whether
+                // the file was produced by an up to date version, and to avoid accidentally comparing
+                // log files produced by different tool versions.
                 LogResult(
                     toolDriverPointer,
+                    toolComponent.Name,
                     nameof(RuleResources.SARIF2005_ProvideHelpfulToolInformation_Warning_ProvideToolVersion_Text));
             }
             else
             {
-                // UseNumericToolVersions
                 if (!string.IsNullOrWhiteSpace(toolComponent.Version))
                 {
-                    AnalyzeVersion(toolComponent.Version, toolDriverPointer.AtProperty(SarifPropertyName.Version));
+                    AnalyzeVersion(toolComponent.Name, toolComponent.Version, toolDriverPointer.AtProperty(SarifPropertyName.Version));
                 }
             }
         }
 
-        private void AnalyzeVersion(string version, string pointer)
+        private void AnalyzeVersion(string name, string version, string pointer)
         {
             if (!s_versionRegex.IsMatch(version))
             {
-                // {0}: Placeholder '{1}'
+                // {0}: The tool '{1}' contains the 'version' property '{2}', which is not numeric.
+                // To facilitate comparison between versions, specify a 'version' that starts with
+                // at least two dot-separated integer components, optionally followed by any desired
+                // characters.
                 LogResult(
                     pointer,
                     nameof(RuleResources.SARIF2005_ProvideHelpfulToolInformation_Warning_UseNumericToolVersions_Text),
+                    name,
                     version);
             }
         }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF2005.ProvideHelpfulToolInformation_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF2005.ProvideHelpfulToolInformation_Invalid.sarif
@@ -11,20 +11,20 @@
               "id": "SARIF2005",
               "name": "ProvideHelpfulToolInformation",
               "shortDescription": {
-                "text": "Placeholder."
+                "text": "Provide information that makes it easy to identify the name and version of your tool."
               },
               "fullDescription": {
-                "text": "Placeholder"
+                "text": "Provide information that makes it easy to identify the name and version of your tool.\r\n\r\nThe tool's 'name' property should be no more than three words long. This makes it easy to remember and allows it to fit into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the 'fullName' property.\r\n\r\nThe tool should provide either or both of the 'version' and 'semanticVersion' properties. This enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions.\r\n\r\nIf 'version' is used, facilitate comparison between versions by specifying it either with an integer, or with at least two dot-separated integer components, optionally followed by any desired characters."
               },
               "messageStrings": {
                 "Warning_ProvideToolVersion": {
-                  "text": "{0}: Placeholder"
+                  "text": "{0}: The tool '{1}' provides neither a 'version' property nor a 'semanticVersion' property. Providing a version enables the log file consumer to determine whether the file was produced by an up to date version, and to avoid accidentally comparing log files produced by different tool versions."
                 },
                 "Warning_ProvideConciseToolName": {
-                  "text": "{0}: Placeholder '{1}' '{2}' '{3}'"
+                  "text": "{0}: The tool name '{1}' contains {2} words, which is more than the recommended maximum of {3} words. A short tool name is easy to remember and fits into a narrow column when displaying a list of results. If you need to provide more information about your tool, use the 'fullName' property."
                 },
                 "Warning_UseNumericToolVersions": {
-                  "text": "{0}: Placeholder '{1}'"
+                  "text": "{0}: The tool '{1}' contains the 'version' property '{2}', which is not numeric. To facilitate comparison between versions, specify a 'version' that starts with at least two dot-separated integer components, optionally followed by any desired characters."
                 }
               },
               "helpUri": "http://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html"
@@ -79,7 +79,8 @@
             "id": "Warning_UseNumericToolVersions",
             "arguments": [
               "runs[0].tool.driver.version",
-              "1"
+              "SARIF Functional Testing Long",
+              "x"
             ]
           },
           "locations": [

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF2005.ProvideHelpfulToolInformation_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF2005.ProvideHelpfulToolInformation_Invalid.sarif
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "SARIF Functional Testing Long",
-          "version": "1"
+          "version": "x"
         }
       },
       "results": [],


### PR DESCRIPTION
Also:
- Loosen up the regex to enable a single integer followed by arbitrary characters, for example `1x`.
- Add the tool name as an argument to the "missing version" message.