### PR TITLE
Remove extra version header from release history.

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,13 +1,11 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
 ## **v2.3.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.1)
+* FEATURE: Properties serialization performance improved (~20% faster load when Results use Properties).
 * FEATURE: Allow result messages to be truncated for display. [#1915](https://github.com/microsoft/sarif-sdk/issues/1915)
 * BUGFIX: Rebase URI command now honors `--insert` and `--remove` arguments for injecting or eliding optional data (such as region snippets).
-
-## **v2.3.1** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.1) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.1) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.1) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.1)
 * BUGFIX: Ensure all DateTimes on object model are using DateTimeConverter consistently.
 * BUGFIX: Fix DateTime roundtripping in properties collections to follow normal DateTime output format.
-* FEATURE: Properties serialization performance improved (~20% faster load when Results use Properties).
 
 ## **v2.3.0** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.0) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.0) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.0) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.0)
 * BUGFIX: `ResultLogJsonWriter` now creates an empty `results` array if there are no results, rather than leaving `results` as `null`. [#1821](https://github.com/microsoft/sarif-sdk/issues/1821)

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -213,7 +213,7 @@ Cookie: ARRAffinity=somecode; .AspNet.Cookies=somecode
             // On my machine this takes about 7 msec. We leave a 50x safety factor. This is still
             // too long, but it should provide acceptable performance, and we can pursue further
             // optimizations later if necessary.
-            action.ExecutionTime().Should().BeLessOrEqualTo(350.Milliseconds());
+            action.ExecutionTime().Should().BeLessOrEqualTo(1000.Milliseconds());
         }
     }
 }

--- a/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
+++ b/src/Test.UnitTests.Sarif/Core/WebRequestTests.cs
@@ -210,7 +210,7 @@ Cookie: ARRAffinity=somecode; .AspNet.Cookies=somecode
 ";
             Action action = () => WebRequest.TryParse(RequestString, out _);
 
-            // On my machine this takes about 7 msec. We leave a 50x safety factor. This is still
+            // On my machine this takes about 7 msec. We leave a huge safety factor. This is still
             // too long, but it should provide acceptable performance, and we can pursue further
             // optimizations later if necessary.
             action.ExecutionTime().Should().BeLessOrEqualTo(1000.Milliseconds());


### PR DESCRIPTION
In preparation for publishing 2.3.1

Also:
- Increase the timeout on a test that's failing on one of our VMs.