### PR TITLE
Generate dependency package Sarif.Multitool.Library

### DIFF
--- a/scripts/NuGetUtilities.psm1
+++ b/scripts/NuGetUtilities.psm1
@@ -43,7 +43,7 @@ function New-NuGetPackageFromProjectFile($configuration, $project, $version) {
         "--include-source", "--include-symbols",
         "-p:Platform=$Platform",
         "--output", (Get-PackageDirectoryName $configuration),
-		"-p:Version=$version"
+        "-p:Version=$version"
 
     Write-CommandLine dotnet $arguments
 
@@ -75,7 +75,9 @@ function New-NuGetPackageFromNuSpecFile($configuration, $project, $version, $suf
         Exit-WithFailureMessage $ScriptName "$project NuGet package creation failed."
     }
 
-    Write-Information "  Successfully created package '$BinRoot\..\Publish\NuGet\$Configuration\$Project.$version.nupkg'."
+    $packageFilePath = Join-Path -Resolve $BinRoot ..\Publish\NuGet\$Configuration\$Project.$version.nupkg
+
+    Write-Information "  Successfully created package '$packageFilePath'."
 }
 
 function New-NuGetPackages($configuration, $projects) {
@@ -87,10 +89,27 @@ function New-NuGetPackages($configuration, $projects) {
         New-NuGetPackageFromProjectFile $configuration $project $version
     }
 
-    # Unfortunately, application projects like MultiTool need to include things
-    # that are not specified in the project file, so their packages still require
-    # a .nuspec file.
+    # We create both a DotnetTool package and a Dependency package from each application (Exe)
+    # project. Users need a DotnetTool package so they can install it and run it from the command
+    # line. They need a Dependency package so they can add a NuGet reference to their project and
+    # invoke the package's public APIs. If you try to add a NuGet reference to a DotnetTool package,
+    # you get the error message "Package '<packageId>' has a package type 'DotnetTool' that is not
+    # supported by project '<project>'."
+    #
+    # It is possible to create a single package that declares multiple package types, but when
+    # you try to add a NuGet reference to such a package, you get the error message "Package
+    # '<packageId>' has multiple package types, which is not supported."
+    #
+    # We create the Dependency package from the project file. We can't create the DotnetTool
+    # package form the project file for two reasons:
+    #
+    # 1. The tool package is standalone and requires dependent binaries that are not specified
+    #    in the project file.
+    # 2. It's not possible (AFAIK) to create multiple packages from the same project file.
+    #
+    # So we author a .nuspec file for projects that require DotnetTool packages.
     foreach ($project in $Projects.Applications) {
+        New-NuGetPackageFromProjectFile $configuration $project $version
         New-NuGetPackageFromNuSpecFile $configuration $project $version
     }
 }

--- a/scripts/Projects.psm1
+++ b/scripts/Projects.psm1
@@ -26,7 +26,8 @@ $Projects.Libraries = @(
     "Sarif",
     "Sarif.Converters",
     "Sarif.Driver",
-    "Sarif.WorkItems"
+    "Sarif.WorkItems",
+    "WorkItems"
 )
 
 $Projects.Applications = @(

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,4 +1,10 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
+
+## **v2.3.5** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.5) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.5) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.5) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.5)
+* FEATURE: Rule `SARIF2005.ProvideToolProperties` now allows `dottedQuadFileVersion to satisfy the requirement for version information, requires `informationUri`, and is configurable.
+* FEATURE: Rule `SARIF2012.ProvideHelpUris` is now named `ProvideRuleProperties`. In addition to checking for `rule.helpUri`, it now checks whether `rule.name` is present and looks like a Pascal case identifier.
+* FEATURE: In the Multitool's `rewrite` command, if `--insert VersionControlInformation` is specified, then `run.versionControlProvenance` is populated, and all absolute URIs are re-expressed as relative references with respect to the nearest enclosing repository root directory.
+
 ## **v2.3.4** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.4) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.4) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.4) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.4)
 * COMMAND-LINE BREAKING: Change `merge` command output directory argument name to `output-directory`.
 * FEATURE: Add analysis rules appropriate for SARIF files that are to be uploaded to the GitHub Developer Security Portal.

--- a/src/Sarif.Multitool/Sarif.Multitool.csproj
+++ b/src/Sarif.Multitool/Sarif.Multitool.csproj
@@ -21,9 +21,16 @@
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishReadyToRun>   
   </PropertyGroup>
 
-  <!-- PackAsTool is supported/recommended for .NET Core >= 2.1 -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net461'">
-    <PackAsTool>true</PackAsTool>
+  <PropertyGroup Label="Packaging">
+    <!--
+    Without this property setting, the id of the Dependency package created from this project file
+    would match the assembly name, "Sarif.Multitool". But we publish a DotnetTool package of that
+    name (by way of a .nuspec file), so we must choose a different name for the Dependency package.
+    -->
+    <PackageId>Sarif.Multitool.Library</PackageId>
+
+    <!-- Place content files at the root of the package. -->
+    <ContentTargetFolders>.</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Label="AssemblyAttributes">

--- a/src/build.props
+++ b/src/build.props
@@ -20,8 +20,8 @@
     having all the relevant values in one place. This property is actually used by the PowerShell
     script that hides ("delists") the previous package versions on nuget.org.
     -->
-    <VersionPrefix>2.3.4</VersionPrefix>
-    <PreviousVersionPrefix>2.3.3</PreviousVersionPrefix>
+    <VersionPrefix>2.3.5</VersionPrefix>
+    <PreviousVersionPrefix>2.3.4</PreviousVersionPrefix>
 
      <!-- SchemaVersionAsPublishedToSchemaStoreOrg identifies the current published version on json schema store at https://schemastore.azurewebsites.net/schemas/json/ -->
     <SchemaVersionAsPublishedToSchemaStoreOrg>2.1.0-rtm.5</SchemaVersionAsPublishedToSchemaStoreOrg>


### PR DESCRIPTION
We need to create both a DotnetTool package and a Dependency package for the Sarif.Multitool project. Users need a DotnetTool package so they can install the Multitool and run it from the command line. They need a Dependency package so they can add a NuGet reference to their project and invoke the package's public APIs. This is how we will expose the "normalization" functionality.

We can't expose the normalization functionality from the DotnetTool package we currently build because if you try to add a NuGet reference to a DotnetTool package you get the error message "Package '<packageId>' has a package type 'DotnetTool' that is not supported by project '<project>'."
 
It is possible to create a single package that declares multiple package types, but when you try to add a NuGet reference to such a package, you get the error message "Package '<packageId>' has multiple package types, which is not supported."

We create the Dependency package from the project file. We can't create the DotnetTool package from the project file for two reasons:

1. The tool package is standalone and requires dependent binaries that are not specified in the project file.
2. It's not possible (AFAIK) to create multiple packages from the same project file.

So we continue to use a .nuspec file to create the DotnetTool package.