### PR TITLE
Fix GitHubDspIngestionVisitor

### DIFF
--- a/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
+++ b/src/Sarif/Baseline/ResultMatching/DataStructures/MatchedResults.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
 
             SetFirstDetectionTime(result);
 
-            resultMatchingProperties = MergeDictionaryPreferFirst(resultMatchingProperties, originalResultMatchingProperties);
+            resultMatchingProperties = resultMatchingProperties.MergePreferFirst(originalResultMatchingProperties) as Dictionary<string, object>;
 
             if (PreviousResult != null &&
                 propertyBagMergeBehavior == DictionaryMergeBehavior.InitializeFromOldest)
@@ -226,22 +226,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
             }
 
             targetResult.Provenance.FirstDetectionTimeUtc = firstDetectionTime;
-        }
-
-        private Dictionary<string, object> MergeDictionaryPreferFirst(
-            Dictionary<string, object> firstPropertyBag,
-            Dictionary<string, object> secondPropertyBag)
-        {
-            Dictionary<string, object> mergedPropertyBag = firstPropertyBag;
-
-            foreach (string key in secondPropertyBag.Keys)
-            {
-                if (!mergedPropertyBag.ContainsKey(key))
-                {
-                    mergedPropertyBag[key] = secondPropertyBag[key];
-                }
-            }
-            return mergedPropertyBag;
         }
 
         public override string ToString()

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -441,6 +441,35 @@ namespace Microsoft.CodeAnalysis.Sarif
             return null;
         }
 
+        /// <summary>
+        /// Merge this property bag with another one, preferring the properties in this property
+        /// bag if there are any duplicates.
+        /// </summary>
+        /// <param name="propertyBag">
+        /// The property bag into which <paramref name="otherPropertyBag"/> is to be merged.
+        /// </param>
+        /// <param name="otherPropertyBag">
+        /// A property bag containing properties to merge into <paramref name="propertyBag"/>.
+        /// </param>
+        /// <returns>
+        /// The original <paramref name="propertyBag"/> object, into which the properties
+        /// from <paramref name="otherPropertyBag"/> have now been merged.
+        /// </returns>
+        public static IDictionary<string, T> MergePreferFirst<T>(
+            this IDictionary<string, T> propertyBag,
+            IDictionary<string, T> otherPropertyBag)
+        {
+            foreach (string key in otherPropertyBag.Keys)
+            {
+                if (!propertyBag.ContainsKey(key))
+                {
+                    propertyBag[key] = otherPropertyBag[key];
+                }
+            }
+
+            return propertyBag;
+        }
+
         /// <summary>Checks if a character is a newline.</summary>
         /// <param name="testedCharacter">The character to check.</param>
         /// <returns>true if newline, false if not.</returns>

--- a/src/Sarif/ExtensionMethods.cs
+++ b/src/Sarif/ExtensionMethods.cs
@@ -451,6 +451,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         /// <param name="otherPropertyBag">
         /// A property bag containing properties to merge into <paramref name="propertyBag"/>.
         /// </param>
+        /// <typeparam name="T">
+        /// The type of object in the property bag. For SARIF property bags, the type will
+        /// be <see cref="SerializedPropertyInfo"/>.
+        /// </typeparam>
         /// <returns>
         /// The original <paramref name="propertyBag"/> object, into which the properties
         /// from <paramref name="otherPropertyBag"/> have now been merged.

--- a/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
+++ b/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
@@ -8,6 +8,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 { 
     public class GitHubDspIngestionVisitor : SarifRewritingVisitor
     {
+        // DSP requires that every related location have a message. It's not clear why this
+        // requirement exists, as this data is mostly used to build embedded links from
+        // results (where the link anchor text actually resides).
+        private const string PlaceholderRelatedLocationMessage = "[No message provided.]";
+
         // GitHub DSP reportedly has an ingestion limit of 500 issues.
         // Internal static rather than private const to allow a unit test with a practical limit.
         internal static int s_MaxResults = 500;
@@ -88,15 +93,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             {
                 foreach (Location relatedLocation in node.RelatedLocations)
                 {
-                    // DSP requires that every related location have a message. It's
-                    // not clear why this requirement exists, as this data is mostly 
-                    // used to build embedded links from results (where the link
-                    // anchor text actually resides).
                     if (string.IsNullOrEmpty(relatedLocation.Message?.Text))
                     {
                         relatedLocation.Message = new Message
                         {
-                            Text = "[No message provided.]" 
+                            Text = PlaceholderRelatedLocationMessage
                         };
                     }
                 }

--- a/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
+++ b/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
                 // Location.Message might vary per usage. For example, on one usage,
                 // we might be tracking an uninitialized variable, and the location
-                // might have the message "Unititialized variable 'ptr' passed to 'f'".
+                // might have the message "Uninitialized variable 'ptr' passed to 'f'".
                 // Another usage of the same location might have a different message,
                 // or none at all. So even though we are getting the location from
                 // the shared object, don't take its message unless the current object

--- a/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
+++ b/src/Sarif/Visitors/GitHubDspIngestionVisitor.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                             errors.Add(result);
                         }
 
-                        if (errors.Count > s_MaxResults) { break; }
+                        if (errors.Count == s_MaxResults) { break; }
                     }
 
                     node.Results = errors;

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -19,9 +19,11 @@
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Absolute_TextFiles.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_All.sarif" />
@@ -81,9 +83,11 @@
 
   <ItemGroup>
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_VersionControlInformation.sarif" />

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -20,11 +20,13 @@
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\Fingerprints.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\ThreadFlowLocations.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\Fingerprints.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\ThreadFlowLocations.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
@@ -88,12 +90,14 @@
   <ItemGroup>
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\Fingerprints.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\ThreadFlowLocations.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\Fingerprints.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\ThreadFlowLocations.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -18,6 +18,7 @@
     <None Remove="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
@@ -25,6 +26,7 @@
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\RelatedLocationMessage.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Absolute_TextFiles.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_All.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_Guids.sarif" />
@@ -84,12 +86,14 @@
   <ItemGroup>
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\RelatedLocationMessage.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_VersionControlInformation.sarif" />
     <EmbeddedResource Include="TestData\Readers\elfie-arriba-utf8-bom.sarif" />
     <EmbeddedResource Include="TestData\Baseline\elfie-arriba.sarif" />

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -17,6 +17,8 @@
     <None Remove="TestData\Baseline\elfie-arriba.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Absolute_TextFiles.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_All.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_Guids.sarif" />
@@ -74,6 +76,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_VersionControlInformation.sarif" />
     <EmbeddedResource Include="TestData\Readers\elfie-arriba-utf8-bom.sarif" />
     <EmbeddedResource Include="TestData\Baseline\elfie-arriba.sarif" />

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -18,7 +18,11 @@
     <None Remove="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Absolute_TextFiles.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_All.sarif" />
     <None Remove="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_Guids.sarif" />
@@ -77,7 +81,11 @@
 
   <ItemGroup>
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\InsertOptionalDataVisitor\ExpectedOutputs\CoreTests-Relative_VersionControlInformation.sarif" />
     <EmbeddedResource Include="TestData\Readers\elfie-arriba-utf8-bom.sarif" />
     <EmbeddedResource Include="TestData\Baseline\elfie-arriba.sarif" />

--- a/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
+++ b/src/Test.UnitTests.Sarif/Test.UnitTests.Sarif.csproj
@@ -17,11 +17,13 @@
     <None Remove="TestData\Baseline\elfie-arriba.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestCurrent.sarif" />
     <None Remove="TestData\Baseline\SuppressionTestPrevious.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\Fingerprints.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
+    <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\Fingerprints.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />
     <None Remove="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
@@ -84,12 +86,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\Fingerprints.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\NonErrorResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\RelatedLocationMessage.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\ExpectedOutputs\TooManyResults.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\NonErrorResults.sarif" />
+    <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\Fingerprints.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithArtifacts.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\WithInvocation.sarif" />
     <EmbeddedResource Include="TestData\GitHubDspIngestionVisitor\Inputs\TooManyResults.sarif" />

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/Fingerprints.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/Fingerprints.sarif
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "partialFingerprints": {
+            "f1": "f1-value",
+            "f2": "f2-value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/NonErrorResults.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/NonErrorResults.sarif
@@ -1,0 +1,29 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1002",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1003",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/RelatedLocationMessage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/RelatedLocationMessage.sarif
@@ -1,0 +1,44 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file.c"
+                }
+              },
+              "message": {
+                "text": "Related location message."
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file2.c"
+                }
+              },
+              "message": {
+                "text": "[No message provided.]"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/ThreadFlowLocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/ThreadFlowLocations.sarif
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file.c"
+                }
+              }
+            }
+          ],
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "importance": "essential",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566982Z",
+                      "location": {
+                        "message": {
+                          "text": "Variable 'ptr' declared."
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "collections/list.h"
+                          },
+                          "region": {
+                            "startLine": 15
+                          }
+                        }
+                      },
+                      "module": "stdlib",
+                      "nestingLevel": 0,
+                      "properties": {
+                        "a": 1
+                      },
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      }
+                    },
+                    {
+                      "importance": "unimportant",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566984Z",
+                      "location": {
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "collections/list.h"
+                          },
+                          "region": {
+                            "startLine": 18
+                          }
+                        }
+                      },
+                      "module": "stdlib",
+                      "nestingLevel": 1,
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      }
+                    },
+                    {
+                      "importance": "essential",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566986Z",
+                      "kinds": [
+                        "enter"
+                      ],
+                      "location": {
+                        "message": {
+                          "text": "Uninitialized variable 'ptr' passed to method 'add_core'."
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "collections/list.h"
+                          },
+                          "region": {
+                            "startLine": 25
+                          }
+                        }
+                      },
+                      "properties": {
+                        "b": 22,
+                        "c": 3,
+                        "d": 4
+                      },
+                      "module": "stdlib",
+                      "nestingLevel": 0,
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/TooManyResults.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/TooManyResults.sarif
@@ -1,0 +1,29 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1002",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithArtifacts.sarif
@@ -1,0 +1,32 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Sarif/SarifConstants.cs",
+                  "uriBaseId": "SOURCE_ROOT"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithArtifacts.sarif
@@ -20,7 +20,12 @@
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "Sarif/SarifConstants.cs",
-                  "uriBaseId": "SOURCE_ROOT"
+                  "uriBaseId": "SOURCE_ROOT",
+                  "properties": {
+                    "a": 1,
+                    "b": 22,
+                    "c": 3
+                  }
                 }
               }
             }

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithInvocation.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/ExpectedOutputs/WithInvocation.sarif
@@ -1,0 +1,22 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/Fingerprints.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/Fingerprints.sarif
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "fingerprints": {
+            "f1": "f1-value",
+            "f2": "f2-value"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/NonErrorResults.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/NonErrorResults.sarif
@@ -1,0 +1,43 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "warning",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1002",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1003",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1004",
+          "level": "warning",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/RelatedLocationMessage.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/RelatedLocationMessage.sarif
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file.c"
+                }
+              },
+              "message": {
+                "text": "Related location message."
+              }
+            },
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file2.c"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/ThreadFlowLocations.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/ThreadFlowLocations.sarif
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "threadFlowLocations": [
+        {
+          "location": {
+            "message": {
+              "text": "This message will not appear in the result when this location is inlined."
+            },
+            "physicalLocation": {
+              "artifactLocation": {
+                "uri": "collections/list.h"
+              },
+              "region": {
+                "startLine": 15
+              }
+            }
+          },
+          "module": "stdlib",
+          "properties": {
+            "a": 1
+          },
+          "state": {
+            "this-state": {
+              "text": "... will not appear in the result when this location is inlined."
+            }
+          }
+        },
+        {
+          "location": {
+            "physicalLocation": {
+              "artifactLocation": {
+                "uri": "collections/list.h"
+              },
+              "region": {
+                "startLine": 18
+              }
+            }
+          },
+          "module": "stdlib"
+        },
+        {
+          "kinds": [
+            "enter"
+          ],
+          "location": {
+            "message": {
+              "text": "Uninitialized variable 'ptr' passed to method 'add_core'."
+            },
+            "physicalLocation": {
+              "artifactLocation": {
+                "uri": "collections/list.h"
+              },
+              "region": {
+                "startLine": 25
+              }
+            }
+          },
+          "module": "stdlib",
+          "properties": {
+            "b": 2,
+            "c": 3
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file.c"
+                }
+              }
+            }
+          ],
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Variable 'ptr' declared."
+                        }
+                      },
+                      "importance": "essential",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566982Z",
+                      "nestingLevel": 0,
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      },
+                      "index": 0
+                    },
+                    {
+                      "importance": "unimportant",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566984Z",
+                      "nestingLevel": 1,
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      },
+                      "index": 1
+                    },
+                    {
+                      "importance": "essential",
+                      "executionTimeUtc": "2020-09-03T09:16:01.566986Z",
+                      "nestingLevel": 0,
+                      "properties": {
+                        "b": 22,
+                        "d": 4
+                      },
+                      "state": {
+                        "ptr": {
+                          "text": "null"
+                        }
+                      },
+                      "index": 2
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/TooManyResults.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/TooManyResults.sarif
@@ -1,0 +1,43 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1002",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1003",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        },
+        {
+          "ruleId": "TEST1004",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithArtifacts.sarif
@@ -12,7 +12,11 @@
         {
           "location": {
             "uri": "Sarif/SarifConstants.cs",
-            "uriBaseId": "SOURCE_ROOT"
+            "uriBaseId": "SOURCE_ROOT",
+            "properties": {
+              "a": 1,
+              "b": 2
+            }
           }
         },
         {
@@ -33,7 +37,11 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "index": 0
+                  "index": 0,
+                  "properties": {
+                    "b": 22,
+                    "c": 3
+                  }
                 }
               }
             }

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithArtifacts.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithArtifacts.sarif
@@ -1,0 +1,45 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "Sarif/SarifConstants.cs",
+            "uriBaseId": "SOURCE_ROOT"
+          }
+        },
+        {
+          "location": {
+            "uri": "Sarif.Multitool/GitHubDspIngestionVisitor.cs",
+            "uriBaseId": "SOURCE_ROOT"
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithInvocation.sarif
+++ b/src/Test.UnitTests.Sarif/TestData/GitHubDspIngestionVisitor/Inputs/WithInvocation.sarif
@@ -1,0 +1,27 @@
+﻿{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif.UnitTests"
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "level": "error",
+          "message": {
+            "text": "The message."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -25,5 +25,25 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void GitHubDspIngestionVisitor_FiltersNonErrorResults()
             => RunTest("NonErrorResults.sarif");
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_LimitsNumberOfResults()
+        {
+            int prevMaxResults = GitHubDspIngestionVisitor.s_MaxResults;
+
+            try
+            {
+                GitHubDspIngestionVisitor.s_MaxResults = 2;
+                RunTest("TooManyResults.sarif");
+            }
+            finally
+            {
+                GitHubDspIngestionVisitor.s_MaxResults = prevMaxResults;
+            }
+        }
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_RemovesInvocations()
+            => RunTest("WithInvocation.sarif");
     }
 }

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -53,5 +53,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void GitHubDspIngestionVisitor_ProvidesPlaceholderRelatedLocationMessage()
             => RunTest("RelatedLocationMessage.sarif");
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_MovesFingerprintsToPartialFingerprints()
+            => RunTest("Fingerprints.sarif");
     }
 }

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -45,5 +45,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void GitHubDspIngestionVisitor_RemovesInvocations()
             => RunTest("WithInvocation.sarif");
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_RemovesArtifactsAndRetainsIndirectArtifactLocations()
+            => RunTest("WithArtifacts.sarif");
     }
 }

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Sarif.Visitors
+{
+    public class GitHubDspIngestionVisitorTests : FileDiffingUnitTests
+    {
+        public GitHubDspIngestionVisitorTests(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+        protected override string ConstructTestOutputFromInputResource(string inputResourceName, object parameter)
+        {
+            string logContents = GetResourceText(inputResourceName);
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+            var visitor = new GitHubDspIngestionVisitor();
+            visitor.Visit(sarifLog);
+
+            return JsonConvert.SerializeObject(sarifLog, SarifTransformerUtilities.JsonSettingsIndented);
+        }
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_FiltersNonErrorResults()
+            => RunTest("NonErrorResults.sarif");
+    }
+}

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -49,5 +49,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void GitHubDspIngestionVisitor_RemovesArtifactsAndRetainsIndirectArtifactLocations()
             => RunTest("WithArtifacts.sarif");
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_ProvidesPlaceholderRelatedLocationMessage()
+            => RunTest("RelatedLocationMessage.sarif");
     }
 }

--- a/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
+++ b/src/Test.UnitTests.Sarif/Visitors/GitHubDspIngestionVisitorTests.cs
@@ -57,5 +57,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
         [Fact]
         public void GitHubDspIngestionVisitor_MovesFingerprintsToPartialFingerprints()
             => RunTest("Fingerprints.sarif");
+
+        [Fact]
+        public void GitHubDspIngestionVisitor_InlinesThreadFlowLocations()
+            => RunTest("ThreadFlowLocations.sarif");
     }
 }


### PR DESCRIPTION
Add file-based unit tests for the `GitHubDspIngestionVisitor` and fix the bugs that they reveal:

- #2058: GitHubDspIngestionVisitor limits number of results only if some of them are non-errors
- #2060: GitHubDspIngestionVisitor removes codeFlows entirely rather than inlining threadFlowLocations

When inlining `threadFlowLocations`, we have to take care to distinguish those properties that are shared among all usages of a given location (for example, the `location` and `module` properties) from those properties that vary across usages (for example, `executionTimeUtc` and `state`). The `location.message` requires special handling because we do want to take `location` from the shared object, but we don't necessarily want to take `location.message`. Finally, we merge the property bags, preferring the values in the per-usage property bag if there are any overlaps.

We also have to merge property bags when inlining artifact locations.