### PR TITLE
Sarif SDK fixes during Fortify conversion comparison testing

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -46,6 +46,7 @@
     <!-- netcoreapp2.1 packs to tools\TargetFramework\any\* for compatibility with dotnet tool install -->
     <file src="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\**"
           target="tools\netcoreapp2.1\any"
+          exclude="bld\bin\$platform$_$configuration$\Sarif.Multitool\Publish\netcoreapp2.1\Sarif*.dll"
           />
     <file src="bld\bin\Signing\netcoreapp2.1\**"
           target="tools\netcoreapp2.1\any"

--- a/src/Samples/SarifTrim/Program.cs
+++ b/src/Samples/SarifTrim/Program.cs
@@ -15,9 +15,9 @@ namespace SarifTrim
     ///  SarifTrim demonstrates how to remove redundant and excessively large parts of a 
     ///  SARIF log file for handling of a huge log.
     /// </summary>
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             if (args.Length < 1)
             {

--- a/src/Samples/SarifTrim/SarifTrim.csproj
+++ b/src/Samples/SarifTrim/SarifTrim.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Samples/SarifTrim/packages.config
+++ b/src/Samples/SarifTrim/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>

--- a/src/Sarif.Converters/FortifyFprConverter.cs
+++ b/src/Sarif.Converters/FortifyFprConverter.cs
@@ -1025,15 +1025,18 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                     EndLine = regionEndLine > regionStartLine ? regionEndLine : 0
                 };
 
-                contextRegion = new Region
+                if (IncludeContextRegions)
                 {
-                    StartLine = snippetStartLine,
-                    EndLine = snippetEndLine > snippetStartLine ? snippetEndLine : 0,
-                    Snippet = new ArtifactContent
+                    contextRegion = new Region
                     {
-                        Text = text
-                    }
-                };
+                        StartLine = snippetStartLine,
+                        EndLine = snippetEndLine > snippetStartLine ? snippetEndLine : 0,
+                        Snippet = new ArtifactContent
+                        {
+                            Text = text
+                        }
+                    };
+                }
 
                 using (StringReader reader = new StringReader(text))
                 {
@@ -1056,11 +1059,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
                 }
 
                 region.Snippet = new ArtifactContent { Text = text };
-            }
-
-            if (!IncludeContextRegions)
-            {
-                contextRegion = null;
             }
 
             _snippetDictionary.Add(snippetId, new Snippet(region, contextRegion));

--- a/src/Sarif/Writers/SarifLogger.cs
+++ b/src/Sarif/Writers/SarifLogger.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Writers
                 throw new ArgumentNullException(nameof(result));
             }
 
-            if (!result.RuleId.IsEqualToOrHierarchicalDescendantOf(rule.Id))
+            if (result.RuleId != null && !result.RuleId.IsEqualToOrHierarchicalDescendantOf(rule.Id))
             {
                 //The rule id '{0}' specified by the result does not match the actual id of the rule '{1}'
                 string message = string.Format(CultureInfo.InvariantCulture, SdkResources.ResultRuleIdDoesNotMatchRule,


### PR DESCRIPTION
- Fix Sarif.Multitool duplicate files in nupkg issue!
- Update SarifTrim sample to match new Newtonsoft reference version.
- Fix SarifLogger NullRefException when Results don't have a RuleId set.
- FortifyFprConverter: More efficient code when ContextRegions excluded.