### PR TITLE
Relax check in GH1005

### DIFF
--- a/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GH1005.LocationsMustBeRelativeUrisOrFilePaths_Valid.sarif
+++ b/src/Test.FunctionalTests.Sarif/TestData/Multitool/ValidateCommand/Inputs/GH1005.LocationsMustBeRelativeUrisOrFilePaths_Valid.sarif
@@ -50,6 +50,49 @@
         }
       ],
       "columnKind": "utf16CodeUnits"
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "Sarif Functional Testing",
+          "version": "1.0"
+        }
+      },
+      "invocations": [
+        {
+          "workingDirectory": {
+            "uri": "file:///C:/code"
+          },
+          "executionSuccessful": true
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "TEST1001",
+          "message": {
+            "text": "Locations that specify file paths."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                   "uri": "https://www.example.com/code/file.cs"
+                }
+              }
+            }
+          ],
+          "relatedLocations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "https://www.example.com/code/file.cs"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
     }
   ]
 }


### PR DESCRIPTION
This PR relaxes the check in GH1005 : If the uri is not a file, we can still determine the file from the working direction in the invocations list. Now we make sure that the if the uri isn't a file, we have a working directory.

I was unable to compile RuleResouces.resx, so the relevant strings & docs still need to be updated

cc @marcogario