### PR TITLE
Mention VersionControlInformation in Multitool help

### DIFF
--- a/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
+++ b/src/Sarif.Driver/Sdk/CommonOptionsBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             HelpText =
             "Optionally present data, expressed as a semicolon-delimited list, that should be inserted into the log file. " +
             "Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, RegionSnippets, ContextRegionSnippets, " +
-            "Guids and NondeterministicProperties.")]
+            "Guids, VersionControlInformation, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToInsert { get; set; }
 
         [Option(
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
             HelpText =
             "Optionally present data, expressed as a semicolon-delimited list, that should be not be persisted to or which " +
             "should be removed from the log file. Valid values include Hashes, TextFiles, BinaryFiles, EnvironmentVariables, " +
-            "RegionSnippets, ContextRegionSnippets and NondeterministicProperties.")]
+            "RegionSnippets, ContextRegionSnippets, Guids, VersionControlInformation, and NondeterministicProperties.")]
         public IEnumerable<OptionallyEmittedData> DataToRemove { get; set; }
 
         [Option(

--- a/src/Sarif.Multitool/RewriteOptions.cs
+++ b/src/Sarif.Multitool/RewriteOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
-    [Verb("rewrite", HelpText = "Transform a SARIF file to a reformatted version.")]
+    [Verb("rewrite", HelpText = "Enrich a SARIF file with additional data.")]
     public class RewriteOptions : SingleFileOptionsBase
     {
 


### PR DESCRIPTION
As of cef88f8, the `rewrite` command's `--insert` option accepts the value `VersionControlInformation`. When this value is specified, the command populates `run.versionControlProvenance`. In addition, any absolute URI that points into a Git repo is rewritten as a relative reference with respect to the nearest enclosing repo root.

We neglected to mention the new value in the command line help; do that now.

Also, we note that the description of the `rewrite` command did not at all say what the command actually does. Fix that.