### PR TITLE
Guarantee "execute" permissions for NPM package.

### DIFF
--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -2,6 +2,9 @@
 	"name": "@microsoft/sarif-multitool-darwin",
 	"description": "SARIF Multitool for MacOS (Darwin)",
 	"version": "{version}",
+	"scripts": {
+		"postinstall": "chmod u+x Sarif.Multitool"
+	}
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-darwin/package.json
+++ b/npm/sarif-multitool-darwin/package.json
@@ -4,7 +4,7 @@
 	"version": "{version}",
 	"scripts": {
 		"postinstall": "chmod u+x Sarif.Multitool"
-	}
+	},
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {

--- a/npm/sarif-multitool-linux/package.json
+++ b/npm/sarif-multitool-linux/package.json
@@ -2,6 +2,9 @@
 	"name": "@microsoft/sarif-multitool-linux",
 	"description": "SARIF Multitool for Linux",
 	"version": "{version}",
+	"scripts": {
+		"postinstall": "chmod u+x Sarif.Multitool"
+	},
 	"author": "Microsoft",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Closes #1963.

Summary: After installation, we now edit the permissions to the binary to allow "execute". Previously it seemed to depend on how the package was packed.