### PR TITLE
Enable RemoveOptionalData for RewriteCommand

### DIFF
--- a/docs/multitool-usage.md
+++ b/docs/multitool-usage.md
@@ -34,6 +34,9 @@ Sarif.Multitool convert Current.fpr -tool FortifyFpr -output Current.sarif
 : Add file contents from analyzed files and snippets from result regions to SARIF
 Sarif.Multitool rewrite Current.sarif --insert "TextFiles,RegionSnippets" --inline
 
+: Remove codeFlows from results regions to SARIF
+Sarif.Multitool rewrite Current.sarif --remove "CodeFlows" --inline
+
 : Rebase URIs from local paths to a token (for later resolution against remote URLs)
 Sarif.Multitool rebaseuri Current.sarif --base-path-value "C:\Local\Path\To\Repo" --base-path-token REPO
 
@@ -72,4 +75,5 @@ Run ```Sarif.Multitool convert --help``` for the current list.
 | Name | Purpose |
 | ---- | ------- |
 | pretty-print | Produce pretty-printed JSON output rather than compact form. |
+| minify | Produce compact JSON output (all white space removed) rather than pretty-printed output. |
 | force | Force overwrite of output file if it exists. |

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,9 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+* FEATURE: Multitool SARIF rewrite accepts `remove` parameter[#2160](https://github.com/microsoft/sarif-sdk/pull/2160)
+
+## **v2.3.8** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.8) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.8) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.8) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.8) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.3.8)
+
 * FEATURE: PACKAGE BREAKING: Upgrade from .NET Framework 4.5 to .NET Framework 4.5.2 [#2135](https://github.com/microsoft/sarif-sdk/pull/2135)
 * FEATURE: Multitool SARIF merge accepts `threads` parameter [#2026](https://github.com/microsoft/sarif-sdk/pull/2026)
 * FEATURE: Enable GitHub SourceLink to all project [#2148](https://github.com/microsoft/sarif-sdk/pull/2148)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,9 +1,9 @@
 # SARIF Package Release History (SDK, Driver, Converters, and Multitool)
 
+## **Unreleased**
 * FEATURE: Multitool SARIF rewrite accepts `remove` parameter[#2160](https://github.com/microsoft/sarif-sdk/pull/2160)
 
 ## **v2.3.8** [Sdk](https://www.nuget.org/packages/Sarif.Sdk/2.3.8) | [Driver](https://www.nuget.org/packages/Sarif.Driver/2.3.8) | [Converters](https://www.nuget.org/packages/Sarif.Converters/2.3.8) | [Multitool](https://www.nuget.org/packages/Sarif.Multitool/2.3.8) | [Multitool Library](https://www.nuget.org/packages/Sarif.Multitool.Library/2.3.8)
-
 * FEATURE: PACKAGE BREAKING: Upgrade from .NET Framework 4.5 to .NET Framework 4.5.2 [#2135](https://github.com/microsoft/sarif-sdk/pull/2135)
 * FEATURE: Multitool SARIF merge accepts `threads` parameter [#2026](https://github.com/microsoft/sarif-sdk/pull/2026)
 * FEATURE: Enable GitHub SourceLink to all project [#2148](https://github.com/microsoft/sarif-sdk/pull/2148)

--- a/src/Sarif.Multitool.Library/RewriteCommand.cs
+++ b/src/Sarif.Multitool.Library/RewriteCommand.cs
@@ -9,8 +9,6 @@ using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 using Microsoft.CodeAnalysis.Sarif.Visitors;
 
-using Newtonsoft.Json;
-
 namespace Microsoft.CodeAnalysis.Sarif.Multitool
 {
     public class RewriteCommand : CommandBase
@@ -35,9 +33,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 SarifLog actualLog = ReadSarifFile<SarifLog>(_fileSystem, rewriteOptions.InputFilePath);
 
                 OptionallyEmittedData dataToInsert = rewriteOptions.DataToInsert.ToFlags();
+                OptionallyEmittedData dataToRemove = rewriteOptions.DataToRemove.ToFlags();
                 IDictionary<string, ArtifactLocation> originalUriBaseIds = rewriteOptions.ConstructUriBaseIdsDictionary();
 
-                SarifLog reformattedLog = new InsertOptionalDataVisitor(dataToInsert, originalUriBaseIds).VisitSarifLog(actualLog);
+                SarifLog reformattedLog = new RemoveOptionalDataVisitor(dataToRemove).VisitSarifLog(actualLog);
+                reformattedLog = new InsertOptionalDataVisitor(dataToInsert, originalUriBaseIds).VisitSarifLog(actualLog);
 
                 string fileName = CommandUtilities.GetTransformedOutputFileName(rewriteOptions);
 

--- a/src/Sarif.Multitool.Library/RewriteCommand.cs
+++ b/src/Sarif.Multitool.Library/RewriteCommand.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 IDictionary<string, ArtifactLocation> originalUriBaseIds = rewriteOptions.ConstructUriBaseIdsDictionary();
 
                 SarifLog reformattedLog = new RemoveOptionalDataVisitor(dataToRemove).VisitSarifLog(actualLog);
-                reformattedLog = new InsertOptionalDataVisitor(dataToInsert, originalUriBaseIds).VisitSarifLog(actualLog);
+                reformattedLog = new InsertOptionalDataVisitor(dataToInsert, originalUriBaseIds).VisitSarifLog(reformattedLog);
 
                 string fileName = CommandUtilities.GetTransformedOutputFileName(rewriteOptions);
 

--- a/src/Sarif/OptionallyEmittedData.cs
+++ b/src/Sarif/OptionallyEmittedData.cs
@@ -73,6 +73,10 @@ namespace Microsoft.CodeAnalysis.Sarif
         // version of the code that was analyzed.
         VersionControlInformation = 0x400,
 
+        // Specifies the repository, branch, and other information describing the source controlled
+        // version of the code that was analyzed.
+        CodeFlows = 0x800,
+
         // A special enum value that indicates that insertion should overwrite any existing
         // information in the SARIF log file. In the absence of this setting, any existing
         // data that would otherwise have been overwritten by the insert operation will

--- a/src/Sarif/OptionallyEmittedData.cs
+++ b/src/Sarif/OptionallyEmittedData.cs
@@ -73,8 +73,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         // version of the code that was analyzed.
         VersionControlInformation = 0x400,
 
-        // Specifies the repository, branch, and other information describing the source controlled
-        // version of the code that was analyzed.
+        // A set of threadFlows which together describe a pattern of code execution relevant
+        // to detecting a result.
         CodeFlows = 0x800,
 
         // A special enum value that indicates that insertion should overwrite any existing

--- a/src/Sarif/Visitors/RemoveOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/RemoveOptionalDataVisitor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Microsoft.CodeAnalysis.Sarif.Visitors
@@ -11,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
             _dataToRemove = optionallyEmittedData;
         }
 
-        readonly OptionallyEmittedData _dataToRemove;
+        private readonly OptionallyEmittedData _dataToRemove;
 
         public override Invocation VisitInvocation(Invocation node)
         {
@@ -71,16 +72,12 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 node.Guid = null;
             }
 
-            return base.VisitResult(node);
-        }
-
-        public override CodeFlow VisitCodeFlow(CodeFlow node)
-        {
             if (_dataToRemove.HasFlag(OptionallyEmittedData.CodeFlows))
             {
-                node = null;
+                node.CodeFlows = null;
             }
-            return base.VisitCodeFlow(node);
+
+            return base.VisitResult(node);
         }
     }
 }

--- a/src/Sarif/Visitors/RemoveOptionalDataVisitor.cs
+++ b/src/Sarif/Visitors/RemoveOptionalDataVisitor.cs
@@ -73,5 +73,14 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
 
             return base.VisitResult(node);
         }
+
+        public override CodeFlow VisitCodeFlow(CodeFlow node)
+        {
+            if (_dataToRemove.HasFlag(OptionallyEmittedData.CodeFlows))
+            {
+                node = null;
+            }
+            return base.VisitCodeFlow(node);
+        }
     }
 }


### PR DESCRIPTION
## Changes:
- Enable `RemoveOptionalData` for `RewriteCommand`
- Enable `CodeFlows` as `OptionallyEmittedData`

With this we would be able to use the following command:
```
rewrite oldfile.sarif --output-path newfile.sarif --remove "CodeFlows" --minify true --force
```

Adding some data:
- based on a sarif with size of 70MB with CodeFlows, after the command, the sarif size dropped to 7MB
- based on a sarif with size of 400MB with CodeFlows, after the command, the sarif size dropped to 8MB 