### PR TITLE
Provide test binary name, not hard-coded literal.

### DIFF
--- a/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
+++ b/src/Test.Utilities.Sarif/FileDiffingUnitTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         protected virtual string ProductDirectory => GetProductDirectory();
 
-        protected virtual string TestDirectory => Path.Combine(ProductDirectory, @"TestBinary\", @"TestData\");
+        protected virtual string TestDirectory => Path.Combine(ProductDirectory, TestBinaryName, @"TestData\");
 
         protected virtual string ProductTestDataDirectory => Path.Combine(ProductDirectory, @"TestData\", TypeUnderTest);
 


### PR DESCRIPTION
@eddynaka, I introduced an issue in a previous change (injected a hard-coded literal instead of resolving a property name.

we don't see this because this code path isn't invoked unless/until baselining of certain tests occurs. we've broken this, I'd guess, across one or more test suites! next time i complete significant work in this repo, i'll take a quick look at the situation.