### PR TITLE
Add check in SARIF1010 that rule is in rules setion

### DIFF
--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1010.RuleIdMustBeConsistent_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/ExpectedOutputs/SARIF1010.RuleIdMustBeConsistent_Invalid.sarif
@@ -63,7 +63,7 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 13,
+                  "startLine": 21,
                   "startColumn": 9
                 }
               }
@@ -89,7 +89,31 @@
                   "index": 0
                 },
                 "region": {
-                  "startLine": 18,
+                  "startLine": 26,
+                  "startColumn": 9
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SARIF1010",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "id": "Error_ResultMustSpecifyRuleId",
+            "arguments": [
+              "runs[0].results[2]"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 35,
                   "startColumn": 9
                 }
               }

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1010.RuleIdMustBeConsistent_Invalid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1010.RuleIdMustBeConsistent_Invalid.sarif
@@ -6,7 +6,15 @@
       "tool": {
         "driver": {
           "name": "Sarif Functional Testing",
-          "version": "1.0"
+          "version": "1.0",
+          "rules": [
+            {
+              "id": "TST0001",
+            },
+            {
+              "id": "TST0002",
+            }
+          ]
         }
       },
       "results": [
@@ -22,6 +30,12 @@
           },
           "message": {
             "text": "This result contains both a ruleId and a rule.id property, but they are different."
+          }
+        },
+        {
+          "ruleId": "TST0003",
+          "message": {
+            "text": "This result contains a ruleId property not described in the 'rules' section."
           }
         }
       ],

--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1010.RuleIdMustBeConsistent_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/SARIF1010.RuleIdMustBeConsistent_Valid.sarif
@@ -6,7 +6,18 @@
       "tool": {
         "driver": {
           "name": "Sarif Functional Testing",
-          "version": "1.0"
+          "version": "1.0",
+          "rules": [
+            {
+              "id": "TST0001",
+            },
+            {
+              "id": "TST0002",
+            },
+            {
+              "id": "TST0003",
+            }
+          ]
         }
       },
       "results": [


### PR DESCRIPTION
This PR adds a check to SARIF1010 that that if `ruleId` or `rule.id` is given, then the rule MUST exist in the `rules` list.

This is required for GitHub's code scanning features to work properly, and I believe is consistent with the SARIF spec.

I was unable to get the `RuleResources.resx` file to compile properly, so some new strings need to be added in order to describe this behavior and the assocated error message. For now I used the same error message as `Error_ResultMustSpecifyRuleId` which is not exactly correct.

cc @marcogario