### PR TITLE
Include GitHub DSP policy files in MultiTool NuGet package.

### DIFF
--- a/src/Nuget/Sarif.Multitool.nuspec
+++ b/src/Nuget/Sarif.Multitool.nuspec
@@ -55,7 +55,9 @@
           target="tools\netcoreapp2.1\any"
           />
 
-    <file src="src\ReleaseHistory.md" />        
+    <file src="src\ReleaseHistory.md" />
+    <file src="policies\github-dsp.config.xml" target="policies" />
+    <file src="policies\github-dsp.config.sarif-external-properties" target="policies" />
     <file src="src\Sarif.Multitool\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,10 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 ## **v2.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.4)
-* BUGFIX: Various Fortify FPR converter improvements (such as improve variable expansion in result messages).
 * COMMAND-LINE BREAKING: Change `merge` command output directory argument name to `output-directory`.
-
-## **v2.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.4)
 * FEATURE: Add analysis rules appropriate for SARIF files that are to be uploaded to the GitHub Developer Security Portal.
+* BUGFIX: Various Fortify FPR converter improvements (such as improve variable expansion in result messages).
 * BUGFIX: The validator no longer reports `SARIF2010.ProvideCodeSnippets` if embedded file content for the specified artifact is present. [#2003](https://github.com/microsoft/sarif-sdk/issues/2003)
 
 ## **v2.3.3** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.3) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.3) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.3) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.3)


### PR DESCRIPTION
This is necessary so the files can be published to the Web site, to support the option to evaluate the DSP rules.