### PR TITLE
Improve package creation

### DIFF
--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -43,7 +43,7 @@ function New-NuGetPackageFromProjectFile($configuration, $project, $version) {
         "--include-source", "--include-symbols",
         "-p:Platform=$Platform",
         "--output", (Get-PackageDirectoryName $configuration),
-		"-p:Version=$version"
+        "-p:Version=$version"
 
     Write-CommandLine dotnet $arguments
 
@@ -75,7 +75,9 @@ function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suf
         Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
     }
 
-    Write-Information "  Successfully created package '$BinRoot\..\Publish\NuGet\$Configuration\$Project.$version.nupkg'."
+    $packageFilePath = Join-Path -Resolve $BinRoot ..\Publish\NuGet\$Configuration\$Project.$version.nupkg
+
+    Write-Information "  Successfully created package '$packageFilePath'."
 }
 
 function New-NuGetPackages($configuration, $projects) {
@@ -87,10 +89,27 @@ function New-NuGetPackages($configuration, $projects) {
         New-NuGetPackageFromProjectFile $configuration $project $version
     }
 
-    # Unfortunately, application projects like MultiTool need to include things
-    # that are not specified in the project file, so their packages still require
-    # a .nuspec file.
+    # We create both a DotnetTool package and a Dependency package from each application (Exe)
+    # project. Users need a DotnetTool package so they can install it and run it from the command
+    # line. They need a Dependency package so they can add a NuGet reference to their project and
+    # invoke the package's public APIs. If you try to add a NuGet reference to a DotnetTool package,
+    # you get the error message "Package '<packageId>' has a package type 'DotnetTool' that is not
+    # supported by project '<project>'."
+    #
+    # It is possible to create a single package that declares multiple package types, but when
+    # you try to add a NuGet reference to such a package, you get the error message "Package
+    # '<packageId>' has multiple package types, which is not supported."
+    #
+    # We create the Dependency package from the project file. We can't create the DotnetTool
+    # package form the project file for two reasons:
+    #
+    # 1. The tool package is standalone and requires dependent binaries that are not specified
+    #    in the project file.
+    # 2. It's not possible (AFAIK) to create multiple packages from the same project file.
+    #
+    # So we author a .nuspec file for projects that require DotnetTool packages.
     foreach ($project in $Projects.Applications) {
+        New-NuGetPackageFromProjectFile $configuration $project $version
         New-NuGetPackageFromNuSpecFile $configuration $project $version
     }
 }

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -16,7 +16,7 @@ $Frameworks.NetFx = @("net461")
 $Frameworks.Library = @("netstandard2.0") + $Frameworks.NetFx
 
 # Frameworks for which we build applications.
-$Frameworks.Application = @("netcoreapp2.1") + $Frameworks.NetFx
+$Frameworks.Application = @("netcoreapp3.1", "netcoreapp2.1") + $Frameworks.NetFx
 
 $Frameworks.All = ($Frameworks.Library + $Frameworks.Application | Select -Unique)
 

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -26,7 +26,8 @@ $Projects.Libraries = @(
     "Sarif",
     "Sarif.Converters",
     "Sarif.Driver",
-    "Sarif.WorkItems"
+    "Sarif.WorkItems",
+    "WorkItems"
 )
 
 $Projects.Applications = @(

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,8 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+
+## **v2.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.5)
+* FEATURE: Support .NET Core 3.1.
+
 ## **v2.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.4)
 * COMMAND-LINE BREAKING: Change `merge` command output directory argument name to `output-directory`.
 * FEATURE: Add analysis rules appropriate for SARIF files that are to be uploaded to the GitHub Developer Security Portal.

--- a/src/Sarif.Converters/Sarif.Converters.csproj
+++ b/src/Sarif.Converters/Sarif.Converters.csproj
@@ -7,10 +7,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="ConverterResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Sarif.Driver/Sarif.Driver.csproj
+++ b/src/Sarif.Driver/Sarif.Driver.csproj
@@ -7,10 +7,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="DriverResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -21,9 +21,16 @@
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 
-  <!-- PackAsTool is supported/recommended for .NET Core >= 2.1 -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net461'">
-    <PackAsTool>true</PackAsTool>
+  <PropertyGroup Label="Packaging">
+    <!--
+    Without this property setting, the id of the Dependency package created from this project file
+    would match the assembly name, "Sarif.Multitool". But we publish a DotnetTool package of that
+    name (by way of a .nuspec file), so we must choose a different name for the Dependency package.
+    -->
+    <PackageId>Sarif.Multitool.Library</PackageId>
+
+    <!-- Place content files at the root of the package. -->
+    <ContentTargetFolders>.</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Label="AssemblyAttributes">

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -33,10 +33,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Microsoft.Json.Pointer" Version="1.1.1" />

--- a/src/Sarif.WorkItems/Sarif.WorkItems.csproj
+++ b/src/Sarif.WorkItems/Sarif.WorkItems.csproj
@@ -7,10 +7,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\WorkItems\WorkItems.csproj" />

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <!--
-    For compatibility with older clients, we still build Sarid.Sdk (but no other packages)
+    For compatibility with older clients, we still build Sarif.Sdk (but no other packages)
     for .NET Framework 4.5.
     -->
     <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>

--- a/src/Sarif/Sarif.csproj
+++ b/src/Sarif/Sarif.csproj
@@ -19,7 +19,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net45</TargetFrameworks>
+    <!--
+    For compatibility with older clients, we still build Sarid.Sdk (but no other packages)
+    for .NET Framework 4.5.
+    -->
+    <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Test.EndToEnd.Baselining/Test.EndToEnd.Baselining.csproj
+++ b/src/Test.EndToEnd.Baselining/Test.EndToEnd.Baselining.csproj
@@ -1,5 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsTestProject>False</IsTestProject>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
   </ItemGroup>
@@ -7,12 +18,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Sarif\Sarif.csproj" />
   </ItemGroup>
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-  </PropertyGroup>
 
 </Project>

--- a/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
+++ b/src/Test.FunctionalTests.Sarif/Test.FunctionalTests.Sarif.csproj
@@ -7,7 +7,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.Plugins/Test.Plugins.csproj
+++ b/src/Test.Plugins/Test.Plugins.csproj
@@ -6,7 +6,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <IsTestProject>False</IsTestProject>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
+
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
+++ b/src/Test.UnitTests.Sarif.Converters/Test.UnitTests.Sarif.Converters.csproj
@@ -7,7 +7,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
+++ b/src/Test.UnitTests.Sarif.Driver/Test.UnitTests.Sarif.Driver.csproj
@@ -8,7 +8,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
+++ b/src/Test.UnitTests.Sarif.WorkItems/Test.UnitTests.Sarif.WorkItems.csproj
@@ -8,7 +8,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -8,7 +8,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
+++ b/src/Test.UnitTests.WorkItems/Test.UnitTests.WorkItems.csproj
@@ -9,7 +9,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Test.Utilities.Sarif/Test.Utilities.Sarif.csproj
+++ b/src/Test.Utilities.Sarif/Test.Utilities.Sarif.csproj
@@ -11,10 +11,13 @@
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <IsTestProject>False</IsTestProject>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/src/WorkItems/WorkItems.csproj
+++ b/src/WorkItems/WorkItems.csproj
@@ -11,10 +11,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />

--- a/src/build.props
+++ b/src/build.props
@@ -1,8 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!--
+  By convention, any project whose name starts with "Test." is a test project. But there are
+  a couple of projects which, although _related_ to testing, do not actually contain tests.
+  These projects set IsTestProject to false before importing build.props. Do not apply the
+  convention to those projects.
+  -->
+  <PropertyGroup Condition="'$(IsTestProject)' == ''">
+    <IsTestProject>False</IsTestProject>
+    <IsTestProject Condition="$(MSBuildProjectName.StartsWith('Test.'))">True</IsTestProject>
+  </PropertyGroup>
+
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <IsExeProject>False</IsExeProject>
+    <IsExeProject Condition="'$(OutputType)' == 'Exe'">True</IsExeProject>
+
+    <TargetFrameworks Condition="$(IsExeProject)">netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition="!$(IsExeProject)">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition="$(IsTestProject)">netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
@@ -20,8 +39,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.3.4</VersionPrefix>
-    <PreviousVersionPrefix>2.3.3</PreviousVersionPrefix>
+    <VersionPrefix>2.3.5</VersionPrefix>
+    <PreviousVersionPrefix>2.3.4</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
- Create both a `DotnetTool` package and a `Dependency` package for `Sarif.Multitool` (the `Dependency` package is called `Sarif.Multitool.Library`.
- Add `netcoreapp3.1` as a supported target for `Sarif.Multitool`.
- DRY out the specification of target frameworks across all projects.
- Side effect: `WorkItems` now must create a package, because `Sarif.Multitool.Library` requires it.