### PR TITLE
Fixing a couple of edge-cases that cause the ESLint formatter to create invalid SARIF files

### DIFF
--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -181,9 +181,12 @@ module.exports = function (results, data) {
                     }
 
                     if (message.line > 0 || message.column > 0) {
-                        sarifRepresentation.locations[0].physicalLocation.region = {
-                            startLine: message.line,
-                            startColumn: message.column
+                        sarifRepresentation.locations[0].physicalLocation.region = {};
+                        if (message.line > 0) {
+                            sarifRepresentation.locations[0].physicalLocation.region.startLine = message.line;
+                        }
+                        if (message.column > 0) {
+                            sarifRepresentation.locations[0].physicalLocation.region.startColumn = message.column;
                         };
                     }
 

--- a/src/ESLint.Formatter/sarif.js
+++ b/src/ESLint.Formatter/sarif.js
@@ -145,14 +145,16 @@ module.exports = function (results, data) {
                                 // Create a new entry in the rules dictionary.
                                 sarifRules[message.ruleId] = {
                                     id: message.ruleId,
-                                    shortDescription: {
-                                        text: meta.docs.description
-                                    },
                                     helpUri: meta.docs.url,
                                     properties: {
                                         category: meta.docs.category
                                     }
                                 };
+                                if (meta.docs.description) {
+                                    sarifRules[message.ruleId].shortDescription = {
+                                        text: meta.docs.description
+                                    };
+                                }
                             }
                         }
 

--- a/src/ESLint.Formatter/test/sarif.js
+++ b/src/ESLint.Formatter/test/sarif.js
@@ -162,6 +162,28 @@ describe("formatter:sarif", () => {
 });
 
 describe("formatter:sarif", () => {
+    describe("when passed one message with line and invalid column", () => {
+        const code = [{
+            filePath: sourceFilePath1,
+            messages: [{
+                message: "Unexpected value.",
+                ruleId: testRuleId,
+                line: 10,
+                column: 0
+            }]
+        }];
+
+        it("should return a log with one result whose location contains a region with line # and no column #", () => {
+            const log = JSON.parse(formatter(code));
+
+            assert.strictEqual(log.runs[0].results[0].locations[0].physicalLocation.region.startLine, code[0].messages[0].line);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.startColumn);
+            assert.isUndefined(log.runs[0].results[0].locations[0].physicalLocation.region.snippet);
+        });
+    });
+});
+
+describe("formatter:sarif", () => {
     describe("when passed one message with line and column but no source string", () => {
         const code = [{
             filePath: sourceFilePath1,


### PR DESCRIPTION
This fixes two issues we've seen in the wild in the ESLint formatter:

- When a rule doesn't have a description the resulting SARIF output would have a `shortDescription` but contain no `text` field - which is required. This removes the outer object `shortDescription` in that case.
- When a result returned the invalid column number of 0 (or negative) the resulting SARIF output would contain the invalid column number. This treats invalid column numbers the same as undefined column numbers