### PR TITLE
Enable NETAnalyzers

### DIFF
--- a/src/Sarif.Converters/CppCheckLocation.cs
+++ b/src/Sarif.Converters/CppCheckLocation.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Converters
         {
             if (string.IsNullOrWhiteSpace(file))
             {
-                throw new ArgumentException(ConverterResources.CppCheckLocationNameEmpty, "file");
+                throw new ArgumentException(ConverterResources.CppCheckLocationNameEmpty, nameof(file));
             }
 
             if (line < 0)

--- a/src/Sarif.Driver/ArgumentSplitter.cs
+++ b/src/Sarif.Driver/ArgumentSplitter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Driver
 
             if (input == null)
             {
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
             }
 
             WhitespaceMode whitespaceMode = WhitespaceMode.Ignore;

--- a/src/Sarif.Multitool.Library/MergeCommand.cs
+++ b/src/Sarif.Multitool.Library/MergeCommand.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Multitool
                 new FixupVisitor().VisitSarifLog(sarifLog);
             }
 
-            _mergeLogsChannel.Writer.WriteAsync(sarifLog);
+            _mergeLogsChannel.Writer.TryWrite(sarifLog);
             Interlocked.Decrement(ref _filesToProcessCount);
         }
 

--- a/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
+++ b/src/Sarif/Baseline/ResultMatching/SarifLogResultMatcher.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Baseline.ResultMatching
         {
             if (currentRuns == null || !currentRuns.Any())
             {
-                throw new ArgumentException(nameof(currentRuns));
+                throw new ArgumentNullException(nameof(currentRuns));
             }
 
             // Results should all be from the same tool, so we'll pull the log from the first run.

--- a/src/Sarif/Core/Notification.cs
+++ b/src/Sarif/Core/Notification.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     sb.Append(argument).Append(',');
                 }
                 sb.Length = sb.Length - 1;
-                sb.Append("}");
+                sb.Append('}');
             }
             return sb.ToString();
         }

--- a/src/Sarif/Core/Result.cs
+++ b/src/Sarif/Core/Result.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     sb.Append(argument).Append(',');
                 }
                 sb.Length -= 1;
-                sb.Append("}");
+                sb.Append('}');
             }
 
             return sb.ToString();

--- a/src/Sarif/Core/StackFrame.cs
+++ b/src/Sarif/Core/StackFrame.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (type != null)
             {
                 sb.Append(type.FullName.Replace('+', '.'));
-                sb.Append(".");
+                sb.Append('.');
             }
             sb.Append(methodBase.Name);
 
@@ -134,14 +134,14 @@ namespace Microsoft.CodeAnalysis.Sarif
             if (methodBase is MethodInfo methodInfo && methodInfo.IsGenericMethod)
             {
                 Type[] typeArguments = methodInfo.GetGenericArguments();
-                sb.Append("[");
+                sb.Append('[');
                 int k = 0;
                 bool firstTypeParameter = true;
                 while (k < typeArguments.Length)
                 {
-                    if (firstTypeParameter == false)
+                    if (!firstTypeParameter)
                     {
-                        sb.Append(",");
+                        sb.Append(',');
                     }
                     else
                     {
@@ -151,11 +151,11 @@ namespace Microsoft.CodeAnalysis.Sarif
                     sb.Append(typeArguments[k].Name);
                     k++;
                 }
-                sb.Append("]");
+                sb.Append(']');
             }
 
             // arguments printing
-            sb.Append("(");
+            sb.Append('(');
             ParameterInfo[] parameterInfos = methodBase.GetParameters();
             bool firstParameterInfo = true;
             for (int j = 0; j < parameterInfos.Length; j++)
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 }
                 sb.Append(typeName).Append(' ').Append(parameterInfos[j].Name);
             }
-            sb.Append(")");
+            sb.Append(')');
 
             return sb.ToString();
         }

--- a/src/Sarif/Core/WebRequest.cs
+++ b/src/Sarif/Core/WebRequest.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 var sb = new StringBuilder("http://www.example.com");
                 if (!uri.OriginalString.StartsWith("/"))
                 {
-                    sb.Append("/");
+                    sb.Append('/');
                 }
 
                 sb.Append(uri.OriginalString);

--- a/src/Sarif/HashUtilities.cs
+++ b/src/Sarif/HashUtilities.cs
@@ -44,11 +44,11 @@ namespace Microsoft.CodeAnalysis.Sarif
 
             var tasks = new List<Task>();
 
-            while (queue.Count > 0 && tasks.Count < Environment.ProcessorCount)
+            while (!queue.IsEmpty && tasks.Count < Environment.ProcessorCount)
             {
                 tasks.Add(Task.Factory.StartNew(() =>
                 {
-                    while (queue.Count > 0)
+                    while (!queue.IsEmpty)
                     {
                         if (queue.TryDequeue(out string filePath))
                         {

--- a/src/Sarif/Map/JsonMapSettings.cs
+++ b/src/Sarif/Map/JsonMapSettings.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
         /// <param name="mapMaximumSizeBytes">Map size limit, in bytes (ex: 10 * JsonMapSettings.Megabyte), 0 for no limit</param>
         public JsonMapSettings(double mapSizeRatio, double mapMaximumSizeBytes = 0)
         {
-            if (mapSizeRatio <= 0 || mapSizeRatio > 100) { throw new ArgumentOutOfRangeException(nameof(mapSizeRatio), "mapSizeRatio must be > 0 and <= 100."); }
+            if (mapSizeRatio <= 0 || mapSizeRatio > 100) { throw new ArgumentOutOfRangeException(nameof(mapSizeRatio), $"{nameof(mapSizeRatio)} must be > 0 and <= 100."); }
             MapDesiredSizeRatio = mapSizeRatio;
             MapMaximumSizeBytes = mapMaximumSizeBytes;
         }

--- a/src/Sarif/Map/JsonMapSettings.cs
+++ b/src/Sarif/Map/JsonMapSettings.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Map
         /// <param name="mapMaximumSizeBytes">Map size limit, in bytes (ex: 10 * JsonMapSettings.Megabyte), 0 for no limit</param>
         public JsonMapSettings(double mapSizeRatio, double mapMaximumSizeBytes = 0)
         {
-            if (mapSizeRatio <= 0 || mapSizeRatio > 100) { throw new ArgumentOutOfRangeException("maxFileSizePercentage must be > 0 and <= 100."); }
+            if (mapSizeRatio <= 0 || mapSizeRatio > 100) { throw new ArgumentOutOfRangeException(nameof(mapSizeRatio), "mapSizeRatio must be > 0 and <= 100."); }
             MapDesiredSizeRatio = mapSizeRatio;
             MapMaximumSizeBytes = mapMaximumSizeBytes;
         }

--- a/src/Sarif/Query/ExpressionParser.cs
+++ b/src/Sarif/Query/ExpressionParser.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
             // Otherwise, build the string, doubling each character to escape
             int nextCopyFrom = 0;
             StringBuilder result = new StringBuilder();
-            result.Append("'");
+            result.Append('\'');
 
             for (int i = 0; i < value.Length; ++i)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
                 result.Append(value, nextCopyFrom, value.Length - nextCopyFrom);
             }
 
-            result.Append("'");
+            result.Append('\'');
             return result.ToString();
         }
 

--- a/src/Sarif/Query/Expressions.cs
+++ b/src/Sarif/Query/Expressions.cs
@@ -46,9 +46,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Query
                 {
                     // Explicit parenthesis are only required on an OR expression inside and AND expression.
                     // AND takes precedence over OR, so A OR B AND C OR D => (A OR (B AND C) OR D)
-                    result.Append("(");
+                    result.Append('(');
                     result.Append(part);
-                    result.Append(")");
+                    result.Append(')');
                 }
                 else
                 {

--- a/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
+++ b/src/Sarif/Visitors/SarifCurrentToVersionOneVisitor.cs
@@ -146,7 +146,9 @@ namespace Microsoft.CodeAnalysis.Sarif.Visitors
                 {
                     // Set the unknown encoding name so the caller can provide useful reporting
                     ex.EncodingName = encodingName;
+#pragma warning disable CA2200 // Rethrow to preserve stack details
                     throw ex;
+#pragma warning restore CA2200 // Rethrow to preserve stack details
                 }
             }
 

--- a/src/build.props
+++ b/src/build.props
@@ -54,6 +54,10 @@
          fail on AppVeyor (and only there, for some reason).
       -->
     <CopyLocalLockFileAssemblies Condition="'$(IsTestProject)' == 'true'">true</CopyLocalLockFileAssemblies>
+    
+    <!-- Enable NETAnalyzers -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->
@@ -120,6 +124,14 @@
   <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
+  </ItemGroup>
+  
+
+  <ItemGroup Label="Common Packages">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/build.props
+++ b/src/build.props
@@ -54,10 +54,6 @@
          fail on AppVeyor (and only there, for some reason).
       -->
     <CopyLocalLockFileAssemblies Condition="'$(IsTestProject)' == 'true'">true</CopyLocalLockFileAssemblies>
-    
-    <!-- Enable NETAnalyzers -->
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->

--- a/src/build.props
+++ b/src/build.props
@@ -29,6 +29,7 @@
     <!-- The stable version of the SARIF specification. -->
     <StableSarifVersion>2.1.0</StableSarifVersion>
 
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
## Changes
- Enable NETAnalyzers
- Fix a few error / warning / messages

## Why
- From our security rules, we should use Roslyn analyzers in IDE/build