### PR TITLE
Resolve null deref in multithreaded analysis with no results (due to …

### DIFF
--- a/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
+++ b/src/Sarif.Driver/Sdk/MultithreadedAnalyzeCommandBase.cs
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
                         DetermineApplicabilityAndAnalyze(context, skimmers, disabledSkimmers);
 
-                        if (_computeHashes && ((CachingLogger)context.Logger).Results.Count > 0)
+                        if (_computeHashes && ((CachingLogger)context.Logger).Results?.Count > 0)
                         {
                             Debug.Assert(context.Hashes == null);
 


### PR DESCRIPTION
…catastrophic rule failure).

@eddynaka @yongyan-gh 